### PR TITLE
Fix 500 in /audio/generate-for-story by using TTS service layer

### DIFF
--- a/backend/src/services/tts_service.py
+++ b/backend/src/services/tts_service.py
@@ -1,0 +1,100 @@
+"""
+TTS service layer.
+
+Provides a plain callable API for story audio generation.
+"""
+
+import hashlib
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from openai import OpenAI
+
+
+def get_audio_output_path() -> str:
+    """Get the audio output directory."""
+    audio_dir = os.getenv("AUDIO_OUTPUT_PATH", "./data/audio")
+    Path(audio_dir).mkdir(parents=True, exist_ok=True)
+    return audio_dir
+
+
+def _resolve_speed(speed: Optional[float], child_age: Optional[int]) -> float:
+    """Resolve speaking speed from explicit input or age defaults."""
+    if speed is not None:
+        return speed
+
+    if child_age is None:
+        return 1.0
+
+    if child_age <= 5:
+        return 0.9
+    if child_age <= 8:
+        return 1.0
+    return 1.1
+
+
+async def generate_story_audio_file(
+    text: str,
+    voice: str = "nova",
+    speed: Optional[float] = None,
+    child_age: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Generate story audio file and return a normalized result payload."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return {
+            "success": False,
+            "error": "OPENAI_API_KEY environment variable is not configured",
+            "audio_path": None,
+        }
+
+    if not text:
+        return {
+            "success": False,
+            "error": "story text is empty",
+            "audio_path": None,
+        }
+
+    resolved_speed = _resolve_speed(speed, child_age)
+
+    try:
+        client = OpenAI(api_key=api_key)
+
+        timestamp = datetime.now().isoformat()
+        text_hash = hashlib.md5(text.encode()).hexdigest()[:8]
+        filename = f"story_{text_hash}_{timestamp.replace(':', '-')}.mp3"
+
+        audio_dir = get_audio_output_path()
+        audio_path = os.path.join(audio_dir, filename)
+
+        response = client.audio.speech.create(
+            model="tts-1",
+            voice=voice,
+            input=text,
+            speed=resolved_speed,
+        )
+        response.stream_to_file(audio_path)
+
+        file_size = os.path.getsize(audio_path)
+        file_size_mb = round(file_size / (1024 * 1024), 2)
+        estimated_duration = round(len(text) / 150 * 60 / resolved_speed, 1)
+
+        return {
+            "success": True,
+            "audio_path": audio_path,
+            "filename": filename,
+            "voice": voice,
+            "speed": resolved_speed,
+            "file_size_mb": file_size_mb,
+            "estimated_duration_seconds": estimated_duration,
+            "duration": estimated_duration,
+            "text_length": len(text),
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"TTS generation failed: {str(e)}",
+            "audio_path": None,
+        }

--- a/backend/tests/test_tts_service.py
+++ b/backend/tests/test_tts_service.py
@@ -1,0 +1,57 @@
+import os
+
+import pytest
+
+from backend.src.services.tts_service import generate_story_audio_file
+
+
+@pytest.mark.asyncio
+async def test_generate_story_audio_file_missing_api_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    result = await generate_story_audio_file(text="hello world")
+
+    assert result["success"] is False
+    assert result["audio_path"] is None
+    assert "OPENAI_API_KEY" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_generate_story_audio_file_success(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("AUDIO_OUTPUT_PATH", str(tmp_path))
+
+    class FakeSpeechResponse:
+        def stream_to_file(self, path):
+            with open(path, "wb") as f:
+                f.write(b"fake-mp3-data")
+
+    class FakeSpeechAPI:
+        @staticmethod
+        def create(**kwargs):
+            assert kwargs["model"] == "tts-1"
+            assert kwargs["voice"] == "alloy"
+            return FakeSpeechResponse()
+
+    class FakeAudioAPI:
+        speech = FakeSpeechAPI()
+
+    class FakeOpenAI:
+        def __init__(self, api_key):
+            assert api_key == "test-key"
+            self.audio = FakeAudioAPI()
+
+    monkeypatch.setattr("backend.src.services.tts_service.OpenAI", FakeOpenAI)
+
+    result = await generate_story_audio_file(
+        text="A short story for testing.",
+        voice="alloy",
+        speed=None,
+        child_age=4,
+    )
+
+    assert result["success"] is True
+    assert result["audio_path"] is not None
+    assert os.path.exists(result["audio_path"])
+    assert result["speed"] == 0.9
+    assert result["duration"] > 0


### PR DESCRIPTION
## Summary
- move TTS generation into a plain service function so API routes do not call MCP `SdkMcpTool` wrappers directly
- update `/api/v1/audio/generate` and `/api/v1/audio/generate-for-story` to use service results and return clearer 500 errors when generation fails
- keep MCP tool compatibility by having `tts_generator_server` wrap the same service output in MCP `content` format
- add focused tests for TTS service success/failure paths

## Why
The audio route imported an MCP-decorated tool and called it like a normal async function, causing runtime `TypeError: 'SdkMcpTool' object is not callable` and a 500 response.

## Testing
- `python3 -m compileall backend/src` ✅
- `python3 -m pytest backend/tests/test_tts_service.py -q` ❌ (pytest not installed in this environment)

Closes #1