### PR TITLE
Fix security issues #2 and #3 (path traversal + password hashing)

### DIFF
--- a/backend/tests/api/test_image_to_story_security.py
+++ b/backend/tests/api/test_image_to_story_security.py
@@ -1,0 +1,39 @@
+from io import BytesIO
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from backend.src.api.routes import image_to_story as route
+
+
+def test_validate_child_id_rejects_path_traversal() -> None:
+    with pytest.raises(HTTPException):
+        route.validate_child_id("../../tmp/pwn")
+
+    with pytest.raises(HTTPException):
+        route.validate_child_id("child/../evil")
+
+
+def test_validate_child_id_accepts_safe_identifier() -> None:
+    assert route.validate_child_id("child_001-safe") == "child_001-safe"
+
+
+@pytest.mark.asyncio
+async def test_save_upload_file_stays_within_upload_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(route, "UPLOAD_DIR", tmp_path)
+
+    upload = UploadFile(filename="drawing.png", file=BytesIO(b"small image bytes"))
+    saved_path = await route.save_upload_file(upload, "child_001")
+
+    assert saved_path.exists()
+    assert saved_path.parent.name == "child_001"
+    assert tmp_path.resolve() in saved_path.resolve().parents
+
+
+@pytest.mark.asyncio
+async def test_save_upload_file_rejects_escaped_directory(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(route, "UPLOAD_DIR", tmp_path)
+
+    upload = UploadFile(filename="drawing.png", file=BytesIO(b"small image bytes"))
+    with pytest.raises(HTTPException):
+        await route.save_upload_file(upload, "../../tmp/pwn")

--- a/backend/tests/test_user_service_security.py
+++ b/backend/tests/test_user_service_security.py
@@ -1,0 +1,26 @@
+import hashlib
+import secrets
+
+from backend.src.services.user_service import UserService
+
+
+def test_hash_password_uses_pbkdf2_scheme() -> None:
+    service = UserService()
+    hashed, salt = service._hash_password("super-secret")
+
+    assert salt
+    assert hashed.startswith("pbkdf2_sha256$")
+    assert service._verify_password("super-secret", hashed)
+    assert not service._verify_password("wrong", hashed)
+
+
+def test_verify_password_supports_legacy_sha256_format() -> None:
+    service = UserService()
+
+    salt = secrets.token_hex(16)
+    legacy_hash = hashlib.sha256(f"{salt}:password123".encode("utf-8")).hexdigest()
+    stored = f"{salt}:{legacy_hash}"
+
+    is_valid, should_rehash = service._verify_password_with_rehash("password123", stored)
+    assert is_valid
+    assert should_rehash


### PR DESCRIPTION
## Summary
- harden image upload handling by validating `child_id` with an allowlist and enforcing resolved upload paths stay within `UPLOAD_DIR`
- upgrade password storage from single-round SHA-256 to PBKDF2-SHA256 with versioned hash format and login-time migration for legacy hashes
- add targeted security tests for traversal rejection, upload path containment, PBKDF2 verification, and legacy-hash compatibility

## Validation
- `backend/.venv/bin/python -m pytest backend/tests/test_user_service_security.py backend/tests/api/test_image_to_story_security.py`
- result: `6 passed`

Closes #2
Closes #3