### PR TITLE
Fix API contract for password change request (#5)

### DIFF
--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -50,7 +50,7 @@ export interface UpdateProfileRequest {
 
 // Change password request
 export interface ChangePasswordRequest {
-  current_password: string
+  old_password: string
   new_password: string
 }
 


### PR DESCRIPTION
## Summary
- align frontend `ChangePasswordRequest` field name with backend model by renaming `current_password` to `old_password`
- keep request payload contract consistent across `frontend/src/types/auth.ts` and backend `/users/me/change-password`

## Validation
- `python3 -m py_compile backend/src/agents/interactive_story_agent.py`
- `npm run build` *(fails due known unrelated TS2352 errors in `HistoryPage`, tracked separately)*

Closes #5