### PR TITLE
Fix frontend lint blockers and stabilize hook usage (#4)

### DIFF
--- a/frontend/src/components/depth/TiltCard.tsx
+++ b/frontend/src/components/depth/TiltCard.tsx
@@ -67,6 +67,10 @@ export function TiltCard({
   const glareXSpring = useSpring(glareX, springConfig)
   const glareYSpring = useSpring(glareY, springConfig)
   const glareOpacitySpring = useSpring(glareOpacity, springConfig)
+  const glareBackground = useTransform(
+    [glareXSpring, glareYSpring],
+    ([x, y]) => `radial-gradient(circle at ${x}% ${y}%, rgba(255,255,255,0.3) 0%, transparent 50%)`
+  )
 
   // Dynamic shadow based on tilt
   const shadowX = useTransform(rotateYSpring, [-maxTilt, maxTilt], [20, -20])
@@ -136,11 +140,7 @@ export function TiltCard({
             <motion.div
               className="tilt-card-glare absolute inset-0 pointer-events-none rounded-inherit overflow-hidden"
               style={{
-                background: useTransform(
-                  [glareXSpring, glareYSpring],
-                  ([x, y]) =>
-                    `radial-gradient(circle at ${x}% ${y}%, rgba(255,255,255,0.3) 0%, transparent 50%)`
-                ),
+                background: glareBackground,
                 opacity: glareOpacitySpring,
               }}
             />

--- a/frontend/src/components/effects/ParticleEmitter.tsx
+++ b/frontend/src/components/effects/ParticleEmitter.tsx
@@ -144,6 +144,7 @@ function getAnimation(config: ParticleConfig, particle: Particle) {
       }
 
     case 'burst':
+    {
       const angle = random(0, 360) * (Math.PI / 180)
       const distance = random(50, 150)
       return {
@@ -157,6 +158,7 @@ function getAnimation(config: ParticleConfig, particle: Particle) {
           ease: 'easeOut',
         },
       }
+    }
 
     case 'float':
     default:

--- a/frontend/src/components/story/BookContainer/index.tsx
+++ b/frontend/src/components/story/BookContainer/index.tsx
@@ -55,6 +55,15 @@ function BookContainer({
     [rotateXSpring, rotateYSpring],
     ([rx, ry]: number[]) => 30 + Math.abs(rx) + Math.abs(ry)
   )
+  const shadowFilter = useTransform(shadowBlur, (blur) => `blur(${blur}px)`)
+  const glareBackground = useTransform(
+    [mouseXSpring, mouseYSpring],
+    ([x, y]: number[]) => {
+      const glareX = ((x + 1) / 2) * 100
+      const glareY = ((y + 1) / 2) * 100
+      return `radial-gradient(circle at ${glareX}% ${glareY}%, rgba(255,255,255,0.08) 0%, transparent 50%)`
+    }
+  )
 
   const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
     if (prefersReducedMotion || !enableTilt || !containerRef.current) return
@@ -141,7 +150,7 @@ function BookContainer({
             style={{
               x: shadowX,
               y: shadowY,
-              filter: useTransform(shadowBlur, (blur) => `blur(${blur}px)`),
+              filter: shadowFilter,
               background: 'rgba(0, 0, 0, 0.15)',
               transform: 'translateZ(-50px)',
             }}
@@ -190,14 +199,7 @@ function BookContainer({
           <motion.div
             className="book-glare absolute inset-0 pointer-events-none rounded-inherit overflow-hidden"
             style={{
-              background: useTransform(
-                [mouseXSpring, mouseYSpring],
-                ([x, y]: number[]) => {
-                  const glareX = ((x + 1) / 2) * 100
-                  const glareY = ((y + 1) / 2) * 100
-                  return `radial-gradient(circle at ${glareX}% ${glareY}%, rgba(255,255,255,0.08) 0%, transparent 50%)`
-                }
-              ),
+              background: glareBackground,
             }}
           />
         )}

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -13,6 +13,53 @@ import useChildStore from '@/store/useChildStore'
 import { storyService } from '@/api/services/storyService'
 import { StoryCard } from '@/components/story/StoryDisplay'
 
+interface StarPosition {
+  top: number
+  left: number
+  duration: number
+  emoji: string
+}
+
+function FloatingStar({
+  star,
+  index,
+  mouseXSpring,
+  mouseYSpring,
+}: {
+  star: StarPosition
+  index: number
+  mouseXSpring: ReturnType<typeof useSpring>
+  mouseYSpring: ReturnType<typeof useSpring>
+}) {
+  const x = useTransform(mouseXSpring, [-1, 1], [-15 * (1 - index * 0.1), 15 * (1 - index * 0.1)])
+  const y = useTransform(mouseYSpring, [-1, 1], [-10 * (1 - index * 0.1), 10 * (1 - index * 0.1)])
+
+  return (
+    <motion.span
+      className="absolute text-2xl pointer-events-none select-none"
+      style={{
+        top: `${star.top}%`,
+        left: `${star.left}%`,
+        x,
+        y,
+      }}
+      animate={{
+        y: [0, -15, 0],
+        opacity: [0.3, 0.8, 0.3],
+        scale: [0.8, 1.1, 0.8],
+        rotate: [0, 10, -10, 0],
+      }}
+      transition={{
+        duration: star.duration,
+        repeat: Infinity,
+        delay: index * 0.2,
+      }}
+    >
+      {star.emoji}
+    </motion.span>
+  )
+}
+
 function HomePage() {
   const navigate = useNavigate()
   const { storyHistory } = useStoryStore()
@@ -37,13 +84,13 @@ function HomePage() {
 
   // Memoize star positions to prevent recalculation on every render
   const starPositions = useMemo(
-    () =>
-      [...Array(8)].map((_, i) => ({
-        top: 15 + Math.random() * 70,
-        left: 5 + Math.random() * 90,
-        duration: 2 + Math.random() * 2,
-        emoji: ['⭐', '✨', '🌟', '💫'][i % 4],
-      })),
+      () =>
+        [...Array(8)].map((_, i) => ({
+          top: 15 + Math.random() * 70,
+          left: 5 + Math.random() * 90,
+          duration: 2 + Math.random() * 2,
+          emoji: ['⭐', '✨', '🌟', '💫'][i % 4],
+        })),
     []
   )
 
@@ -77,37 +124,13 @@ function HomePage() {
         {/* Floating stars with parallax */}
         {!prefersReducedMotion &&
           starPositions.map((star, i) => (
-            <motion.span
+            <FloatingStar
               key={i}
-              className="absolute text-2xl pointer-events-none select-none"
-              style={{
-                top: `${star.top}%`,
-                left: `${star.left}%`,
-                x: useTransform(
-                  mouseXSpring,
-                  [-1, 1],
-                  [-15 * (1 - i * 0.1), 15 * (1 - i * 0.1)]
-                ),
-                y: useTransform(
-                  mouseYSpring,
-                  [-1, 1],
-                  [-10 * (1 - i * 0.1), 10 * (1 - i * 0.1)]
-                ),
-              }}
-              animate={{
-                y: [0, -15, 0],
-                opacity: [0.3, 0.8, 0.3],
-                scale: [0.8, 1.1, 0.8],
-                rotate: [0, 10, -10, 0],
-              }}
-              transition={{
-                duration: star.duration,
-                repeat: Infinity,
-                delay: i * 0.2,
-              }}
-            >
-              {star.emoji}
-            </motion.span>
+              star={star}
+              index={i}
+              mouseXSpring={mouseXSpring}
+              mouseYSpring={mouseYSpring}
+            />
           ))}
 
         {/* Main content layer - moves faster (foreground) */}

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { useQuery } from '@tanstack/react-query'
@@ -19,11 +19,11 @@ function ProfilePage() {
   })
   const [saving, setSaving] = useState(false)
 
-  // Redirect to login if not authenticated
-  if (!isAuthenticated) {
-    navigate('/login')
-    return null
-  }
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate('/login')
+    }
+  }, [isAuthenticated, navigate])
 
   // Fetch user stats
   const { data: stats, isLoading: statsLoading } = useQuery({
@@ -65,6 +65,10 @@ function ProfilePage() {
       month: 'long',
       day: 'numeric',
     })
+  }
+
+  if (!isAuthenticated) {
+    return null
   }
 
   return (


### PR DESCRIPTION
## Summary
- fix hook-order violations by moving `useTransform` calls out of conditional/render-loop locations in `TiltCard`, `BookContainer`, and `HomePage`
- fix conditional hook usage in `ProfilePage` by redirecting via `useEffect` and keeping query hooks unconditionally declared
- fix `no-case-declarations` in `ParticleEmitter` by scoping `burst` case declarations

## Validation
- `npm run lint` (0 errors, warnings only)
- `npm run build` (passes)

Closes #4