### PR TITLE
Fix backend startup import regressions for preference/news routes

### DIFF
--- a/backend/src/agents/__init__.py
+++ b/backend/src/agents/__init__.py
@@ -14,6 +14,7 @@ from .interactive_story_agent import (
     StoryOpeningOutput,
     NextSegmentOutput
 )
+from .news_to_kids_agent import convert_news_to_kids, stream_news_to_kids
 
 __all__ = [
     # Image to Story Agent
@@ -28,4 +29,7 @@ __all__ = [
     "AGE_CONFIG",
     "StoryOpeningOutput",
     "NextSegmentOutput",
+    # News to Kids Agent
+    "convert_news_to_kids",
+    "stream_news_to_kids",
 ]

--- a/backend/src/agents/news_to_kids_agent.py
+++ b/backend/src/agents/news_to_kids_agent.py
@@ -1,0 +1,105 @@
+"""Fallback News-to-Kids agent implementation."""
+
+import re
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"\s+", " ", text or "").strip()
+
+
+def _first_sentences(text: str, max_sentences: int = 3) -> str:
+    cleaned = _normalize(text)
+    if not cleaned:
+        return ""
+    parts = re.split(r"(?<=[.!?])\s+", cleaned)
+    return " ".join(parts[:max_sentences]).strip()
+
+
+def _concepts(text: str) -> List[Dict[str, str]]:
+    words = re.findall(r"[A-Za-z][A-Za-z\-']{3,}", text)
+    seen = []
+    for word in words:
+        key = word.lower()
+        if key not in seen:
+            seen.append(key)
+        if len(seen) >= 3:
+            break
+
+    if not seen:
+        seen = ["news"]
+
+    return [
+        {
+            "term": term,
+            "explanation": f"{term.capitalize()} is a key idea from this story.",
+            "emoji": "💡",
+        }
+        for term in seen
+    ]
+
+
+async def convert_news_to_kids(
+    *,
+    news_text: str,
+    age_group: str,
+    child_id: str,
+    category: str,
+    news_url: Optional[str] = None,
+    enable_audio: bool = True,
+    voice: Optional[str] = None,
+) -> Dict[str, Any]:
+    del child_id, enable_audio, voice
+
+    source = _normalize(news_text)
+    if not source and news_url:
+        source = f"Article source: {news_url}."
+
+    summary = _first_sentences(source) or "There is a new story to learn from today."
+    content = f"For ages {age_group}, here is a simple {category or 'general'} update: {summary}"
+
+    return {
+        "kid_title": f"Kid News: {(category or 'general').title()}",
+        "kid_content": content,
+        "why_care": "Learning about news helps kids understand the world and ask good questions.",
+        "key_concepts": _concepts(source),
+        "interactive_questions": [
+            {
+                "question": "What was the most interesting part of this story?",
+                "hint": "Pick one detail and explain why.",
+                "emoji": "🤔",
+            },
+            {
+                "question": "What kind action could help in a story like this?",
+                "hint": "Think about helping people, animals, or the planet.",
+                "emoji": "✨",
+            },
+        ],
+        "audio_path": None,
+    }
+
+
+async def stream_news_to_kids(
+    *,
+    news_text: str,
+    age_group: str,
+    child_id: str,
+    category: str,
+    news_url: Optional[str] = None,
+    enable_audio: bool = True,
+    voice: Optional[str] = None,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    yield {"type": "status", "data": {"stage": "started", "message": "Starting conversion"}}
+    yield {"type": "thinking", "data": {"message": "Simplifying article for children"}}
+
+    result = await convert_news_to_kids(
+        news_text=news_text,
+        age_group=age_group,
+        child_id=child_id,
+        category=category,
+        news_url=news_url,
+        enable_audio=enable_audio,
+        voice=voice,
+    )
+    yield {"type": "result", "data": result}
+    yield {"type": "complete", "data": {"message": "Conversion complete"}}

--- a/backend/src/api/__init__.py
+++ b/backend/src/api/__init__.py
@@ -22,8 +22,15 @@ from .models import (
     ChoiceRequest,
     ChoiceResponse,
     SessionStatusResponse,
+    SaveInteractiveStoryResponse,
     StorySegment,
     StoryChoice,
+    # 新闻转儿童
+    NewsCategory,
+    NewsToKidsRequest,
+    NewsToKidsResponse,
+    KeyConceptResponse,
+    InteractiveQuestionResponse,
     # 错误处理
     ErrorResponse,
     ErrorDetail,
@@ -49,8 +56,15 @@ __all__ = [
     "ChoiceRequest",
     "ChoiceResponse",
     "SessionStatusResponse",
+    "SaveInteractiveStoryResponse",
     "StorySegment",
     "StoryChoice",
+    # 新闻转儿童
+    "NewsCategory",
+    "NewsToKidsRequest",
+    "NewsToKidsResponse",
+    "KeyConceptResponse",
+    "InteractiveQuestionResponse",
     # 错误处理
     "ErrorResponse",
     "ErrorDetail",

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -59,6 +59,18 @@ class VideoStatus(str, Enum):
     FAILED = "failed"
 
 
+class NewsCategory(str, Enum):
+    """新闻分类"""
+    SCIENCE = "science"
+    NATURE = "nature"
+    TECHNOLOGY = "technology"
+    SPACE = "space"
+    ANIMALS = "animals"
+    SPORTS = "sports"
+    CULTURE = "culture"
+    GENERAL = "general"
+
+
 # ============================================================================
 # 画作转故事 API Models
 # ============================================================================
@@ -257,6 +269,53 @@ class SessionStatusResponse(BaseModel):
     created_at: datetime = Field(..., description="创建时间")
     updated_at: datetime = Field(..., description="更新时间")
     expires_at: datetime = Field(..., description="过期时间")
+
+
+class SaveInteractiveStoryResponse(BaseModel):
+    """保存互动故事响应"""
+    story_id: str = Field(..., description="保存后的故事ID")
+    session_id: str = Field(..., description="互动会话ID")
+    message: str = Field(..., description="操作结果消息")
+
+
+class KeyConceptResponse(BaseModel):
+    """新闻关键概念"""
+    term: str = Field(..., description="概念词")
+    explanation: str = Field(..., description="儿童友好解释")
+    emoji: str = Field(default="💡", description="概念图标")
+
+
+class InteractiveQuestionResponse(BaseModel):
+    """互动提问"""
+    question: str = Field(..., description="问题")
+    hint: Optional[str] = Field(None, description="提示")
+    emoji: str = Field(default="🤔", description="问题图标")
+
+
+class NewsToKidsRequest(BaseModel):
+    """新闻转儿童内容请求"""
+    child_id: str = Field(..., min_length=1, max_length=100, description="儿童唯一标识符")
+    age_group: AgeGroup = Field(..., description="年龄组")
+    category: NewsCategory = Field(default=NewsCategory.GENERAL, description="新闻分类")
+    news_url: Optional[str] = Field(None, description="新闻URL")
+    news_text: Optional[str] = Field(None, description="新闻原文")
+    enable_audio: bool = Field(default=True, description="是否生成音频")
+    voice: Optional[VoiceType] = Field(default=VoiceType.FABLE, description="语音类型")
+
+
+class NewsToKidsResponse(BaseModel):
+    """新闻转儿童内容响应"""
+    conversion_id: str = Field(..., description="转换ID")
+    kid_title: str = Field(..., description="儿童版标题")
+    kid_content: str = Field(..., description="儿童版正文")
+    why_care: str = Field(..., description="为什么重要")
+    key_concepts: List[KeyConceptResponse] = Field(default_factory=list, description="关键概念")
+    interactive_questions: List[InteractiveQuestionResponse] = Field(default_factory=list, description="互动问题")
+    category: NewsCategory = Field(..., description="新闻分类")
+    age_group: AgeGroup = Field(..., description="年龄组")
+    audio_url: Optional[str] = Field(None, description="音频URL")
+    original_url: Optional[str] = Field(None, description="原始新闻URL")
+    created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
 
 
 # ============================================================================

--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -4,7 +4,7 @@ API Routes Package
 所有 API 路由定义
 """
 
-from . import image_to_story, interactive_story, audio, video, users
+from . import image_to_story, interactive_story, audio, video, users, news_to_kids
 
 __all__ = [
     "image_to_story",
@@ -12,4 +12,5 @@ __all__ = [
     "audio",
     "video",
     "users",
+    "news_to_kids",
 ]

--- a/backend/src/services/database/__init__.py
+++ b/backend/src/services/database/__init__.py
@@ -8,6 +8,7 @@ from .connection import DatabaseManager, db_manager
 from .story_repository import StoryRepository, story_repo
 from .session_repository import SessionRepository, session_repo
 from .user_repository import UserRepository, user_repo, UserData
+from .preference_repository import PreferenceRepository, preference_repo
 
 __all__ = [
     "DatabaseManager",
@@ -19,4 +20,6 @@ __all__ = [
     "UserRepository",
     "user_repo",
     "UserData",
+    "PreferenceRepository",
+    "preference_repo",
 ]

--- a/backend/src/services/database/preference_repository.py
+++ b/backend/src/services/database/preference_repository.py
@@ -1,0 +1,71 @@
+"""In-memory child preference repository."""
+
+from typing import Any, Dict, List
+
+
+class PreferenceRepository:
+    def __init__(self):
+        self._profiles: Dict[str, Dict[str, Any]] = {}
+
+    async def update_from_story_result(self, child_id: str, story_result: Dict[str, Any]) -> None:
+        profile = self._get_or_create_profile(child_id)
+        self._bump(profile["themes"], story_result.get("themes", []), 1)
+        self._bump(profile["concepts"], self._extract_concepts(story_result.get("concepts", [])), 1)
+
+    async def update_from_choices(self, child_id: str, choice_history: List[str], session_data: Dict[str, Any]) -> None:
+        profile = self._get_or_create_profile(child_id)
+        self._bump(profile["interests"], session_data.get("interests", []), 2)
+        if isinstance(session_data.get("theme"), str) and session_data["theme"].strip():
+            self._bump(profile["themes"], [session_data["theme"].strip()], 2)
+        profile["recent_choices"] = [str(choice) for choice in (choice_history or [])[-20:]]
+
+    async def update_from_news(self, child_id: str, category: str, key_concepts: List[Dict[str, Any]]) -> None:
+        profile = self._get_or_create_profile(child_id)
+        if isinstance(category, str) and category.strip():
+            self._bump(profile["themes"], [category.strip()], 1)
+        concepts = []
+        for item in key_concepts or []:
+            if isinstance(item, dict) and isinstance(item.get("term"), str):
+                concepts.append(item["term"])
+        self._bump(profile["concepts"], concepts, 1)
+
+    async def get_profile(self, child_id: str) -> Dict[str, Any]:
+        return self._profiles.get(child_id, self._empty_profile())
+
+    def _get_or_create_profile(self, child_id: str) -> Dict[str, Any]:
+        if child_id not in self._profiles:
+            self._profiles[child_id] = self._empty_profile()
+        return self._profiles[child_id]
+
+    def _empty_profile(self) -> Dict[str, Any]:
+        return {
+            "themes": {},
+            "concepts": {},
+            "interests": {},
+            "recent_choices": [],
+        }
+
+    def _extract_concepts(self, concepts: Any) -> List[str]:
+        if not isinstance(concepts, list):
+            return []
+        extracted = []
+        for concept in concepts:
+            if isinstance(concept, str):
+                extracted.append(concept)
+            elif isinstance(concept, dict) and isinstance(concept.get("term"), str):
+                extracted.append(concept["term"])
+        return extracted
+
+    def _bump(self, scores: Dict[str, int], labels: Any, delta: int) -> None:
+        if not isinstance(labels, list):
+            return
+        for label in labels:
+            if not isinstance(label, str):
+                continue
+            token = label.strip()
+            if not token:
+                continue
+            scores[token] = int(scores.get(token, 0)) + delta
+
+
+preference_repo = PreferenceRepository()


### PR DESCRIPTION
## Summary
- add missing `preference_repo` implementation/export so image, interactive, and news routes import cleanly
- add missing API models used by interactive save and news-to-kids routes
- add fallback `news_to_kids_agent` module and export from agents package to resolve missing module import

## Validation
- `./venv/bin/python -c \"import src.main; print('import-ok')\"` ✅
- `./venv/bin/pytest -q` ❌ fails in pre-existing test expectation (`AgeGroup.AGE_6_8` vs `AGE_6_9`)

## Related Issues
- Closes #24
- Related: #21, #22