### PR TITLE
Fix API path/param mismatches and repo artifact ignores (#6 #8 #9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 backend/.env
 venv/
 backend/venv/
+backend/.venv/
 
 # Python
 __pycache__/
@@ -34,3 +35,11 @@ htmlcov/
 # Runtime data
 data/sessions/
 data/uploads/
+backend/data/
+
+# Frontend artifacts
+frontend/node_modules/
+frontend/dist/
+frontend/*.tsbuildinfo
+frontend/vite.config.d.ts
+frontend/vite.config.js

--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -6,7 +6,7 @@ User authentication and management API endpoints
 
 from datetime import datetime
 from typing import Optional
-from fastapi import APIRouter, Depends, HTTPException, Header, status
+from fastapi import APIRouter, Depends, HTTPException, Header, Query, status
 
 from ..models import (
     UserRegisterRequest,
@@ -296,16 +296,19 @@ async def get_me_stories(
     description="Get paginated list of interactive story sessions for the current user"
 )
 async def get_me_sessions(
-    status_filter: Optional[str] = None,
+    status: Optional[str] = None,
+    status_filter: Optional[str] = Query(default=None, alias="status_filter"),
     limit: int = 20,
     offset: int = 0,
     user: UserData = Depends(get_current_user),
 ):
     """Get current user's interactive story sessions with pagination"""
 
+    effective_status = status if status is not None else status_filter
+
     from ...services.database import user_repo
     result = await user_repo.get_user_sessions(
-        user.user_id, status=status_filter, limit=limit, offset=offset
+        user.user_id, status=effective_status, limit=limit, offset=offset
     )
     return result
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ const HistoryPage = lazy(() => import('./pages/HistoryPage'))
 const InteractiveStoryPage = lazy(() => import('./pages/InteractiveStoryPage'))
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const ProfilePage = lazy(() => import('./pages/ProfilePage'))
+const NewsPage = lazy(() => import('./pages/NewsPage'))
 
 function App() {
   return (
@@ -26,6 +27,7 @@ function App() {
           <Route path="story/:storyId" element={<StoryPage />} />
           <Route path="history" element={<HistoryPage />} />
           <Route path="interactive" element={<InteractiveStoryPage />} />
+          <Route path="news" element={<NewsPage />} />
           <Route path="profile" element={<ProfilePage />} />
         </Route>
       </Routes>

--- a/frontend/src/api/services/authService.ts
+++ b/frontend/src/api/services/authService.ts
@@ -96,8 +96,18 @@ export const authService = {
   /**
    * Get current user's interactive sessions (paginated)
    */
-  async getMySessions(params?: { status?: string; limit?: number; offset?: number }): Promise<PaginatedSessions> {
-    const response = await apiClient.get<PaginatedSessions>(`${AUTH_BASE}/me/sessions`, { params })
+  async getMySessions(params?: { status?: string; status_filter?: string; limit?: number; offset?: number }): Promise<PaginatedSessions> {
+    const normalizedParams = params
+      ? {
+          status_filter: params.status_filter ?? params.status,
+          limit: params.limit,
+          offset: params.offset,
+        }
+      : undefined
+
+    const response = await apiClient.get<PaginatedSessions>(`${AUTH_BASE}/me/sessions`, {
+      params: normalizedParams,
+    })
     return response.data
   },
 }

--- a/frontend/src/api/services/storyService.ts
+++ b/frontend/src/api/services/storyService.ts
@@ -206,8 +206,11 @@ export const storyService = {
    * Health check
    */
   async healthCheck(): Promise<HealthCheckResponse> {
-    const response = await apiClient.get<HealthCheckResponse>('/health')
-    return response.data
+    const response = await fetch('/health')
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+    return response.json() as Promise<HealthCheckResponse>
   },
 
   /**

--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -52,6 +52,7 @@ function PageContainer() {
             {/* Navigation links */}
             <div className="flex items-center gap-4">
               <NavLink to="/history" icon="📚" label="My Stories" />
+              <NavLink to="/news" icon="📰" label="News for Kids" />
 
               {/* Auth section */}
               {isAuthenticated ? (


### PR DESCRIPTION
## Summary
- fix health check client pathing by calling root `/health` directly instead of using the versioned API axios base
- align session filtering between frontend and backend by normalizing to `status_filter` on requests and accepting both `status` and `status_filter` server-side
- expand `.gitignore` coverage for backend runtime data and frontend build/dependency artifacts to reduce accidental commits
- restore News for Kids page visibility by re-adding `/news` routing and navigation entry

## Validation
- `npm run lint` (warnings only, no errors)
- `npm run build`
- `python3 -m py_compile backend/src/api/routes/users.py`

Closes #6
Closes #8
Closes #9