### PR TITLE
Fix preference repo by persisting child profiles in SQLite

### DIFF
--- a/backend/src/services/database/preference_repository.py
+++ b/backend/src/services/database/preference_repository.py
@@ -1,26 +1,32 @@
-"""In-memory child preference repository."""
+"""Persistent child preference repository."""
 
+import json
+from datetime import datetime
 from typing import Any, Dict, List
+
+from .connection import db_manager
 
 
 class PreferenceRepository:
     def __init__(self):
-        self._profiles: Dict[str, Dict[str, Any]] = {}
+        self._db = db_manager
 
     async def update_from_story_result(self, child_id: str, story_result: Dict[str, Any]) -> None:
-        profile = self._get_or_create_profile(child_id)
+        profile = await self._get_profile(child_id)
         self._bump(profile["themes"], story_result.get("themes", []), 1)
         self._bump(profile["concepts"], self._extract_concepts(story_result.get("concepts", [])), 1)
+        await self._save_profile(child_id, profile)
 
     async def update_from_choices(self, child_id: str, choice_history: List[str], session_data: Dict[str, Any]) -> None:
-        profile = self._get_or_create_profile(child_id)
+        profile = await self._get_profile(child_id)
         self._bump(profile["interests"], session_data.get("interests", []), 2)
         if isinstance(session_data.get("theme"), str) and session_data["theme"].strip():
             self._bump(profile["themes"], [session_data["theme"].strip()], 2)
         profile["recent_choices"] = [str(choice) for choice in (choice_history or [])[-20:]]
+        await self._save_profile(child_id, profile)
 
     async def update_from_news(self, child_id: str, category: str, key_concepts: List[Dict[str, Any]]) -> None:
-        profile = self._get_or_create_profile(child_id)
+        profile = await self._get_profile(child_id)
         if isinstance(category, str) and category.strip():
             self._bump(profile["themes"], [category.strip()], 1)
         concepts = []
@@ -28,14 +34,40 @@ class PreferenceRepository:
             if isinstance(item, dict) and isinstance(item.get("term"), str):
                 concepts.append(item["term"])
         self._bump(profile["concepts"], concepts, 1)
+        await self._save_profile(child_id, profile)
 
     async def get_profile(self, child_id: str) -> Dict[str, Any]:
-        return self._profiles.get(child_id, self._empty_profile())
+        return await self._get_profile(child_id)
 
-    def _get_or_create_profile(self, child_id: str) -> Dict[str, Any]:
-        if child_id not in self._profiles:
-            self._profiles[child_id] = self._empty_profile()
-        return self._profiles[child_id]
+    async def _get_profile(self, child_id: str) -> Dict[str, Any]:
+        row = await self._db.fetchone(
+            "SELECT profile_json FROM child_preferences WHERE child_id = ?",
+            (child_id,),
+        )
+        if not row:
+            return self._empty_profile()
+
+        try:
+            loaded = json.loads(row.get("profile_json") or "{}")
+        except json.JSONDecodeError:
+            loaded = {}
+
+        return self._normalize_profile(loaded)
+
+    async def _save_profile(self, child_id: str, profile: Dict[str, Any]) -> None:
+        now = datetime.now().isoformat()
+        payload = self._normalize_profile(profile)
+
+        await self._db.execute(
+            """
+            INSERT INTO child_preferences (child_id, profile_json, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(child_id)
+            DO UPDATE SET profile_json = excluded.profile_json, updated_at = excluded.updated_at
+            """,
+            (child_id, json.dumps(payload, ensure_ascii=False), now),
+        )
+        await self._db.commit()
 
     def _empty_profile(self) -> Dict[str, Any]:
         return {
@@ -44,6 +76,19 @@ class PreferenceRepository:
             "interests": {},
             "recent_choices": [],
         }
+
+    def _normalize_profile(self, profile: Dict[str, Any]) -> Dict[str, Any]:
+        normalized = self._empty_profile()
+        if isinstance(profile, dict):
+            normalized.update(profile)
+
+        for key in ["themes", "concepts", "interests"]:
+            if not isinstance(normalized.get(key), dict):
+                normalized[key] = {}
+        if not isinstance(normalized.get("recent_choices"), list):
+            normalized["recent_choices"] = []
+
+        return normalized
 
     def _extract_concepts(self, concepts: Any) -> List[str]:
         if not isinstance(concepts, list):

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -150,6 +150,20 @@ CREATE INDEX IF NOT EXISTS idx_tokens_user_id ON tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_tokens_expires_at ON tokens(expires_at);
 """
 
+CHILD_PREFERENCES_TABLE = """
+CREATE TABLE IF NOT EXISTS child_preferences (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    child_id TEXT UNIQUE NOT NULL,
+    profile_json TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+"""
+
+CHILD_PREFERENCES_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_child_preferences_child_id ON child_preferences(child_id);
+CREATE INDEX IF NOT EXISTS idx_child_preferences_updated_at ON child_preferences(updated_at DESC);
+"""
+
 
 # ============================================================================
 # Schema Initialization
@@ -187,6 +201,15 @@ async def init_schema(db: "DatabaseManager") -> None:
     # Create tokens table
     await db.execute(TOKENS_TABLE)
     for stmt in TOKENS_INDEXES.strip().split(";"):
+        if stmt.strip():
+            try:
+                await db.execute(stmt)
+            except Exception:
+                pass
+
+    # Create child preferences table
+    await db.execute(CHILD_PREFERENCES_TABLE)
+    for stmt in CHILD_PREFERENCES_INDEXES.strip().split(";"):
         if stmt.strip():
             try:
                 await db.execute(stmt)


### PR DESCRIPTION
## Summary
- replace in-memory `PreferenceRepository` storage with SQLite-backed persistence via `db_manager`
- add upsert-based profile writes and JSON profile reads for `child_preferences`
- add `child_preferences` table and indexes in schema initialization

## Validation
- `./venv/bin/python -c "import src.main; print('app-import-ok')"` ✅
- preference persistence smoke test (write -> reconnect -> read) ✅ (`preference-persist-ok`)
- `./venv/bin/pytest -q` ❌ pre-existing unrelated failure in `tests/test_simple.py` expecting `AgeGroup.AGE_6_8` (current enum uses `AGE_6_9`)

## Context
This completes the unfinished part where `preference_repo` existed but only stored data in memory.