### PR TITLE
Remove News to Kids from header navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,6 @@ const HistoryPage = lazy(() => import('./pages/HistoryPage'))
 const InteractiveStoryPage = lazy(() => import('./pages/InteractiveStoryPage'))
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const ProfilePage = lazy(() => import('./pages/ProfilePage'))
-const NewsPage = lazy(() => import('./pages/NewsPage'))
 
 function App() {
   return (
@@ -27,7 +26,6 @@ function App() {
           <Route path="story/:storyId" element={<StoryPage />} />
           <Route path="history" element={<HistoryPage />} />
           <Route path="interactive" element={<InteractiveStoryPage />} />
-          <Route path="news" element={<NewsPage />} />
           <Route path="profile" element={<ProfilePage />} />
         </Route>
       </Routes>

--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -52,7 +52,6 @@ function PageContainer() {
             {/* Navigation links */}
             <div className="flex items-center gap-4">
               <NavLink to="/history" icon="📚" label="My Stories" />
-              <NavLink to="/news" icon="📰" label="News for Kids" />
 
               {/* Auth section */}
               {isAuthenticated ? (


### PR DESCRIPTION
## Summary
- remove the `News for Kids` nav item from the main header
- remove the `/news` route from app routing so the section is no longer exposed in primary UI flow

## Validation
- `npm run build` (frontend) ✅

## Related
- Closes #29