### PR TITLE
Show News to Kids in hero while keeping header clean

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ const HistoryPage = lazy(() => import('./pages/HistoryPage'))
 const InteractiveStoryPage = lazy(() => import('./pages/InteractiveStoryPage'))
 const LoginPage = lazy(() => import('./pages/LoginPage'))
 const ProfilePage = lazy(() => import('./pages/ProfilePage'))
+const NewsPage = lazy(() => import('./pages/NewsPage'))
 
 function App() {
   return (
@@ -26,6 +27,7 @@ function App() {
           <Route path="story/:storyId" element={<StoryPage />} />
           <Route path="history" element={<HistoryPage />} />
           <Route path="interactive" element={<InteractiveStoryPage />} />
+          <Route path="news" element={<NewsPage />} />
           <Route path="profile" element={<ProfilePage />} />
         </Route>
       </Routes>

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -243,6 +243,16 @@ function HomePage() {
                     Interactive Tales
                   </Button>
                 </Link>
+                <Link to="/news">
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    rightIcon={<span>📰</span>}
+                    className="shadow-lg hover:shadow-xl transition-shadow w-full sm:w-auto"
+                  >
+                    News to Kids
+                  </Button>
+                </Link>
               </motion.div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- restore `/news` route in app routing so News page remains accessible
- add a `News to Kids` action button in the Home hero CTA group
- keep header navigation clean (no News tab in top nav)

## Validation
- `npm run build` (frontend) ✅