### PR TITLE
docs: update all Qdrant references to ChromaDB

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -57,7 +57,7 @@ Debug: $ARGUMENTS
 | MCP servers | Tool name mismatch (`mcp__server-name__tool_name` format), server not in `mcp_servers` dict |
 | Database | Missing schema migration, repository method not found |
 | TTS | OpenAI API key missing, audio path not returned correctly |
-| Vector search | Qdrant not running, embedding dimension mismatch |
+| Vector search | ChromaDB not initialized, embedding dimension mismatch |
 | Frontend | API URL mismatch, SSE event type not handled in store |
 
 ## Output

--- a/.claude/skills/investigate/SKILL.md
+++ b/.claude/skills/investigate/SKILL.md
@@ -17,7 +17,7 @@ Investigate: $ARGUMENTS
 3. **Trace the flow**: Follow the code path from entry to exit
    - Data flow: where data comes from, how it's transformed, where it goes
    - Control flow: what triggers this code, what decisions are made
-   - Dependencies: what external services/libraries are involved (Claude Agent SDK, MCP servers, Qdrant, OpenAI TTS)
+   - Dependencies: what external services/libraries are involved (Claude Agent SDK, MCP servers, ChromaDB, OpenAI TTS)
 4. **Check history**: Use `git log` and `git blame` on key files to understand evolution
 5. **Identify risks**: Note any code smells, tech debt, or potential issues
 6. **Document findings**: Produce a clear summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ FastAPI (backend/src/api/)
             └─► Claude Agent SDK
                     ├─► MCP Tool Servers (backend/src/mcp_servers/)
                     │       ├── vision_analysis_server    — Claude Vision API
-                    │       ├── vector_search_server      — Qdrant embeddings
+                    │       ├── vector_search_server      — ChromaDB embeddings
                     │       ├── safety_check_server       — Content safety (required)
                     │       ├── tts_generator_server      — OpenAI TTS
                     │       └── video_generator_server    — Video generation
@@ -31,7 +31,7 @@ React SPA (frontend/src/)
 | AI Engine | Claude Agent SDK (`claude_agent_sdk`), Anthropic API |
 | MCP Tools | Custom Python MCP servers |
 | Database | SQLite (via repository pattern) |
-| Vector DB | Qdrant (local) |
+| Vector DB | ChromaDB (local) |
 | TTS | OpenAI TTS API |
 | Frontend | React 18, TypeScript, Vite, Tailwind CSS, Zustand |
 
@@ -105,7 +105,7 @@ python -m pytest tests/integration/ -v     # integration tests only
 ```env
 ANTHROPIC_API_KEY=...     # Required for Claude Agent SDK + Vision
 OPENAI_API_KEY=...        # Required for TTS
-QDRANT_PATH=./data/vectors
+CHROMA_PATH=./data/vectors
 ```
 
 ## Critical Project Rules

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ result = await agent.run(input_data)  # 符合契约才能通过
 
 ### 3. 简化的存储设计
 - JSON 文件存储用户数据和配置
-- Qdrant 本地向量数据库（记忆系统）
+- ChromaDB 本地向量数据库（记忆系统）
 - 避免复杂的关系型数据库
 
 ## 文档结构
@@ -78,8 +78,8 @@ ANTHROPIC_API_KEY=your_api_key_here
 # OpenAI TTS (可选)
 OPENAI_API_KEY=your_api_key_here
 
-# 向量数据库（本地 Qdrant）
-QDRANT_PATH=./data/vectors
+# 向量数据库（本地 ChromaDB）
+CHROMA_PATH=./data/vectors
 ```
 
 ### 3. 运行契约测试
@@ -97,8 +97,7 @@ pytest tests/contracts/ -v
 ### 4. 启动开发环境
 
 ```bash
-# 启动本地向量数据库
-docker run -d -p 6333:6333 qdrant/qdrant
+# ChromaDB 为内嵌式 Python 库，无需单独启动
 
 # 启动 FastAPI 开发服务器
 uvicorn src.main:app --reload --port 8000
@@ -302,7 +301,7 @@ creative_agent/
 ├── data/                      # 数据存储（本地）
 │   ├── users/                 # 用户数据（JSON）
 │   ├── content/               # 内容数据（JSON）
-│   └── vectors/               # 向量数据（Qdrant）
+│   └── vectors/               # 向量数据（ChromaDB）
 │
 └── tools/                     # 开发工具
     └── generate_skills.py     # 从契约生成 Skills
@@ -319,7 +318,7 @@ creative_agent/
 ### AI & 存储
 - **Claude API**: GPT-4 级别的 AI 能力
 - **OpenAI TTS**: 语音合成
-- **Qdrant**: 本地向量数据库
+- **ChromaDB**: 本地向量数据库
 
 ### 开发工具
 - **pytest**: 测试框架
@@ -374,8 +373,7 @@ test: 添加故事生成契约测试
 
 ### 本地开发
 ```bash
-# 启动 Qdrant
-docker run -d -p 6333:6333 qdrant/qdrant
+# ChromaDB 为内嵌式 Python 库，无需单独启动
 
 # 启动 API
 uvicorn src.main:app --reload

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -84,7 +84,7 @@ Artifact 系统采用 Story 容器 + Artifact 一等实体的混合模型，详�
 |------|---------|----------------|
 | 画作分析 | MCP Tool (Vision API) | `mcp__vision__analyze` |
 | 故事生成 | Agent Prompt + Skills | `.claude/skills/story-generation/` |
-| 向量搜索 | MCP Tool (Qdrant) | `mcp__qdrant__search` |
+| 向量搜索 | MCP Tool (ChromaDB) | `mcp__vector-search__search_similar_drawings` |
 | 内容安全审查 | Custom MCP Tool | SDK MCP Server |
 | 年龄适配 | Skill (Markdown) | `.claude/skills/age-adapter/` |
 | TTS 生成 | MCP Tool (OpenAI) | `mcp__openai__tts` |
@@ -191,7 +191,7 @@ vision_server = create_sdk_mcp_server(
 ```python
 # src/mcp_servers/vector_search_server.py
 from claude_agent_sdk import tool, create_sdk_mcp_server
-from qdrant_client import QdrantClient
+import chromadb
 from typing import Any
 import json
 
@@ -216,7 +216,7 @@ import json
 )
 async def search_similar_drawings(args: dict[str, Any]) -> dict[str, Any]:
     """搜索相似画作"""
-    client = QdrantClient(path="./data/vectors")
+    client = chromadb.PersistentClient(path="./data/vectors")
 
     # 生成查询向量（使用 Claude 的嵌入功能）
     from anthropic import Anthropic
@@ -1186,7 +1186,7 @@ creative_agent/
 │   ├── uploads/                     # 上传的图片
 │   ├── audio/                       # 生成的音频
 │   ├── sessions/                    # 互动故事会话
-│   └── vectors/                     # Qdrant 向量数据库
+│   └── vectors/                     # ChromaDB 向量数据库
 │
 ├── DOMAIN.md                        # 领域文档
 ├── PRD.md                           # 产品需求
@@ -1234,7 +1234,7 @@ Step 6: 运行 Agent 集成测试
 | 手动管理工具执行循环 | SDK 自动处理 |
 | Skill = Python 类 | Skill = Markdown 文件 |
 | 需要实现 `to_claude_tool()` | 使用 `@tool` 装饰器 |
-| 复杂的数据库设计 | 简单的 JSON + Qdrant |
+| 复杂的数据库设计 | 简单的 JSON + ChromaDB |
 | ContractSkill 作为运行时验证 | 契约测试 + MCP Tool 输入验证 |
 
 ---
@@ -1248,7 +1248,7 @@ Step 6: 运行 Agent 集成测试
 claude-agent-sdk==1.0.0
 anthropic==0.18.1
 openai==1.12.0
-qdrant-client==1.7.0
+chromadb==1.4.1
 fastapi==0.110.0
 pydantic==2.6.1
 pytest==8.0.0
@@ -1259,14 +1259,14 @@ pytest==8.0.0
 ```env
 ANTHROPIC_API_KEY=your_key
 OPENAI_API_KEY=your_key
-QDRANT_PATH=./data/vectors
+CHROMA_PATH=./data/vectors
 ```
 
 ### C. 快速开始
 
 ```bash
 # 1. 安装依赖
-pip install claude-agent-sdk anthropic openai qdrant-client fastapi
+pip install claude-agent-sdk anthropic openai chromadb fastapi
 
 # 2. 设置 API Key
 export ANTHROPIC_API_KEY=your_key


### PR DESCRIPTION
## Summary

- Replace all Qdrant references with ChromaDB across documentation — the codebase uses ChromaDB (embedded Python library) but docs incorrectly referenced Qdrant (standalone Docker service)
- Fix env var name (`QDRANT_PATH` → `CHROMA_PATH`), dependency names, code examples, MCP tool names, and Docker startup commands
- Updated 5 files: `CLAUDE.md`, `README.md`, `docs/architecture/ARCHITECTURE.md`, `.claude/skills/debug/SKILL.md`, `.claude/skills/investigate/SKILL.md`

Fixes #48

## Test plan

- [ ] Verify no remaining incorrect Qdrant references in docs (`grep -ri qdrant` should only match the example branch name in DEVELOPMENT_WORKFLOW.md)
- [ ] Verify env var matches `backend/.env.example` (`CHROMA_PATH`)
- [ ] Verify dependency matches `backend/requirements.txt` (`chromadb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)