### PR TITLE
Fix: resume interactive stories from My Library cards

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -272,6 +272,19 @@ class SessionStatusResponse(BaseModel):
     expires_at: datetime = Field(..., description="过期时间")
 
 
+class SessionResumeResponse(BaseModel):
+    """Resume an in-progress interactive story session."""
+    session_id: str = Field(..., description="会话ID")
+    status: SessionStatus = Field(..., description="会话状态")
+    story_title: str = Field(..., description="故事标题")
+    age_group: AgeGroup = Field(..., description="年龄组")
+    segments: List[StorySegment] = Field(..., description="所有已生成段落")
+    choice_history: List[str] = Field(..., description="选择历史")
+    progress: float = Field(..., ge=0.0, le=1.0, description="完成进度 0-1")
+    total_segments: int = Field(..., description="总段落数")
+    educational_summary: Optional[EducationalValue] = Field(None, description="教育总结")
+
+
 class SaveInteractiveStoryResponse(BaseModel):
     """保存互动故事响应"""
     story_id: str = Field(..., description="保存后的故事ID")

--- a/frontend/src/api/services/storyService.ts
+++ b/frontend/src/api/services/storyService.ts
@@ -6,6 +6,7 @@ import type {
   ChoiceRequest,
   ChoiceResponse,
   SessionStatusResponse,
+  SessionResumeResponse,
   HealthCheckResponse,
   AgeGroup,
   VoiceType,
@@ -166,6 +167,16 @@ export const storyService = {
   async getSessionStatus(sessionId: string): Promise<SessionStatusResponse> {
     const response = await apiClient.get<SessionStatusResponse>(
       `/story/interactive/${sessionId}/status`
+    )
+    return response.data
+  },
+
+  /**
+   * Resume an interactive story session (fetch full segment data)
+   */
+  async resumeSession(sessionId: string): Promise<SessionResumeResponse> {
+    const response = await apiClient.get<SessionResumeResponse>(
+      `/story/interactive/${sessionId}/resume`
     )
     return response.data
   },

--- a/frontend/src/hooks/useInteractiveStory.ts
+++ b/frontend/src/hooks/useInteractiveStory.ts
@@ -40,6 +40,7 @@ interface UseInteractiveStoryReturn {
   startStoryStream: (params: InteractiveStoryStartRequest) => Promise<void>
   makeChoice: (choiceId: string) => Promise<void>
   makeChoiceStream: (choiceId: string) => Promise<void>
+  resumeSession: (sessionId: string) => Promise<void>
   reset: () => void
 }
 
@@ -59,6 +60,7 @@ export function useInteractiveStory(): UseInteractiveStoryReturn {
     streaming,
     setSession,
     addSegment,
+    restoreSession,
     complete,
     setAgeGroup,
     reset: resetStore,
@@ -266,6 +268,26 @@ export function useInteractiveStory(): UseInteractiveStoryReturn {
     [sessionId, addSegment, complete, startStreaming, updateStreamStatus, updateThinking, stopStreaming]
   )
 
+  const resumeSession = useCallback(
+    async (resumeSessionId: string) => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const response = await storyService.resumeSession(resumeSessionId)
+        restoreSession(response)
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : 'Failed to resume story'
+        setError(message)
+        throw err
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [restoreSession]
+  )
+
   const reset = useCallback(() => {
     resetStore()
     setError(null)
@@ -287,6 +309,7 @@ export function useInteractiveStory(): UseInteractiveStoryReturn {
     startStoryStream,
     makeChoice,
     makeChoiceStream,
+    resumeSession,
     reset,
   }
 }

--- a/frontend/src/store/useInteractiveStoryStore.ts
+++ b/frontend/src/store/useInteractiveStoryStore.ts
@@ -6,6 +6,7 @@ import type {
   EducationalValue,
   InteractiveStoryStartResponse,
   ChoiceResponse,
+  SessionResumeResponse,
   SSEStatusData,
   SSEThinkingData,
 } from '@/types/api'
@@ -38,6 +39,7 @@ interface InteractiveStoryState {
   // Actions
   setSession: (response: InteractiveStoryStartResponse, ageGroup?: AgeGroup) => void
   addSegment: (response: ChoiceResponse) => void
+  restoreSession: (response: SessionResumeResponse) => void
   complete: (summary: EducationalValue) => void
   setAgeGroup: (ageGroup: AgeGroup) => void
   reset: () => void
@@ -98,6 +100,22 @@ const useInteractiveStoryStore = create<InteractiveStoryState>()(
           progress: response.progress,
           streaming: initialStreamingState,
         }))
+      },
+
+      restoreSession: (response) => {
+        const lastSegment = response.segments[response.segments.length - 1] || null
+        set({
+          sessionId: response.session_id,
+          storyTitle: response.story_title,
+          ageGroup: response.age_group,
+          currentSegment: lastSegment,
+          segments: response.segments,
+          choiceHistory: response.choice_history,
+          progress: response.progress,
+          status: response.status === 'completed' ? 'completed' : 'playing',
+          educationalSummary: response.educational_summary,
+          streaming: initialStreamingState,
+        })
       },
 
       complete: (summary) => {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -105,6 +105,19 @@ export interface ChoiceResponse {
   progress: number;
 }
 
+// Session resume response (full data for restoring story view)
+export interface SessionResumeResponse {
+  session_id: string;
+  status: SessionStatus;
+  story_title: string;
+  age_group: AgeGroup;
+  segments: StorySegment[];
+  choice_history: string[];
+  progress: number;
+  total_segments: number;
+  educational_summary: EducationalValue | null;
+}
+
 // Session status response
 export interface SessionStatusResponse {
   session_id: string;


### PR DESCRIPTION
## Summary

- **Root cause**: Clicking an interactive story card in My Library navigates to `/interactive?session=<id>`, but the `InteractiveStoryPage` never read the `?session=` query parameter — it always showed the setup form.
- Adds `GET /interactive/{session_id}/resume` backend endpoint that returns all story segments, choice history, progress, and educational summary
- Frontend reads `?session=` via `useSearchParams()` and calls the resume endpoint on mount
- Zustand `restoreSession` action populates the full store state from the resume response
- Persists story state to `sessionStorage` so in-progress stories survive tab navigation

Fixes #80
Related to Epic #41

## Files Changed

| File | Change |
|------|--------|
| `backend/src/api/models.py` | Add `SessionResumeResponse` model |
| `backend/src/api/routes/interactive_story.py` | Add `GET /{session_id}/resume` endpoint |
| `frontend/src/types/api.ts` | Add `SessionResumeResponse` type |
| `frontend/src/api/services/storyService.ts` | Add `resumeSession()` API method |
| `frontend/src/store/useInteractiveStoryStore.ts` | Add `restoreSession` action + sessionStorage persist |
| `frontend/src/hooks/useInteractiveStory.ts` | Add `resumeSession` callback |
| `frontend/src/pages/InteractiveStoryPage/index.tsx` | Read `?session=` param, call resume on mount |

## Test plan

- [x] Backend: 113 tests pass, 0 failures
- [x] Frontend: TypeScript compiles clean
- [ ] Manual: Navigate to interactive story -> make choices -> leave page -> click card in My Library -> story resumes at correct segment
- [ ] Manual: Click a completed story card -> shows completed view with educational summary
- [ ] Manual: Click an expired/invalid session card -> falls back to setup page

Generated with [Claude Code](https://claude.com/claude-code)