### PR TITLE
feat(library): add Favorite and FavoriteCreate Pydantic domain models

### DIFF
--- a/backend/src/services/models/favorite_models.py
+++ b/backend/src/services/models/favorite_models.py
@@ -1,0 +1,38 @@
+"""
+Favorite Domain Models
+
+Pydantic v2 models for the favorites/bookmarking feature.
+Used by the FavoriteRepository and library API layer.
+"""
+
+from enum import Enum
+from typing import Optional
+from datetime import datetime
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LibraryItemType(str, Enum):
+    """Valid content types that can be favorited."""
+    ART_STORY = "art-story"
+    INTERACTIVE = "interactive"
+    NEWS = "news"
+
+
+class FavoriteCreate(BaseModel):
+    """Input model for creating a favorite."""
+    model_config = ConfigDict(frozen=True)
+
+    user_id: str = Field(..., description="Authenticated user's ID")
+    item_type: LibraryItemType = Field(..., description="Content type")
+    item_id: str = Field(..., description="ID of the content item")
+
+
+class Favorite(BaseModel):
+    """Domain model for a favorited item (as stored in the DB)."""
+    model_config = ConfigDict(frozen=True)
+
+    id: Optional[int] = Field(None, description="DB row ID")
+    user_id: str = Field(..., description="Owner's user ID")
+    item_type: LibraryItemType = Field(..., description="Content type")
+    item_id: str = Field(..., description="ID of the content item")
+    created_at: str = Field(..., description="ISO 8601 timestamp when favorited")


### PR DESCRIPTION
## Summary
- Adds `Favorite` and `FavoriteCreate` Pydantic v2 models in `backend/src/services/models/favorite_models.py`
- Structured domain models for the favorites feature with proper validation

**Parent Epic**: #49
Related to #57

## Test plan
- [x] Models validate correctly with Pydantic v2
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)