### PR TITLE
fix(safety): add explicit safety check instruction to image-to-story prompt

### DIFF
--- a/backend/src/agents/image_to_story_agent.py
+++ b/backend/src/agents/image_to_story_agent.py
@@ -29,15 +29,6 @@ except Exception:  # pragma: no cover - import fallback for test env
     ToolResultBlock = object
 
 
-def _should_use_mock() -> bool:
-    """Return True when running inside pytest or when the SDK is unavailable."""
-    return (
-        ClaudeSDKClient is None
-        or ClaudeAgentOptions is None
-        or os.getenv("PYTEST_CURRENT_TEST") is not None
-    )
-
-
 from ..mcp_servers import (
     vision_server,
     vector_server,
@@ -166,6 +157,14 @@ async def image_to_story(
    - image_path: {image_path}
 
 请根据画作内容创作故事，并提取主题、概念和寓意。
+
+**安全检查（必须执行）**：
+故事创作完成后，你**必须**使用 `mcp__safety-check__check_content_safety` 工具检查故事内容的安全性，参数如下：
+- content_text: 生成的故事文本
+- target_age: {child_age}
+- content_type: "story"
+如果安全检查未通过（passed == false），**必须**使用 `mcp__safety-check__suggest_content_improvements` 工具改进内容，然后重新检查，最多重试3次。
+安全检查通过后才能继续后续步骤。
 """
 
     # Add TTS instruction if audio should be generated
@@ -352,6 +351,14 @@ async def stream_image_to_story(
    - image_path: {image_path}
 
 请根据画作内容创作故事，并提取主题、概念和寓意。
+
+**安全检查（必须执行）**：
+故事创作完成后，你**必须**使用 `mcp__safety-check__check_content_safety` 工具检查故事内容的安全性，参数如下：
+- content_text: 生成的故事文本
+- target_age: {child_age}
+- content_type: "story"
+如果安全检查未通过（passed == false），**必须**使用 `mcp__safety-check__suggest_content_improvements` 工具改进内容，然后重新检查，最多重试3次。
+安全检查通过后才能继续后续步骤。
 """
 
     # Add TTS instruction if audio should be generated

--- a/backend/tests/contracts/test_safety_prompt_contract.py
+++ b/backend/tests/contracts/test_safety_prompt_contract.py
@@ -1,0 +1,107 @@
+"""
+Safety Prompt Contract Tests
+
+Ensures that agent prompts explicitly instruct safety check invocation.
+Content safety is non-negotiable (CLAUDE.md, PRD §1.2) — the agent MUST be
+told to call check_content_safety, not just have it in allowed_tools.
+
+Related: #105
+"""
+
+import re
+import pytest
+
+
+SAFETY_TOOL = "mcp__safety-check__check_content_safety"
+IMPROVEMENT_TOOL = "mcp__safety-check__suggest_content_improvements"
+
+
+def _build_image_to_story_prompt(child_age: int = 7) -> str:
+    """Build the inline prompt the same way image_to_story_agent does."""
+    from src.agents.image_to_story_agent import (
+        image_to_story,
+        stream_image_to_story,
+    )
+    import inspect
+
+    # Extract prompt string from source to avoid needing real files / SDK
+    source = inspect.getsource(image_to_story)
+    return source
+
+
+def _build_stream_prompt() -> str:
+    from src.agents.image_to_story_agent import stream_image_to_story
+    import inspect
+    return inspect.getsource(stream_image_to_story)
+
+
+class TestImageToStorySafetyPromptContract:
+    """The inline prompt in image_to_story_agent MUST instruct the agent to
+    call the safety check tool explicitly."""
+
+    def test_prompt_references_safety_check_tool(self):
+        """The prompt text must mention the safety check tool by full MCP name."""
+        source = _build_image_to_story_prompt()
+        assert SAFETY_TOOL in source, (
+            f"image_to_story prompt must reference {SAFETY_TOOL}"
+        )
+
+    def test_prompt_contains_mandatory_safety_instruction(self):
+        """The prompt must contain a MUST/mandatory instruction to run safety."""
+        source = _build_image_to_story_prompt()
+        # Look for mandatory language near the safety tool reference
+        has_mandatory = bool(
+            re.search(
+                r"(MUST|必须|mandatory|required|一定).{0,120}"
+                + re.escape(SAFETY_TOOL),
+                source,
+                re.IGNORECASE | re.DOTALL,
+            )
+            or re.search(
+                re.escape(SAFETY_TOOL)
+                + r".{0,120}(MUST|必须|mandatory|required|一定)",
+                source,
+                re.IGNORECASE | re.DOTALL,
+            )
+        )
+        assert has_mandatory, (
+            "image_to_story prompt must use mandatory language (MUST/必须) "
+            "when instructing the agent to call the safety check tool"
+        )
+
+    def test_prompt_references_improvement_tool(self):
+        """The prompt should reference suggest_content_improvements for failures."""
+        source = _build_image_to_story_prompt()
+        assert IMPROVEMENT_TOOL in source, (
+            f"image_to_story prompt must reference {IMPROVEMENT_TOOL} "
+            "for handling safety check failures"
+        )
+
+    def test_stream_prompt_references_safety_check_tool(self):
+        """stream_image_to_story must also instruct safety check."""
+        source = _build_stream_prompt()
+        assert SAFETY_TOOL in source, (
+            f"stream_image_to_story prompt must reference {SAFETY_TOOL}"
+        )
+
+    def test_stream_prompt_contains_mandatory_safety_instruction(self):
+        """stream_image_to_story must also use mandatory language for safety."""
+        source = _build_stream_prompt()
+        has_mandatory = bool(
+            re.search(
+                r"(MUST|必须|mandatory|required|一定).{0,120}"
+                + re.escape(SAFETY_TOOL),
+                source,
+                re.IGNORECASE | re.DOTALL,
+            )
+            or re.search(
+                re.escape(SAFETY_TOOL)
+                + r".{0,120}(MUST|必须|mandatory|required|一定)",
+                source,
+                re.IGNORECASE | re.DOTALL,
+            )
+        )
+        assert has_mandatory, (
+            "stream_image_to_story prompt must use mandatory language "
+            "when instructing the agent to call the safety check tool"
+        )


### PR DESCRIPTION
## Summary

- **Fixes #105** — Image-to-Story prompt did not explicitly instruct safety check invocation
- The inline prompt listed `check_content_safety` in `allowed_tools` but never told the agent to call it, making safety enforcement non-deterministic
- Added mandatory safety check instruction (with retry logic) to both `image_to_story()` and `stream_image_to_story()` prompts
- Added contract test ensuring the prompt always references the safety tool with mandatory language
- Removed duplicate `_should_use_mock()` definition (related to #111)

**Parent Epic**: #40

## Changes
- `backend/src/agents/image_to_story_agent.py`: Added explicit safety check block to both prompt strings; removed duplicate function
- `backend/tests/contracts/test_safety_prompt_contract.py`: New contract test (5 assertions)

## Test plan
- [x] Contract tests pass: `pytest tests/contracts/test_safety_prompt_contract.py` (5/5)
- [x] Full suite: 222 passed, no new failures
- [ ] Manual: generate a story and verify safety check tool is called in agent trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)