### PR TITLE
feat(library): hide search bar for 3-5 age group

### DIFF
--- a/frontend/src/config/ageConfig.ts
+++ b/frontend/src/config/ageConfig.ts
@@ -6,6 +6,7 @@ export interface AgeLayoutConfig {
   cardSize: 'sm' | 'md' | 'lg'
   fontSize: string
   showWordCount: boolean
+  showSearchBar: boolean
 }
 
 const AGE_CONFIGS: Record<string, AgeLayoutConfig> = {
@@ -15,6 +16,7 @@ const AGE_CONFIGS: Record<string, AgeLayoutConfig> = {
     cardSize: 'lg',
     fontSize: 'text-lg',
     showWordCount: false,
+    showSearchBar: false,
   },
   '6-8': {
     gridCols: 3,
@@ -22,6 +24,7 @@ const AGE_CONFIGS: Record<string, AgeLayoutConfig> = {
     cardSize: 'md',
     fontSize: 'text-base',
     showWordCount: true,
+    showSearchBar: true,
   },
   '9-12': {
     gridCols: 4,
@@ -29,6 +32,7 @@ const AGE_CONFIGS: Record<string, AgeLayoutConfig> = {
     cardSize: 'sm',
     fontSize: 'text-sm',
     showWordCount: true,
+    showSearchBar: true,
   },
 }
 

--- a/frontend/src/pages/LibraryPage/index.tsx
+++ b/frontend/src/pages/LibraryPage/index.tsx
@@ -810,14 +810,16 @@ function LibraryPage() {
         </div>
       </motion.div>
 
-      {/* Search bar (#62) */}
-      <motion.div
-        initial={{ opacity: 0, y: -10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.05 }}
-      >
-        <SearchBar onSearch={handleSearch} isLoading={searchLoading} />
-      </motion.div>
+      {/* Search bar (#62) — hidden for 3-5 age group per #114 */}
+      {ageLayout.showSearchBar && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.05 }}
+        >
+          <SearchBar onSearch={handleSearch} isLoading={searchLoading} />
+        </motion.div>
+      )}
 
       {/* Tab bar + sort dropdown (#65) */}
       <motion.div


### PR DESCRIPTION
## Summary
- Add `showSearchBar` boolean to `AgeLayoutConfig` in `frontend/src/config/ageConfig.ts`
- Conditionally render `SearchBar` in `LibraryPage` based on age group config
- 3-5 age group: search bar hidden (parents can search); 6-8 and 9-12: search bar visible

**Parent Epic**: #49

## Test plan
- [ ] Switch to 3-5 age group child profile → verify search bar is hidden
- [ ] Switch to 6-8 or 9-12 → verify search bar is visible
- [ ] Verify 3-5 library still allows browse, play audio, and favorites
- [ ] Verify no child profile (default config) shows search bar

Fixes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)