### PR TITLE
feat: add Morning Show entry point to Home page

### DIFF
--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -253,6 +253,16 @@ function HomePage() {
                     News to Kids
                   </Button>
                 </Link>
+                <Link to="/morning-show/subscriptions">
+                  <Button
+                    size="lg"
+                    variant="accent"
+                    rightIcon={<span>🌅</span>}
+                    className="shadow-lg hover:shadow-xl transition-shadow w-full sm:w-auto"
+                  >
+                    Morning Show
+                  </Button>
+                </Link>
               </motion.div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Adds a "Morning Show" action button to the Home page hero section, matching the style of existing buttons (Art to Story, Interactive Tales, News to Kids)
- Links to `/morning-show/subscriptions` so users can discover and subscribe to daily AI news episodes
- Uses `accent` variant with 🌅 icon to visually distinguish the morning show feature

Fixes #112
**Parent Epic**: #44

## Test plan
- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Verify button renders correctly on desktop and mobile
- [ ] Verify navigation to `/morning-show/subscriptions` works
- [ ] Verify layout with 4 buttons wraps properly on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)