### PR TITLE
fix(library): use artifact_url instead of nonexistent storage_url

### DIFF
--- a/backend/src/api/routes/library.py
+++ b/backend/src/api/routes/library.py
@@ -161,8 +161,8 @@ async def _resolve_thumbnail(story_id: str) -> Optional[str]:
     try:
         link_repo = StoryArtifactLinkRepository(db_manager)
         artifact = await link_repo.get_canonical_artifact(story_id, "cover")
-        if artifact and artifact.storage_url:
-            return artifact.storage_url
+        if artifact and artifact.artifact_url:
+            return artifact.artifact_url
     except Exception:
         pass
     return None

--- a/backend/tests/api/test_library_thumbnail.py
+++ b/backend/tests/api/test_library_thumbnail.py
@@ -1,0 +1,85 @@
+"""
+Tests for Library Thumbnail Resolution (#136)
+
+Verifies that _resolve_thumbnail() correctly reads artifact_url
+from the Artifact model returned by get_canonical_artifact().
+
+Bug: The code referenced artifact.storage_url which does not exist
+on the Artifact model — the correct field is artifact_url.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from datetime import datetime, timezone
+
+from backend.src.api.routes.library import _resolve_thumbnail
+
+
+class TestResolveThumbnail:
+    """Unit tests for _resolve_thumbnail() helper."""
+
+    def _make_artifact(self, artifact_url="https://cdn.example.com/cover.png"):
+        """Create a mock Artifact with artifact_url field."""
+        artifact = MagicMock()
+        artifact.artifact_url = artifact_url
+        # Ensure storage_url does NOT exist, to catch the old bug
+        del artifact.storage_url
+        return artifact
+
+    @pytest.mark.asyncio
+    async def test_returns_artifact_url_when_cover_exists(self):
+        """Should return artifact_url from the canonical cover artifact."""
+        mock_artifact = self._make_artifact("https://cdn.example.com/cover.png")
+
+        with patch(
+            "backend.src.api.routes.library.StoryArtifactLinkRepository"
+        ) as MockRepo:
+            instance = MockRepo.return_value
+            instance.get_canonical_artifact = AsyncMock(return_value=mock_artifact)
+
+            result = await _resolve_thumbnail("story-123")
+
+        assert result == "https://cdn.example.com/cover.png"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_cover_artifact(self):
+        """Should return None when no canonical cover artifact exists."""
+        with patch(
+            "backend.src.api.routes.library.StoryArtifactLinkRepository"
+        ) as MockRepo:
+            instance = MockRepo.return_value
+            instance.get_canonical_artifact = AsyncMock(return_value=None)
+
+            result = await _resolve_thumbnail("story-456")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_artifact_url_is_none(self):
+        """Should return None when artifact exists but has no URL."""
+        mock_artifact = self._make_artifact(artifact_url=None)
+
+        with patch(
+            "backend.src.api.routes.library.StoryArtifactLinkRepository"
+        ) as MockRepo:
+            instance = MockRepo.return_value
+            instance.get_canonical_artifact = AsyncMock(return_value=mock_artifact)
+
+            result = await _resolve_thumbnail("story-789")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_exception(self):
+        """Should swallow exceptions and return None."""
+        with patch(
+            "backend.src.api.routes.library.StoryArtifactLinkRepository"
+        ) as MockRepo:
+            instance = MockRepo.return_value
+            instance.get_canonical_artifact = AsyncMock(
+                side_effect=Exception("DB error")
+            )
+
+            result = await _resolve_thumbnail("story-err")
+
+        assert result is None


### PR DESCRIPTION
## Summary
- Fix `_resolve_thumbnail()` in `library.py` to use `artifact.artifact_url` instead of the nonexistent `artifact.storage_url` field
- Library card cover thumbnails were silently returning `None` for all stories with cover artifacts
- Add 4 unit tests covering happy path, missing artifact, null URL, and exception handling

Fixes #136
Related to #43 (Epic: Artifact Lifecycle)

## Test plan
- [x] RED: `test_returns_artifact_url_when_cover_exists` fails with `assert None == 'https://...'`
- [x] GREEN: All 4 new tests pass after fix
- [x] Existing library tests (19) still pass
- [ ] Manual: generate a story, verify library card shows cover thumbnail

🤖 Generated with [Claude Code](https://claude.com/claude-code)