### PR TITLE
feat(artifacts): add STORY_TEXT role to StoryArtifactRole enum

### DIFF
--- a/backend/src/api/routes/image_to_story.py
+++ b/backend/src/api/routes/image_to_story.py
@@ -395,15 +395,14 @@ async def create_story_from_image(
                 # Promote and link all created artifacts
                 for artifact_id, role in [
                     (image_artifact_id, StoryArtifactRole.COVER),
-                    (text_artifact_id, None),
+                    (text_artifact_id, StoryArtifactRole.STORY_TEXT),
                     (audio_artifact_id, StoryArtifactRole.FINAL_AUDIO),
                 ]:
                     if not artifact_id:
                         continue
                     await art_repo.update_lifecycle_state(artifact_id, "candidate")
                     await art_repo.update_lifecycle_state(artifact_id, "published")
-                    if role:
-                        await tracker.link_to_story(story_id, artifact_id, role)
+                    await tracker.link_to_story(story_id, artifact_id, role)
 
                 await tracker.complete_run(run_id, result_summary={
                     "artifacts_created": sum(1 for a in [image_artifact_id, text_artifact_id, audio_artifact_id] if a),

--- a/backend/src/services/models/artifact_models.py
+++ b/backend/src/services/models/artifact_models.py
@@ -52,6 +52,7 @@ class StoryArtifactRole(str, Enum):
     FINAL_AUDIO = "final_audio"
     FINAL_VIDEO = "final_video"
     SCENE_IMAGE = "scene_image"
+    STORY_TEXT = "story_text"
 
 
 class RunStatus(str, Enum):

--- a/backend/tests/contracts/artifact_models_contract.py
+++ b/backend/tests/contracts/artifact_models_contract.py
@@ -87,16 +87,16 @@ class TestStoryArtifactRoleEnum:
 
     def test_story_artifact_role_values(self):
         """
-        Contract: Four canonical roles plus custom.
+        Contract: Five canonical roles for story artifacts.
         """
-        valid_roles = {
-            "COVER": "cover",
-            "FINAL_AUDIO": "final_audio",
-            "FINAL_VIDEO": "final_video",
-            "SCENE_IMAGE": "scene_image"
-        }
+        from backend.src.services.models.artifact_models import StoryArtifactRole
 
-        assert len(valid_roles) == 4
+        assert StoryArtifactRole.COVER.value == "cover"
+        assert StoryArtifactRole.FINAL_AUDIO.value == "final_audio"
+        assert StoryArtifactRole.FINAL_VIDEO.value == "final_video"
+        assert StoryArtifactRole.SCENE_IMAGE.value == "scene_image"
+        assert StoryArtifactRole.STORY_TEXT.value == "story_text"
+        assert len(StoryArtifactRole) == 5
 
 
 class TestArtifactMetadataModel:


### PR DESCRIPTION
## Summary
- Add `STORY_TEXT = "story_text"` to `StoryArtifactRole` enum so text artifacts can be semantically linked to stories
- Update image-to-story provenance to link text artifacts with the new role (was previously `None`, skipping the link)
- Update contract test to validate 5 canonical roles using real enum imports

**Parent Epic**: #43

Fixes #142

## Test plan
- [x] Contract test validates `StoryArtifactRole` has 5 members including `STORY_TEXT`
- [x] Full test suite passes (261 passed, 3 pre-existing failures unrelated to this change)
- [x] Curated endpoint (`/stories/{story_id}/curated`) automatically iterates new role — no code change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)