### PR TITLE
feat(memory): expose memory API endpoints for preferences and characters

### DIFF
--- a/backend/src/api/routes/__init__.py
+++ b/backend/src/api/routes/__init__.py
@@ -16,6 +16,7 @@ from . import (
     artifacts,
     admin_artifacts,
     library,
+    memory,
 )
 
 __all__ = [
@@ -30,4 +31,5 @@ __all__ = [
     "artifacts",
     "admin_artifacts",
     "library",
+    "memory",
 ]

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -1,0 +1,77 @@
+"""Memory API routes — preferences and characters (#162).
+
+Exposes read/delete endpoints for the memory system so the frontend can
+display favorite themes, suggest topics, and show a character gallery.
+
+Parent Epic: #42
+"""
+
+import re
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ..deps import get_current_user
+from ...services.database import preference_repo, character_repo
+from ...services.user_service import UserData
+
+router = APIRouter(
+    prefix="/api/v1/memory",
+    tags=["Memory"],
+)
+
+
+def _validate_child_id(child_id: str) -> str:
+    """Validate child_id format — alphanumeric, underscore, hyphen, 1-100 chars."""
+    if not re.match(r"^[a-zA-Z0-9_-]{1,100}$", child_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid child_id format",
+        )
+    return child_id
+
+
+@router.get(
+    "/preferences/{child_id}",
+    summary="Get child preference profile",
+)
+async def get_preferences(
+    child_id: str,
+    user: UserData = Depends(get_current_user),
+):
+    """Return the normalized preference profile for a child."""
+    child_id = _validate_child_id(child_id)
+    profile = await preference_repo.get_profile(child_id)
+    return {"child_id": child_id, "profile": profile}
+
+
+@router.delete(
+    "/preferences/{child_id}",
+    status_code=status.HTTP_200_OK,
+    summary="Delete child preference data",
+)
+async def delete_preferences(
+    child_id: str,
+    user: UserData = Depends(get_current_user),
+):
+    """Remove preference profile for a child (COPPA compliance)."""
+    child_id = _validate_child_id(child_id)
+    db = preference_repo._db
+    await db.execute(
+        "DELETE FROM child_preferences WHERE child_id = ?",
+        (child_id,),
+    )
+    await db.commit()
+    return {"child_id": child_id, "deleted": True}
+
+
+@router.get(
+    "/characters/{child_id}",
+    summary="Get child's character gallery",
+)
+async def get_characters(
+    child_id: str,
+    user: UserData = Depends(get_current_user),
+):
+    """Return all characters for a child, sorted by appearance count."""
+    child_id = _validate_child_id(child_id)
+    characters = await character_repo.get_characters(child_id)
+    return {"child_id": child_id, "characters": characters}

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -247,6 +247,7 @@ from .api.routes import (
     artifacts,
     admin_artifacts,
     library,
+    memory,
 )
 
 app.include_router(image_to_story.router)
@@ -260,6 +261,7 @@ app.include_router(subscriptions.router)
 app.include_router(artifacts.router)
 app.include_router(admin_artifacts.router)
 app.include_router(library.router)
+app.include_router(memory.router)
 
 
 # ============================================================================

--- a/backend/tests/api/test_memory.py
+++ b/backend/tests/api/test_memory.py
@@ -1,0 +1,79 @@
+"""API tests for memory endpoints (#162).
+
+Tests GET/DELETE preferences and GET characters.
+"""
+
+import uuid
+import pytest
+
+
+@pytest.mark.asyncio
+class TestMemoryPreferencesEndpoints:
+    async def test_get_preferences_returns_profile(self, test_client):
+        child_id = f"child-mem-{uuid.uuid4().hex[:8]}"
+        async with test_client as client:
+            resp = await client.get(f"/api/v1/memory/preferences/{child_id}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["child_id"] == child_id
+            profile = body["profile"]
+            assert "themes" in profile
+            assert "concepts" in profile
+            assert "interests" in profile
+            assert "recent_choices" in profile
+            assert "morning_show" in profile
+
+    async def test_get_preferences_invalid_child_id(self, test_client):
+        async with test_client as client:
+            resp = await client.get("/api/v1/memory/preferences/bad id!@#")
+            assert resp.status_code == 400
+
+    async def test_delete_preferences(self, test_client):
+        child_id = f"child-del-{uuid.uuid4().hex[:8]}"
+        async with test_client as client:
+            # Create some preference data first
+            from backend.src.services.database import preference_repo
+            await preference_repo.update_from_story_result(child_id, {"themes": ["space"]})
+
+            # Verify it exists
+            resp = await client.get(f"/api/v1/memory/preferences/{child_id}")
+            assert resp.json()["profile"]["themes"].get("space") == 1
+
+            # Delete
+            del_resp = await client.delete(f"/api/v1/memory/preferences/{child_id}")
+            assert del_resp.status_code == 200
+            assert del_resp.json()["deleted"] is True
+
+            # Verify cleared (returns empty profile)
+            after = await client.get(f"/api/v1/memory/preferences/{child_id}")
+            assert after.json()["profile"]["themes"] == {}
+
+
+@pytest.mark.asyncio
+class TestMemoryCharactersEndpoints:
+    async def test_get_characters_empty(self, test_client):
+        child_id = f"child-chr-{uuid.uuid4().hex[:8]}"
+        async with test_client as client:
+            resp = await client.get(f"/api/v1/memory/characters/{child_id}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["child_id"] == child_id
+            assert body["characters"] == []
+
+    async def test_get_characters_returns_data(self, test_client):
+        child_id = f"child-chr-{uuid.uuid4().hex[:8]}"
+        async with test_client as client:
+            # Insert a character directly
+            from backend.src.services.database import character_repo
+            await character_repo.upsert_character(
+                child_id=child_id,
+                name="Lightning Dog",
+                description="A fast golden dog",
+            )
+
+            resp = await client.get(f"/api/v1/memory/characters/{child_id}")
+            assert resp.status_code == 200
+            chars = resp.json()["characters"]
+            assert len(chars) == 1
+            assert chars[0]["name"] == "Lightning Dog"
+            assert chars[0]["appearance_count"] == 1


### PR DESCRIPTION
## Summary

- `GET /api/v1/memory/preferences/{child_id}` — returns normalized preference profile
- `DELETE /api/v1/memory/preferences/{child_id}` — removes profile (COPPA compliance)
- `GET /api/v1/memory/characters/{child_id}` — character gallery sorted by appearance count
- Input validation with child_id format check
- 5 API tests

Fixes #162
**Parent Epic**: #42

## Test plan

- [x] 5 API tests pass
- [x] All existing tests unaffected

## Generated with [Claude Code](https://claude.com/claude-code)