### PR TITLE
feat(memory): add preference privacy controls and data retention

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -1,4 +1,4 @@
-"""Memory API routes — preferences and characters (#162).
+"""Memory API routes — preferences and characters (#162, #164).
 
 Exposes read/delete endpoints for the memory system so the frontend can
 display favorite themes, suggest topics, and show a character gallery.
@@ -6,12 +6,15 @@ display favorite themes, suggest topics, and show a character gallery.
 Parent Epic: #42
 """
 
+import logging
 import re
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..deps import get_current_user
 from ...services.database import preference_repo, character_repo
 from ...services.user_service import UserData
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/v1/memory",
@@ -37,10 +40,15 @@ async def get_preferences(
     child_id: str,
     user: UserData = Depends(get_current_user),
 ):
-    """Return the normalized preference profile for a child."""
+    """Return the normalized preference profile with data timestamps (#164)."""
     child_id = _validate_child_id(child_id)
-    profile = await preference_repo.get_profile(child_id)
-    return {"child_id": child_id, "profile": profile}
+    result = await preference_repo.get_profile_with_metadata(child_id)
+    return {
+        "child_id": child_id,
+        "profile": result["profile"],
+        "data_collected_since": result["data_collected_since"],
+        "last_updated_at": result["last_updated_at"],
+    }
 
 
 @router.delete(
@@ -52,15 +60,37 @@ async def delete_preferences(
     child_id: str,
     user: UserData = Depends(get_current_user),
 ):
-    """Remove preference profile for a child (COPPA compliance)."""
+    """Remove preference profile + ChromaDB vectors for a child (COPPA compliance, #164)."""
     child_id = _validate_child_id(child_id)
-    db = preference_repo._db
-    await db.execute(
-        "DELETE FROM child_preferences WHERE child_id = ?",
-        (child_id,),
-    )
-    await db.commit()
-    return {"child_id": child_id, "deleted": True}
+
+    # Delete SQLite profile
+    deleted_sqlite = await preference_repo.delete_profile(child_id)
+
+    # Delete ChromaDB vectors for this child
+    deleted_vectors = 0
+    try:
+        import anyio
+        from ...mcp_servers.vector_search_server import get_or_create_collection
+        collection = await anyio.to_thread.run_sync(get_or_create_collection)
+        # Get all document IDs for this child
+        results = await anyio.to_thread.run_sync(
+            lambda: collection.get(where={"child_id": child_id})
+        )
+        if results and results.get("ids"):
+            doc_ids = results["ids"]
+            deleted_vectors = len(doc_ids)
+            await anyio.to_thread.run_sync(lambda: collection.delete(ids=doc_ids))
+    except Exception:
+        logger.warning("Failed to delete ChromaDB vectors for child %s", child_id, exc_info=True)
+
+    return {
+        "child_id": child_id,
+        "deleted": True,
+        "deleted_records": {
+            "preferences": 1 if deleted_sqlite else 0,
+            "vectors": deleted_vectors,
+        },
+    }
 
 
 @router.get(

--- a/backend/src/services/database/preference_repository.py
+++ b/backend/src/services/database/preference_repository.py
@@ -1,7 +1,7 @@
 """Persistent child preference repository."""
 
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
 from .connection import db_manager
@@ -82,6 +82,38 @@ class PreferenceRepository:
     async def get_profile(self, child_id: str) -> Dict[str, Any]:
         return await self._get_profile(child_id)
 
+    async def get_profile_with_metadata(self, child_id: str) -> Dict[str, Any]:
+        """Return profile with data_collected_since and last_updated_at timestamps."""
+        row = await self._db.fetchone(
+            "SELECT profile_json, updated_at FROM child_preferences WHERE child_id = ?",
+            (child_id,),
+        )
+        if not row:
+            profile = self._empty_profile()
+            return {"profile": profile, "data_collected_since": None, "last_updated_at": None}
+
+        try:
+            loaded = json.loads(row.get("profile_json") or "{}")
+        except json.JSONDecodeError:
+            loaded = {}
+
+        profile = self._normalize_profile(loaded)
+        profile = self._apply_retention(profile)
+        return {
+            "profile": profile,
+            "data_collected_since": loaded.get("data_collected_since"),
+            "last_updated_at": row.get("updated_at"),
+        }
+
+    async def delete_profile(self, child_id: str) -> bool:
+        """Delete preference profile for a child. Returns True if a row was deleted."""
+        cursor = await self._db.execute(
+            "DELETE FROM child_preferences WHERE child_id = ?",
+            (child_id,),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
     async def _get_profile(self, child_id: str) -> Dict[str, Any]:
         row = await self._db.fetchone(
             "SELECT profile_json FROM child_preferences WHERE child_id = ?",
@@ -100,6 +132,13 @@ class PreferenceRepository:
     async def _save_profile(self, child_id: str, profile: Dict[str, Any]) -> None:
         now = datetime.now().isoformat()
         payload = self._normalize_profile(profile)
+
+        # Cap recent_choices at 50 (#164)
+        payload["recent_choices"] = payload["recent_choices"][-50:]
+
+        # Stamp data_collected_since if not set
+        if not payload.get("data_collected_since"):
+            payload["data_collected_since"] = now
 
         await self._db.execute(
             """
@@ -145,6 +184,30 @@ class PreferenceRepository:
                 morning["topic_stats"] = {}
 
         return normalized
+
+    def _apply_retention(self, profile: Dict[str, Any]) -> Dict[str, Any]:
+        """Apply data retention rules (#164).
+
+        - Cap recent_choices at 50
+        - Decay topic scores not updated in 6 months by 50%
+        """
+        profile["recent_choices"] = profile.get("recent_choices", [])[-50:]
+
+        morning = profile.get("morning_show", {})
+        last_event = morning.get("last_event_at")
+        if last_event:
+            try:
+                last_dt = datetime.fromisoformat(last_event)
+                cutoff = datetime.now() - timedelta(days=180)
+                if last_dt < cutoff:
+                    topic_scores = morning.get("topic_scores", {})
+                    for topic in topic_scores:
+                        topic_scores[topic] = round(float(topic_scores[topic]) * 0.5, 3)
+                    morning["topic_scores"] = topic_scores
+            except (ValueError, TypeError):
+                pass
+
+        return profile
 
     def _extract_concepts(self, concepts: Any) -> List[str]:
         if not isinstance(concepts, list):

--- a/backend/tests/contracts/test_preference_retention_contract.py
+++ b/backend/tests/contracts/test_preference_retention_contract.py
@@ -1,0 +1,130 @@
+"""
+Preference Retention & Privacy Contract Tests (#164)
+
+Tests data minimization: recent_choices cap, topic score decay,
+delete_profile, and get_profile_with_metadata.
+
+Parent Epic: #42 | Issue: #164
+"""
+
+import json
+import pytest
+from datetime import datetime, timedelta
+
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.preference_repository import PreferenceRepository
+
+
+@pytest.fixture
+async def db():
+    manager = DatabaseManager(":memory:")
+    await manager.connect()
+    await manager.execute(
+        """
+        CREATE TABLE IF NOT EXISTS child_preferences (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            child_id TEXT UNIQUE NOT NULL,
+            profile_json TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    await manager.commit()
+    yield manager
+    await manager.disconnect()
+
+
+@pytest.fixture
+def repo(db):
+    r = PreferenceRepository()
+    r._db = db
+    return r
+
+
+class TestRecentChoicesCap:
+    """Contract: recent_choices capped at 50 on save."""
+
+    @pytest.mark.asyncio
+    async def test_cap_at_50_on_save(self, repo):
+        choices = [f"choice-{i}" for i in range(70)]
+        await repo.update_from_choices("child-1", choice_history=choices, session_data={})
+        profile = await repo.get_profile("child-1")
+        assert len(profile["recent_choices"]) <= 50
+
+    @pytest.mark.asyncio
+    async def test_retention_trims_on_read(self, repo):
+        """_apply_retention also trims recent_choices."""
+        profile = repo._empty_profile()
+        profile["recent_choices"] = [f"c-{i}" for i in range(60)]
+        result = repo._apply_retention(profile)
+        assert len(result["recent_choices"]) == 50
+
+
+class TestTopicScoreDecay:
+    """Contract: topic scores decay by 50% if not updated in 6 months."""
+
+    @pytest.mark.asyncio
+    async def test_scores_decay_after_6_months(self, repo):
+        stale_date = (datetime.now() - timedelta(days=200)).isoformat()
+        profile = repo._empty_profile()
+        profile["morning_show"]["topic_scores"] = {"space": 10.0, "robots": 4.0}
+        profile["morning_show"]["last_event_at"] = stale_date
+
+        result = repo._apply_retention(profile)
+        assert result["morning_show"]["topic_scores"]["space"] == 5.0
+        assert result["morning_show"]["topic_scores"]["robots"] == 2.0
+
+    @pytest.mark.asyncio
+    async def test_scores_no_decay_if_recent(self, repo):
+        recent_date = datetime.now().isoformat()
+        profile = repo._empty_profile()
+        profile["morning_show"]["topic_scores"] = {"space": 10.0}
+        profile["morning_show"]["last_event_at"] = recent_date
+
+        result = repo._apply_retention(profile)
+        assert result["morning_show"]["topic_scores"]["space"] == 10.0
+
+    @pytest.mark.asyncio
+    async def test_scores_no_decay_if_no_event(self, repo):
+        profile = repo._empty_profile()
+        profile["morning_show"]["topic_scores"] = {"space": 10.0}
+        # last_event_at is None by default
+        result = repo._apply_retention(profile)
+        assert result["morning_show"]["topic_scores"]["space"] == 10.0
+
+
+class TestDeleteProfile:
+    """Contract: delete_profile removes the row."""
+
+    @pytest.mark.asyncio
+    async def test_delete_existing_profile(self, repo):
+        await repo.update_from_story_result("child-del", {"themes": ["space"]})
+        deleted = await repo.delete_profile("child-del")
+        assert deleted is True
+
+        profile = await repo.get_profile("child-del")
+        assert profile["themes"] == {}
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_returns_false(self, repo):
+        deleted = await repo.delete_profile("ghost-child")
+        assert deleted is False
+
+
+class TestGetProfileWithMetadata:
+    """Contract: get_profile_with_metadata includes timestamps."""
+
+    @pytest.mark.asyncio
+    async def test_includes_timestamps_after_save(self, repo):
+        await repo.update_from_story_result("child-ts", {"themes": ["ocean"]})
+        result = await repo.get_profile_with_metadata("child-ts")
+        assert "profile" in result
+        assert "last_updated_at" in result
+        assert result["last_updated_at"] is not None
+        assert "data_collected_since" in result
+
+    @pytest.mark.asyncio
+    async def test_new_child_returns_none_timestamps(self, repo):
+        result = await repo.get_profile_with_metadata("new-child")
+        assert result["data_collected_since"] is None
+        assert result["last_updated_at"] is None


### PR DESCRIPTION
## Summary

- Cap `recent_choices` at 50 entries (previously unbounded in save path)
- Decay morning show topic scores by 50% when stale > 6 months
- `DELETE /api/v1/memory/preferences/{child_id}` now clears both SQLite profile AND ChromaDB vectors
- `GET /api/v1/memory/preferences/{child_id}` now includes `data_collected_since` and `last_updated_at` timestamps
- New repository methods: `delete_profile()`, `get_profile_with_metadata()`, `_apply_retention()`
- 9 contract tests covering caps, decay, deletion, and metadata

Fixes #164
**Parent Epic**: #42

## Test plan

- [x] 9 retention contract tests pass
- [x] 16 existing preference contract tests still pass
- [x] 5 memory API tests still pass

## Generated with [Claude Code](https://claude.com/claude-code)