### PR TITLE
feat(memory): add story deduplication via ChromaDB embeddings

### DIFF
--- a/backend/src/mcp_servers/__init__.py
+++ b/backend/src/mcp_servers/__init__.py
@@ -17,6 +17,8 @@ analyze_children_drawing = _unavailable_tool
 vector_server = {}
 search_similar_drawings = _unavailable_tool
 store_drawing_embedding = _unavailable_tool
+store_story_embedding = _unavailable_tool
+search_similar_stories = _unavailable_tool
 safety_server = {}
 check_content_safety = _unavailable_tool
 suggest_content_improvements = _unavailable_tool
@@ -38,7 +40,7 @@ except Exception:
     pass
 
 try:
-    from .vector_search_server import vector_server, search_similar_drawings, store_drawing_embedding
+    from .vector_search_server import vector_server, search_similar_drawings, store_drawing_embedding, store_story_embedding, search_similar_stories
 except Exception:
     pass
 
@@ -78,6 +80,8 @@ __all__ = [
     "vector_server",
     "search_similar_drawings",
     "store_drawing_embedding",
+    "store_story_embedding",
+    "search_similar_stories",
     "safety_server",
     "check_content_safety",
     "suggest_content_improvements",

--- a/backend/src/mcp_servers/vector_search_server.py
+++ b/backend/src/mcp_servers/vector_search_server.py
@@ -41,15 +41,24 @@ def get_chroma_client():
 
 # 集合名称
 COLLECTION_NAME = "children_drawings"
+STORY_COLLECTION_NAME = "story_embeddings"
 
 
 def get_or_create_collection():
     """获取或创建集合"""
     client = get_chroma_client()
-    # ChromaDB 会自动创建集合（如果不存在）
     return client.get_or_create_collection(
         name=COLLECTION_NAME,
         metadata={"description": "儿童画作的向量存储"}
+    )
+
+
+def get_or_create_story_collection():
+    """Get or create story embeddings collection (#161)."""
+    client = get_chroma_client()
+    return client.get_or_create_collection(
+        name=STORY_COLLECTION_NAME,
+        metadata={"description": "Story text embeddings for deduplication"}
     )
 
 
@@ -261,11 +270,134 @@ async def store_drawing_embedding(args: Dict[str, Any]) -> Dict[str, Any]:
         }
 
 
+@tool(
+    "store_story_embedding",
+    """Store a story's text embedding for deduplication (#161).
+
+    Called after story generation to enable semantic similarity checks
+    before future generations. Prevents near-duplicate stories for the
+    same child.""",
+    {"child_id": str, "story_id": str, "story_text": str, "themes": str, "age_group": str}
+)
+async def store_story_embedding(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Store story text embedding in the story_embeddings collection."""
+    child_id = args.get("child_id", "")
+    story_id = args.get("story_id", "")
+    story_text = args.get("story_text", "")
+
+    if not child_id or not story_text:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({"success": False, "error": "child_id and story_text are required"}, ensure_ascii=False)
+            }]
+        }
+
+    try:
+        collection = await anyio.to_thread.run_sync(get_or_create_story_collection)
+
+        doc_id = story_id or hashlib.md5(f"{child_id}_{datetime.now().isoformat()}".encode()).hexdigest()
+
+        metadata = {
+            "child_id": child_id,
+            "story_id": story_id,
+            "themes": args.get("themes", ""),
+            "age_group": args.get("age_group", ""),
+            "created_at": datetime.now().isoformat(),
+        }
+
+        await anyio.to_thread.run_sync(lambda: collection.upsert(
+            ids=[doc_id],
+            documents=[story_text[:2000]],
+            metadatas=[metadata]
+        ))
+
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({"success": True, "document_id": doc_id}, ensure_ascii=False)
+            }]
+        }
+    except Exception as e:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({"success": False, "error": f"Failed to store story embedding: {e}"}, ensure_ascii=False)
+            }]
+        }
+
+
+@tool(
+    "search_similar_stories",
+    """Search for semantically similar stories for a child (#161).
+
+    Used before story generation to detect near-duplicates (similarity > 0.9)
+    and inject variation nudges into the prompt.""",
+    {"child_id": str, "story_description": str, "top_k": int}
+)
+async def search_similar_stories(args: Dict[str, Any]) -> Dict[str, Any]:
+    """Search for similar stories in the story_embeddings collection."""
+    child_id = args.get("child_id", "")
+    story_description = args.get("story_description", "")
+    top_k = args.get("top_k", 5)
+
+    if not child_id or not story_description:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({"similar_stories": [], "total_found": 0}, ensure_ascii=False)
+            }]
+        }
+
+    try:
+        collection = await anyio.to_thread.run_sync(get_or_create_story_collection)
+
+        results = await anyio.to_thread.run_sync(lambda: collection.query(
+            query_texts=[story_description],
+            n_results=top_k,
+            where={"child_id": child_id}
+        ))
+
+        similar_stories = []
+        if results and results['ids'] and len(results['ids']) > 0:
+            ids = results['ids'][0]
+            distances = results.get('distances', [[]])[0]
+            metadatas = results.get('metadatas', [[]])[0]
+            documents = results.get('documents', [[]])[0]
+
+            for i, doc_id in enumerate(ids):
+                similarity_score = 1.0 / (1.0 + distances[i]) if i < len(distances) else 0.0
+                similar_stories.append({
+                    "story_id": doc_id,
+                    "similarity_score": round(similarity_score, 4),
+                    "story_text_preview": (documents[i][:200] + "...") if i < len(documents) and len(documents[i]) > 200 else (documents[i] if i < len(documents) else ""),
+                    "metadata": metadatas[i] if i < len(metadatas) else {},
+                })
+
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "similar_stories": similar_stories,
+                    "total_found": len(similar_stories),
+                    "query": {"child_id": child_id, "top_k": top_k}
+                }, ensure_ascii=False, indent=2)
+            }]
+        }
+    except Exception as e:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({"similar_stories": [], "total_found": 0, "error": str(e)}, ensure_ascii=False)
+            }]
+        }
+
+
 # 创建 MCP Server
 vector_server = create_sdk_mcp_server(
     name="vector-search",
     version="1.0.0",
-    tools=[search_similar_drawings, store_drawing_embedding]
+    tools=[search_similar_drawings, store_drawing_embedding, store_story_embedding, search_similar_stories]
 )
 
 

--- a/backend/tests/contracts/test_story_dedup_contract.py
+++ b/backend/tests/contracts/test_story_dedup_contract.py
@@ -1,0 +1,121 @@
+"""
+Story Deduplication Contract Tests (#161)
+
+Tests store_story_embedding and search_similar_stories MCP tools.
+
+Parent Epic: #42 | Issue: #161
+"""
+
+import importlib
+import json
+import pytest
+
+
+@pytest.fixture()
+def vs():
+    return importlib.import_module("backend.src.mcp_servers.vector_search_server")
+
+
+async def _call(tool_obj, args):
+    if hasattr(tool_obj, "handler"):
+        return await tool_obj.handler(args)
+    return await tool_obj(args)
+
+
+class TestStoreStoryEmbedding:
+    @pytest.mark.asyncio
+    async def test_rejects_empty_child_id(self, vs):
+        result = await _call(vs.store_story_embedding, {
+            "child_id": "",
+            "story_id": "s1",
+            "story_text": "A dog flew to the moon",
+            "themes": "space",
+            "age_group": "6-8",
+        })
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_story_text(self, vs):
+        result = await _call(vs.store_story_embedding, {
+            "child_id": "child-1",
+            "story_id": "s1",
+            "story_text": "",
+            "themes": "",
+            "age_group": "",
+        })
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_stores_successfully(self, vs, tmp_path):
+        pytest.importorskip("chromadb")
+        import os
+        os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
+
+        result = await _call(vs.store_story_embedding, {
+            "child_id": "child-dedup",
+            "story_id": "story-001",
+            "story_text": "Lightning Dog flew to the moon and found a glowing rock.",
+            "themes": "space, adventure",
+            "age_group": "6-8",
+        })
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["success"] is True
+        assert payload["document_id"] == "story-001"
+
+
+class TestSearchSimilarStories:
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_unknown_child(self, vs, tmp_path):
+        pytest.importorskip("chromadb")
+        import os
+        os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
+
+        result = await _call(vs.search_similar_stories, {
+            "child_id": "ghost",
+            "story_description": "anything",
+            "top_k": 3,
+        })
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["similar_stories"] == []
+        assert payload["total_found"] == 0
+
+    @pytest.mark.asyncio
+    async def test_finds_similar_story(self, vs, tmp_path):
+        pytest.importorskip("chromadb")
+        import os
+        os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
+
+        await _call(vs.store_story_embedding, {
+            "child_id": "child-sim",
+            "story_id": "story-sim-1",
+            "story_text": "A brave dog named Lightning flew to the moon on a rocket ship.",
+            "themes": "space",
+            "age_group": "6-8",
+        })
+
+        result = await _call(vs.search_similar_stories, {
+            "child_id": "child-sim",
+            "story_description": "Lightning Dog goes to the moon",
+            "top_k": 3,
+        })
+        payload = json.loads(result["content"][0]["text"])
+        assert payload["total_found"] >= 1
+        assert 0.0 <= payload["similar_stories"][0]["similarity_score"] <= 1.0
+
+    @pytest.mark.asyncio
+    async def test_response_shape(self, vs, tmp_path):
+        pytest.importorskip("chromadb")
+        import os
+        os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
+
+        result = await _call(vs.search_similar_stories, {
+            "child_id": "child-shape",
+            "story_description": "test",
+            "top_k": 1,
+        })
+        payload = json.loads(result["content"][0]["text"])
+        assert "similar_stories" in payload
+        assert "total_found" in payload
+        assert "query" in payload


### PR DESCRIPTION
## Summary

- New `story_embeddings` ChromaDB collection for semantic story dedup
- `store_story_embedding` MCP tool — stores story text after generation
- `search_similar_stories` MCP tool — finds near-duplicates before generation
- Exported via `mcp_servers/__init__.py` with safe fallbacks
- 6 contract tests

Fixes #161
**Parent Epic**: #42

## Test plan

- [x] 6 story dedup contract tests pass
- [x] 8 existing vector search contract tests still pass

## Generated with [Claude Code](https://claude.com/claude-code)