### PR TITLE
fix(security): remove auto-claiming of ownerless resources (#187)

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -128,11 +128,11 @@ async def get_admin_user(
 
 async def get_story_for_owner(story_id: str, user_id: str) -> dict:
     """
-    Fetch story by ID, verify ownership. Auto-claims legacy stories (user_id=NULL).
+    Fetch story by ID, verify ownership.
 
     Raises:
         HTTPException 404: Story not found
-        HTTPException 403: User does not own this story
+        HTTPException 403: User does not own this story or story has no owner
     """
     story = await story_repo.get_by_id(story_id)
     if not story:
@@ -143,9 +143,10 @@ async def get_story_for_owner(story_id: str, user_id: str) -> dict:
 
     owner = story.get("user_id")
     if owner is None:
-        # Legacy story with no owner — auto-claim for requesting user
-        await story_repo.update_user_id(story_id, user_id)
-        story["user_id"] = user_id
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This resource is not accessible",
+        )
     elif owner != user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -157,11 +158,11 @@ async def get_story_for_owner(story_id: str, user_id: str) -> dict:
 
 async def get_session_for_owner(session_id: str, user_id: str) -> SessionData:
     """
-    Fetch session by ID, verify ownership. Auto-claims legacy sessions (user_id=NULL).
+    Fetch session by ID, verify ownership.
 
     Raises:
         HTTPException 404: Session not found
-        HTTPException 403: User does not own this session
+        HTTPException 403: User does not own this session or session has no owner
     """
     session = await session_repo.get_session(session_id)
     if not session:
@@ -171,9 +172,10 @@ async def get_session_for_owner(session_id: str, user_id: str) -> SessionData:
         )
 
     if session.user_id is None:
-        # Legacy session with no owner — auto-claim
-        await session_repo.update_user_id(session_id, user_id)
-        session.user_id = user_id
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This resource is not accessible",
+        )
     elif session.user_id != user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/tests/contracts/test_ownership_contract.py
+++ b/backend/tests/contracts/test_ownership_contract.py
@@ -1,0 +1,129 @@
+"""
+Ownership Contract Tests
+
+Ensures that ownerless resources are rejected (403) instead of auto-claimed,
+and that standard ownership checks still work correctly.
+
+Related: #187
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from fastapi import HTTPException
+
+from src.api.deps import get_story_for_owner, get_session_for_owner
+
+
+class TestStoryOwnership:
+    """get_story_for_owner must reject ownerless stories and enforce ownership."""
+
+    @pytest.mark.asyncio
+    async def test_ownerless_story_returns_403(self):
+        """Requesting a story with user_id=None must return 403, not auto-claim."""
+        ownerless_story = {"story_id": "s1", "user_id": None, "title": "test"}
+
+        with patch("src.api.deps.story_repo") as mock_repo:
+            mock_repo.get_by_id = AsyncMock(return_value=ownerless_story)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_story_for_owner("s1", "any_user")
+
+            assert exc_info.value.status_code == 403
+            # Must NOT have called update_user_id (no auto-claim)
+            mock_repo.update_user_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_other_users_story_returns_403(self):
+        """Requesting a story owned by another user must return 403."""
+        other_story = {"story_id": "s2", "user_id": "owner_a", "title": "test"}
+
+        with patch("src.api.deps.story_repo") as mock_repo:
+            mock_repo.get_by_id = AsyncMock(return_value=other_story)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_story_for_owner("s2", "owner_b")
+
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_own_story_succeeds(self):
+        """Requesting your own story must succeed."""
+        my_story = {"story_id": "s3", "user_id": "me", "title": "my story"}
+
+        with patch("src.api.deps.story_repo") as mock_repo:
+            mock_repo.get_by_id = AsyncMock(return_value=my_story)
+
+            result = await get_story_for_owner("s3", "me")
+
+            assert result["story_id"] == "s3"
+            assert result["user_id"] == "me"
+
+    @pytest.mark.asyncio
+    async def test_missing_story_returns_404(self):
+        """Requesting a non-existent story must return 404."""
+        with patch("src.api.deps.story_repo") as mock_repo:
+            mock_repo.get_by_id = AsyncMock(return_value=None)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_story_for_owner("no_such", "me")
+
+            assert exc_info.value.status_code == 404
+
+
+class TestSessionOwnership:
+    """get_session_for_owner must reject ownerless sessions and enforce ownership."""
+
+    @pytest.mark.asyncio
+    async def test_ownerless_session_returns_403(self):
+        """Requesting a session with user_id=None must return 403, not auto-claim."""
+        ownerless_session = MagicMock()
+        ownerless_session.user_id = None
+
+        with patch("src.api.deps.session_repo") as mock_repo:
+            mock_repo.get_session = AsyncMock(return_value=ownerless_session)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_session_for_owner("sess1", "any_user")
+
+            assert exc_info.value.status_code == 403
+            # Must NOT have called update_user_id (no auto-claim)
+            mock_repo.update_user_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_other_users_session_returns_403(self):
+        """Requesting a session owned by another user must return 403."""
+        other_session = MagicMock()
+        other_session.user_id = "owner_a"
+
+        with patch("src.api.deps.session_repo") as mock_repo:
+            mock_repo.get_session = AsyncMock(return_value=other_session)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_session_for_owner("sess2", "owner_b")
+
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_own_session_succeeds(self):
+        """Requesting your own session must succeed."""
+        my_session = MagicMock()
+        my_session.user_id = "me"
+        my_session.session_id = "sess3"
+
+        with patch("src.api.deps.session_repo") as mock_repo:
+            mock_repo.get_session = AsyncMock(return_value=my_session)
+
+            result = await get_session_for_owner("sess3", "me")
+
+            assert result.user_id == "me"
+
+    @pytest.mark.asyncio
+    async def test_missing_session_returns_404(self):
+        """Requesting a non-existent session must return 404."""
+        with patch("src.api.deps.session_repo") as mock_repo:
+            mock_repo.get_session = AsyncMock(return_value=None)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await get_session_for_owner("no_such", "me")
+
+            assert exc_info.value.status_code == 404


### PR DESCRIPTION
## Summary
- Removed auto-claim logic in `get_story_for_owner()` and `get_session_for_owner()` that allowed any authenticated user to take ownership of ownerless (NULL user_id) stories and sessions
- Ownerless resources now return 403 Forbidden instead of being silently claimed
- Added 8 contract tests covering ownerless, other-user, own-resource, and missing-resource scenarios

## Test plan
- [x] `test_ownerless_story_returns_403` — ownerless story rejected with 403
- [x] `test_ownerless_session_returns_403` — ownerless session rejected with 403
- [x] `test_other_users_story_returns_403` — cross-user access blocked
- [x] `test_other_users_session_returns_403` — cross-user session access blocked
- [x] `test_own_story_succeeds` — legitimate owner access works
- [x] `test_own_session_succeeds` — legitimate session access works
- [x] `test_missing_story_returns_404` — nonexistent story returns 404
- [x] `test_missing_session_returns_404` — nonexistent session returns 404

Fixes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)