### PR TITLE
fix(auth): centralize logout to clear all stores on 401 (#194)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, AxiosInstance } from 'axios'
 import type { ErrorResponse } from '@/types/api'
+import { performFullLogout } from '@/utils/logout'
 
 // API base configuration
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1'
@@ -49,21 +50,8 @@ apiClient.interceptors.response.use(
       // Handle different status codes
       switch (error.response.status) {
         case 401:
-          // Token expired or invalid - clear auth state
-          try {
-            const authStorage = localStorage.getItem('auth-storage')
-            if (authStorage) {
-              const parsed = JSON.parse(authStorage)
-              if (parsed.state?.token) {
-                parsed.state.token = null
-                parsed.state.user = null
-                parsed.state.isAuthenticated = false
-                localStorage.setItem('auth-storage', JSON.stringify(parsed))
-              }
-            }
-          } catch {
-            // Ignore
-          }
+          // Token expired or invalid - reset all stores and persisted state
+          performFullLogout()
           break
         case 400:
           // Bad request

--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -6,6 +6,7 @@ import GenerationStatusBar from '@/components/layout/GenerationStatusBar'
 import useGenerationNavigator from '@/hooks/useGenerationNavigator'
 import useAuthStore from '@/store/useAuthStore'
 import { authService } from '@/api/services/authService'
+import { performFullLogout } from '@/utils/logout'
 
 function PageContainer() {
   const location = useLocation()
@@ -20,7 +21,7 @@ function PageContainer() {
     } catch {
       // Ignore logout errors
     }
-    logout()
+    performFullLogout()
     navigate('/')
   }
 

--- a/frontend/src/utils/logout.ts
+++ b/frontend/src/utils/logout.ts
@@ -1,0 +1,23 @@
+/**
+ * Centralized logout — resets all Zustand stores and clears persisted storage.
+ *
+ * Called on explicit logout AND on 401 responses so that in-memory
+ * Zustand state stays in sync with what the server considers valid.
+ */
+
+import useAuthStore from '@/store/useAuthStore'
+import useChildStore from '@/store/useChildStore'
+import useInteractiveStoryStore from '@/store/useInteractiveStoryStore'
+
+export function performFullLogout(): void {
+  // 1. Reset every Zustand store that holds user-scoped data
+  useAuthStore.getState().logout()
+  useChildStore.getState().clearChild()
+  useInteractiveStoryStore.getState().reset()
+
+  // 2. Belt-and-suspenders: remove the persisted storage keys directly
+  //    in case a store's persist middleware doesn't fire synchronously.
+  localStorage.removeItem('auth-storage')
+  localStorage.removeItem('child-storage')
+  sessionStorage.removeItem('interactive-story-session')
+}


### PR DESCRIPTION
## Summary
- Created `frontend/src/utils/logout.ts` with a `performFullLogout()` function that resets auth, child, and interactive story Zustand stores and removes their persisted localStorage/sessionStorage keys
- Updated `PageContainer` logout handler to call `performFullLogout()` instead of only `logout()` from the auth store
- Updated the 401 response interceptor in `frontend/src/api/client.ts` to call `performFullLogout()` instead of directly mutating localStorage, keeping live Zustand state in sync

Fixes #194

## Test plan
- [ ] Log in, select a child profile, start an interactive story, then click logout -- verify child store and interactive story session are cleared
- [ ] Trigger a 401 (e.g. expired token) -- verify all stores reset and the UI reflects logged-out state immediately without a page refresh
- [ ] Verify localStorage keys `auth-storage` and `child-storage` are removed after logout
- [ ] Verify sessionStorage key `interactive-story-session` is removed after logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)