### PR TITLE
fix(ux): show login prompt for guest users instead of 401 errors

### DIFF
--- a/frontend/src/components/common/LoginPrompt/index.tsx
+++ b/frontend/src/components/common/LoginPrompt/index.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+import Button from '@/components/common/Button'
+import Card from '@/components/common/Card'
+
+interface LoginPromptProps {
+  feature: string
+}
+
+function LoginPrompt({ feature }: LoginPromptProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+    >
+      <Card>
+        <div className="text-center py-8">
+          <span className="text-6xl block mb-4">🔒</span>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">
+            Log in to {feature}
+          </h2>
+          <p className="text-gray-500 mb-6 max-w-sm mx-auto">
+            Create a free account to start making amazing stories, explore news, and save your creations!
+          </p>
+          <Link to="/login">
+            <Button size="lg" leftIcon={<span>🚀</span>}>
+              Log In or Sign Up
+            </Button>
+          </Link>
+        </div>
+      </Card>
+    </motion.div>
+  )
+}
+
+export default LoginPrompt

--- a/frontend/src/pages/InteractiveStoryPage/index.tsx
+++ b/frontend/src/pages/InteractiveStoryPage/index.tsx
@@ -14,9 +14,11 @@ import { storyService } from '@/api/services/storyService'
 import useInteractiveStory from '@/hooks/useInteractiveStory'
 import useInteractiveStoryStore from '@/store/useInteractiveStoryStore'
 import useStreamVisualization from '@/hooks/useStreamVisualization'
+import useAuthStore from '@/store/useAuthStore'
 import useChildStore, { DEFAULT_INTERESTS } from '@/store/useChildStore'
 import type { AgeGroup } from '@/types/api'
 import type { AnimationPhase } from '@/types/streaming'
+import LoginPrompt from '@/components/common/LoginPrompt'
 
 type PageState = 'setup' | 'playing' | 'completed'
 
@@ -29,7 +31,16 @@ const AGE_GROUPS: { value: AgeGroup; label: string; emoji: string }[] = [
 function InteractiveStoryPage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
+  const { isAuthenticated } = useAuthStore()
   const { defaultChildId } = useChildStore()
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-lg mx-auto mt-12">
+        <LoginPrompt feature="play interactive stories" />
+      </div>
+    )
+  }
 
   // Local form state
   const [selectedAge, setSelectedAge] = useState<AgeGroup | null>(null)

--- a/frontend/src/pages/NewsPage/index.tsx
+++ b/frontend/src/pages/NewsPage/index.tsx
@@ -6,9 +6,11 @@ import Card from '@/components/common/Card'
 import AgeAwareContent from '@/components/common/AgeAwareContent'
 import { StreamingVisualizer } from '@/components/streaming/StreamingVisualizer'
 import { storyService } from '@/api/services/storyService'
+import useAuthStore from '@/store/useAuthStore'
 import useChildStore from '@/store/useChildStore'
 import type { AgeGroup, NewsCategory, NewsToKidsResponse } from '@/types/api'
 import type { AnimationPhase } from '@/types/streaming'
+import LoginPrompt from '@/components/common/LoginPrompt'
 
 const AGE_GROUPS: { value: AgeGroup; label: string; emoji: string }[] = [
   { value: '3-5', label: '3-5 yrs', emoji: '🧒' },
@@ -28,7 +30,16 @@ const CATEGORIES: { value: NewsCategory; label: string; emoji: string }[] = [
 ]
 
 function NewsPage() {
+  const { isAuthenticated } = useAuthStore()
   const { defaultChildId } = useChildStore()
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-lg mx-auto mt-12">
+        <LoginPrompt feature="explore kids news" />
+      </div>
+    )
+  }
 
   // Mode toggle
   const [mode, setMode] = useState<'quick-read' | 'morning-show'>('quick-read')

--- a/frontend/src/pages/UploadPage/index.tsx
+++ b/frontend/src/pages/UploadPage/index.tsx
@@ -9,10 +9,12 @@ import TiltCard from '@/components/depth/TiltCard'
 import { FloatingElement } from '@/components/depth/ParallaxContainer'
 import { useStreamVisualizationContext } from '@/providers/StreamVisualizationProvider'
 import useStoryStore from '@/store/useStoryStore'
+import useAuthStore from '@/store/useAuthStore'
 import useChildStore, { DEFAULT_INTERESTS } from '@/store/useChildStore'
 import useStoryGeneration from '@/hooks/useStoryGeneration'
 import type { AgeGroup, VoiceType } from '@/types/api'
 import type { AnimationPhase } from '@/types/streaming'
+import LoginPrompt from '@/components/common/LoginPrompt'
 
 const AGE_GROUPS: { value: AgeGroup; label: string; emoji: string; description: string }[] = [
   { value: '3-5', label: '3-5 yrs', emoji: '🧒', description: 'Simple & Fun' },
@@ -40,10 +42,20 @@ function UploadPage() {
     setEnableAudio,
   } = useStoryStore()
 
+  const { isAuthenticated } = useAuthStore()
+
   const { currentChild, setAgeGroup, setInterests, addInterest, removeInterest } =
     useChildStore()
 
   const { prefersReducedMotion } = useStreamVisualizationContext()
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-lg mx-auto mt-12">
+        <LoginPrompt feature="create stories" />
+      </div>
+    )
+  }
 
   const [selectedAgeGroup, setSelectedAgeGroup] = useState<AgeGroup | null>(
     currentChild?.age_group || null


### PR DESCRIPTION
## Summary
- Add reusable `LoginPrompt` component with friendly card UI
- Gate UploadPage, InteractiveStoryPage, and NewsPage behind `isAuthenticated` check
- Guest users see "Log in to [feature]" card with sign-up button instead of raw 401 errors

Fixes #214
Related to Epic #40

## Changes
| File | Change |
|------|--------|
| `frontend/src/components/common/LoginPrompt/index.tsx` | **New** — reusable auth gate card component |
| `frontend/src/pages/UploadPage/index.tsx` | Early return with LoginPrompt when not authenticated |
| `frontend/src/pages/InteractiveStoryPage/index.tsx` | Same pattern |
| `frontend/src/pages/NewsPage/index.tsx` | Same pattern |

## Test plan
- [x] TypeScript — clean
- [ ] Manual: visit /upload as guest — see login prompt
- [ ] Manual: visit /interactive as guest — see login prompt
- [ ] Manual: visit /news as guest — see login prompt
- [ ] Manual: log in — all pages work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)