### PR TITLE
fix(morning-show): scope onboarding localStorage key per child (#200)

### DIFF
--- a/frontend/src/pages/MorningShowSubscriptionsPage/index.tsx
+++ b/frontend/src/pages/MorningShowSubscriptionsPage/index.tsx
@@ -20,7 +20,7 @@ const TOPIC_CARDS: Array<{ topic: NewsCategory; titleZh: string; titleEn: string
 ]
 
 const MAX_SUBSCRIPTIONS = 5
-const ONBOARD_KEY = 'morning_show_onboarding_done'
+const onboardKey = (childId: string) => `morning_show_onboarding_done_${childId}`
 
 function MorningShowSubscriptionsPage() {
   const queryClient = useQueryClient()
@@ -49,7 +49,7 @@ function MorningShowSubscriptionsPage() {
 
   useEffect(() => {
     if (isLoading || !childId) return
-    const onboardingDone = localStorage.getItem(ONBOARD_KEY) === 'true'
+    const onboardingDone = localStorage.getItem(onboardKey(childId)) === 'true'
     if (!onboardingDone && activeCount === 0) {
       setShowOnboarding(true)
       setOnboardingStep(0)
@@ -107,7 +107,7 @@ function MorningShowSubscriptionsPage() {
           await storyService.subscribeTopic({ child_id: childId, topic })
         }
       }
-      localStorage.setItem(ONBOARD_KEY, 'true')
+      localStorage.setItem(onboardKey(childId), 'true')
       setShowOnboarding(false)
       await queryClient.invalidateQueries({ queryKey: ['morning-show-subscriptions', childId] })
       await queryClient.invalidateQueries({ queryKey: ['library'] })


### PR DESCRIPTION
## Summary
- Replaced global `morning_show_onboarding_done` key with `morning_show_onboarding_done_${childId}`
- Each child now has independent onboarding state
- Children with zero subscriptions can see onboarding even if another child completed it

Fixes #200

## Test plan
- [ ] Complete onboarding as child A, switch to child B with no subs — onboarding should appear
- [ ] Child A should not see onboarding again after completing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)