### PR TITLE
feat(news-to-kids): add TTS audio narration

### DIFF
--- a/backend/src/agents/news_to_kids_agent.py
+++ b/backend/src/agents/news_to_kids_agent.py
@@ -29,7 +29,7 @@ except Exception:  # pragma: no cover - import fallback for test env
     ToolUseBlock = object
     ToolResultBlock = object
 
-from ..mcp_servers import safety_server
+from ..mcp_servers import safety_server, tts_server
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +140,16 @@ def _build_questions(category: str) -> List[Dict[str, str]]:
 # SDK mock guard
 # ---------------------------------------------------------------------------
 
+def _get_audio_config(age_group: str) -> dict:
+    """Get audio configuration for age group."""
+    configs = {
+        "3-5": {"audio_mode": "audio_first", "voice": "nova", "speed": 0.9},
+        "6-8": {"audio_mode": "simultaneous", "voice": "shimmer", "speed": 1.0},
+        "9-12": {"audio_mode": "text_first", "voice": "alloy", "speed": 1.1},
+    }
+    return configs.get(age_group, configs["6-8"])
+
+
 def _should_use_mock() -> bool:
     """Return True when running inside pytest or when the SDK is unavailable."""
     return (
@@ -214,11 +224,24 @@ def _normalize_questions(raw: Any, category: str) -> List[Dict[str, str]]:
 # Live LLM generation via Claude Agent SDK
 # ---------------------------------------------------------------------------
 
-async def _convert_news_to_kids_live(source: str, age_group: str, category: str) -> Dict[str, Any]:
+async def _convert_news_to_kids_live(
+    source: str,
+    age_group: str,
+    category: str,
+    enable_audio: bool = True,
+    voice: Optional[str] = None,
+    child_id: str = "",
+) -> Dict[str, Any]:
     """Generate kid-friendly news content using Claude Agent SDK with MCP safety check."""
     rules = AGE_RULES.get(age_group, AGE_RULES["6-8"])
     age_map = {"3-5": 4, "6-8": 7, "9-12": 11}
     target_age = age_map.get(age_group, 7)
+
+    # Audio configuration
+    audio_config = _get_audio_config(age_group)
+    should_generate_audio = enable_audio and audio_config["audio_mode"] in ["audio_first", "simultaneous"]
+    actual_voice = voice or audio_config["voice"]
+    audio_speed = audio_config["speed"]
 
     prompt = (
         "Rewrite the following news text for children.\n"
@@ -244,14 +267,32 @@ async def _convert_news_to_kids_live(source: str, age_group: str, category: str)
         "Include the safety_score in your output.\n"
     )
 
+    # Add TTS instruction if audio should be generated
+    if should_generate_audio:
+        prompt += (
+            f"\n**语音生成**：\n"
+            f"内容转换完成后，请使用 `mcp__tts-generation__generate_story_audio` 工具为 kid_content 生成语音。\n"
+            f"- 语音类型: {actual_voice}\n"
+            f"- 语速: {audio_speed}\n"
+            f"- 儿童ID: {child_id}\n"
+        )
+
+    # Build MCP servers and allowed tools lists
+    mcp_servers: Dict[str, Any] = {
+        "safety-check": safety_server,
+    }
+    allowed_tools = [
+        "mcp__safety-check__check_content_safety",
+        "mcp__safety-check__suggest_content_improvements",
+    ]
+
+    if should_generate_audio:
+        mcp_servers["tts-generation"] = tts_server
+        allowed_tools.append("mcp__tts-generation__generate_story_audio")
+
     options = ClaudeAgentOptions(
-        mcp_servers={
-            "safety-check": safety_server,
-        },
-        allowed_tools=[
-            "mcp__safety-check__check_content_safety",
-            "mcp__safety-check__suggest_content_improvements",
-        ],
+        mcp_servers=mcp_servers,
+        allowed_tools=allowed_tools,
         cwd=".",
         permission_mode="acceptEdits",
         max_turns=8,
@@ -262,11 +303,27 @@ async def _convert_news_to_kids_live(source: str, age_group: str, category: str)
     )
 
     result_data: Dict[str, Any] = {}
+    audio_path = None
 
     async with ClaudeSDKClient(options=options) as client:
         await client.query(prompt)
 
         async for message in client.receive_response():
+            # Check for TTS tool results in assistant messages
+            if isinstance(message, AssistantMessage):
+                content = getattr(message, "content", None)
+                if isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, ToolResultBlock):
+                            result_content = getattr(block, "content", None)
+                            if result_content and isinstance(result_content, str):
+                                try:
+                                    result_json = json.loads(result_content)
+                                    if "audio_path" in result_json:
+                                        audio_path = result_json["audio_path"]
+                                except (json.JSONDecodeError, TypeError):
+                                    pass
+
             if isinstance(message, ResultMessage):
                 if hasattr(message, "structured_output") and message.structured_output:
                     result_data = message.structured_output
@@ -303,7 +360,7 @@ async def _convert_news_to_kids_live(source: str, age_group: str, category: str)
         "why_care": why_care,
         "key_concepts": key_concepts,
         "interactive_questions": questions,
-        "audio_path": None,
+        "audio_path": audio_path,
         "safety_score": safety_score,
     }
 
@@ -322,15 +379,15 @@ async def convert_news_to_kids(
     enable_audio: bool = True,
     voice: Optional[str] = None,
 ) -> Dict[str, Any]:
-    del child_id, enable_audio, voice
-
     source = _normalize(news_text)
     if not source and news_url:
         source = f"Article source: {news_url}."
 
     if not _should_use_mock():
         try:
-            return await _convert_news_to_kids_live(source, age_group, category)
+            return await _convert_news_to_kids_live(
+                source, age_group, category, enable_audio, voice, child_id
+            )
         except Exception:
             pass
 

--- a/backend/tests/contracts/test_news_tts_contract.py
+++ b/backend/tests/contracts/test_news_tts_contract.py
@@ -1,0 +1,101 @@
+"""Contract tests for News-to-Kids TTS audio narration (issue #155).
+
+Verifies:
+- _get_audio_config returns correct config per age group
+- convert_news_to_kids accepts enable_audio/voice params
+- enable_audio=False returns audio_path: None
+- enable_audio=True in mock env returns result (audio_path may be None)
+"""
+
+import pytest
+
+from backend.src.agents.news_to_kids_agent import (
+    _get_audio_config,
+    convert_news_to_kids,
+)
+
+
+class TestGetAudioConfig:
+    """Contract: _get_audio_config returns age-appropriate TTS settings."""
+
+    def test_age_3_5_returns_audio_first_nova(self):
+        config = _get_audio_config("3-5")
+        assert config["audio_mode"] == "audio_first"
+        assert config["voice"] == "nova"
+        assert config["speed"] == 0.9
+
+    def test_age_6_8_returns_simultaneous_shimmer(self):
+        config = _get_audio_config("6-8")
+        assert config["audio_mode"] == "simultaneous"
+        assert config["voice"] == "shimmer"
+        assert config["speed"] == 1.0
+
+    def test_age_9_12_returns_text_first_alloy(self):
+        config = _get_audio_config("9-12")
+        assert config["audio_mode"] == "text_first"
+        assert config["voice"] == "alloy"
+        assert config["speed"] == 1.1
+
+    def test_unknown_age_falls_back_to_6_8(self):
+        config = _get_audio_config("unknown")
+        assert config == _get_audio_config("6-8")
+
+
+class TestConvertNewsToKidsAudioParams:
+    """Contract: convert_news_to_kids accepts and handles audio parameters."""
+
+    @pytest.mark.asyncio
+    async def test_audio_disabled_returns_none_audio_path(self):
+        result = await convert_news_to_kids(
+            news_text="Scientists discovered a new species of butterfly in the Amazon rainforest.",
+            age_group="6-8",
+            child_id="test-child-1",
+            category="science",
+            enable_audio=False,
+            voice=None,
+        )
+        assert "audio_path" in result
+        assert result["audio_path"] is None
+
+    @pytest.mark.asyncio
+    async def test_audio_enabled_returns_result_with_audio_path_key(self):
+        result = await convert_news_to_kids(
+            news_text="A new park opened in the city center with a big playground.",
+            age_group="3-5",
+            child_id="test-child-2",
+            category="community",
+            enable_audio=True,
+            voice="nova",
+        )
+        assert "audio_path" in result
+        # In mock/test env, audio_path will be None (no real TTS call)
+        assert result["audio_path"] is None
+
+    @pytest.mark.asyncio
+    async def test_result_still_contains_required_fields(self):
+        result = await convert_news_to_kids(
+            news_text="The school robotics team won the national competition.",
+            age_group="9-12",
+            child_id="test-child-3",
+            category="education",
+            enable_audio=True,
+        )
+        assert "kid_title" in result
+        assert "kid_content" in result
+        assert "why_care" in result
+        assert "key_concepts" in result
+        assert "interactive_questions" in result
+        assert "audio_path" in result
+
+    @pytest.mark.asyncio
+    async def test_signature_accepts_voice_param(self):
+        """Ensure the function signature accepts voice without TypeError."""
+        result = await convert_news_to_kids(
+            news_text="Weather forecast shows sunny skies all week.",
+            age_group="6-8",
+            child_id="test-child-4",
+            category="weather",
+            enable_audio=True,
+            voice="shimmer",
+        )
+        assert isinstance(result, dict)


### PR DESCRIPTION
## Summary
- Wire `enable_audio` and `voice` params through to the Claude Agent SDK call (previously deleted at line 325)
- Add `_get_audio_config()` for age-appropriate voice/speed selection (matches image-to-story pattern)
- Conditionally inject TTS prompt instructions and register `tts-generation` MCP server
- Extract `audio_path` from `ToolResultBlock` (same pattern as `image_to_story_agent.py`)
- Add 8 contract tests for audio config and parameter handling

The route layer and frontend already handle `audio_url` correctly — this PR fixes the agent layer gap.

**Parent Epic**: #44
Fixes #155

## Test plan
- [x] 8 new contract tests pass (`tests/contracts/test_news_tts_contract.py`)
- [x] Full test suite: 455 passed, 0 new failures (11 pre-existing on main)
- [ ] Manual: convert news with `enable_audio=true` and verify `audio_url` is returned
- [ ] Manual: verify audio player renders in NewsPage frontend
- [ ] Manual: test with different age groups (3-5, 6-8, 9-12) for correct voice selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)