### PR TITLE
Fix Morning Show illustration cost leak

### DIFF
--- a/backend/src/api/routes/morning_show.py
+++ b/backend/src/api/routes/morning_show.py
@@ -53,11 +53,8 @@ router = APIRouter(
 
 
 def _illustration_count(age_group: str) -> int:
-    if age_group == "3-5":
-        return 2
-    if age_group == "6-8":
-        return 3
-    return 4
+    """One illustration per episode to control API costs when live generation is on."""
+    return 1
 
 
 def _make_placeholder_svg(title: str, subtitle: str, width: int = 1280, height: int = 720) -> str:
@@ -79,13 +76,17 @@ def _make_placeholder_svg(title: str, subtitle: str, width: int = 1280, height: 
 
 
 def _is_live_illustration_enabled() -> bool:
+    """Live image generation is OFF by default to avoid per-request API costs.
+
+    Set ``MORNING_SHOW_LIVE_ILLUSTRATIONS=1`` to opt in.
+    """
     if os.getenv("PYTEST_CURRENT_TEST") is not None:
+        return False
+    opt_in = os.getenv("MORNING_SHOW_LIVE_ILLUSTRATIONS", "").strip().lower()
+    if opt_in not in {"1", "true", "yes"}:
         return False
     api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
     if not api_key or api_key.startswith("your_"):
-        return False
-    force_placeholder = os.getenv("MORNING_SHOW_FORCE_PLACEHOLDER_ILLUSTRATIONS", "").strip().lower()
-    if force_placeholder in {"1", "true", "yes"}:
         return False
     return True
 
@@ -162,7 +163,7 @@ async def _generate_illustrations(
     openai_client = None
     if live_enabled and OpenAI is not None:
         openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
-    image_model = os.getenv("MORNING_SHOW_IMAGE_MODEL", "gpt-image-1")
+    image_model = os.getenv("MORNING_SHOW_IMAGE_MODEL", "gpt-image-1-mini")
     api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
 
     illustrations: List[EpisodeIllustration] = []

--- a/backend/tests/integration/test_model_providers.py
+++ b/backend/tests/integration/test_model_providers.py
@@ -206,7 +206,7 @@ class TestTTSProvider:
 
 
 # ===========================================================================
-# 4. Image Generation Provider (OpenAI gpt-image-1)
+# 4. Image Generation Provider (OpenAI gpt-image-1-mini)
 # ===========================================================================
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
- Default live image generation to OFF (opt-in via `MORNING_SHOW_LIVE_ILLUSTRATIONS=1`) — previously auto-enabled whenever `OPENAI_API_KEY` existed
- Reduce illustration count from 2-4 per episode to 1
- Switch default image model from `gpt-image-1` to cheaper `gpt-image-1-mini`

**Parent Epic**: #44

## Test plan
- [x] All 74 morning show contract + safety tests pass
- [ ] Verify no illustrations generated without `MORNING_SHOW_LIVE_ILLUSTRATIONS=1`
- [ ] Verify live generation works when opted in

🤖 Generated with [Claude Code](https://claude.com/claude-code)