### PR TITLE
chore(mcp): surface import failures in logs and health endpoint

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -553,7 +553,7 @@ class HealthCheckResponse(BaseModel):
         default_factory=datetime.now,
         description="检查时间"
     )
-    services: Dict[str, str] = Field(
+    services: Dict[str, Any] = Field(
         default_factory=dict,
         description="依赖服务状态"
     )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -56,6 +56,15 @@ async def lifespan(app: FastAPI):
     if scheduler_enabled and os.getenv("ENVIRONMENT") != "test":
         await daily_drop_scheduler.start()
 
+    # MCP server diagnostics
+    from .mcp_servers import MCP_SERVER_STATUS
+    print("🔌 MCP Servers:")
+    for server, status in MCP_SERVER_STATUS.items():
+        icon = "✅" if status == "ok" else "❌"
+        short_status = "OK" if status == "ok" else status
+        print(f"  {icon} {server}: {short_status}")
+
+
     yield
 
     # On shutdown
@@ -205,17 +214,27 @@ async def health_check():
     else:
         scheduler_status = "stopped"
 
+    # MCP server import status
+    from .mcp_servers import MCP_SERVER_STATUS
+
+    mcp_all_ok = all(v == "ok" for v in MCP_SERVER_STATUS.values())
+
     services_status = {
         "api": "running",
         "database": "running" if db_connected else "degraded",
         "session_manager": "running" if db_connected else "degraded",
         "environment": "configured" if env_vars_set else "missing_keys",
-        "daily_drop_scheduler": scheduler_status
+        "daily_drop_scheduler": scheduler_status,
+        "mcp_servers": dict(MCP_SERVER_STATUS),
     }
 
-    overall_status = "healthy" if all(
-        s in ["running", "configured"] for s in services_status.values()
-    ) else "degraded"
+    # Determine overall health — ignore nested mcp_servers dict in top-level check
+    top_level_ok = all(
+        s in ["running", "configured"]
+        for k, s in services_status.items()
+        if isinstance(s, str)
+    )
+    overall_status = "healthy" if (top_level_ok and mcp_all_ok) else "degraded"
 
     return HealthCheckResponse(
         status=overall_status,

--- a/backend/src/mcp_servers/__init__.py
+++ b/backend/src/mcp_servers/__init__.py
@@ -1,58 +1,101 @@
 """MCP server exports with dependency-safe fallbacks."""
 
+import json
+import logging
 from typing import Any, Dict
 
+logger = logging.getLogger(__name__)
 
-async def _unavailable_tool(_args: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        "content": [{
-            "type": "text",
-            "text": "{\"error\": \"MCP server dependency unavailable\"}",
-        }]
-    }
+# Track which MCP servers loaded successfully vs failed.
+# Keys: server module name, Values: "ok" or "error: <exception details>"
+MCP_SERVER_STATUS: Dict[str, str] = {}
 
 
+def _get_unavailable_msg(server_name: str) -> str:
+    """Return a descriptive error message for a missing MCP server."""
+    err_detail = MCP_SERVER_STATUS.get(server_name, "unknown error")
+    return json.dumps({
+        "error": "MCP server dependency unavailable",
+        "server": server_name,
+        "details": err_detail,
+        "instruction": "Check server logs/diagnostics and ensure required dependencies are installed."
+    })
+
+
+def create_unavailable_tool(server_name: str):
+    """Factory to create a tool stub that reports why it's missing."""
+    async def _unavailable_stub(_args: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "content": [{
+                "type": "text",
+                "text": _get_unavailable_msg(server_name),
+            }]
+        }
+    return _unavailable_stub
+
+
+# Default stubs
 vision_server = {}
-analyze_children_drawing = _unavailable_tool
-vector_server = {}
-search_similar_drawings = _unavailable_tool
-store_drawing_embedding = _unavailable_tool
-store_story_embedding = _unavailable_tool
-search_similar_stories = _unavailable_tool
-safety_server = {}
-check_content_safety = _unavailable_tool
-suggest_content_improvements = _unavailable_tool
-tts_server = {}
-generate_story_audio = _unavailable_tool
-list_available_voices = _unavailable_tool
-generate_audio_batch = _unavailable_tool
-video_server = {}
-generate_painting_video = _unavailable_tool
-check_video_status = _unavailable_tool
-combine_video_audio = _unavailable_tool
-web_search_server = {}
-get_headlines_by_topic = _unavailable_tool
-fetch_article_text = _unavailable_tool
+analyze_children_drawing = create_unavailable_tool("vision_analysis_server")
 
+vector_server = {}
+search_similar_drawings = create_unavailable_tool("vector_search_server")
+store_drawing_embedding = create_unavailable_tool("vector_search_server")
+store_story_embedding = create_unavailable_tool("vector_search_server")
+search_similar_stories = create_unavailable_tool("vector_search_server")
+
+safety_server = {}
+check_content_safety = create_unavailable_tool("safety_check_server")
+suggest_content_improvements = create_unavailable_tool("safety_check_server")
+
+tts_server = {}
+generate_story_audio = create_unavailable_tool("tts_generator_server")
+list_available_voices = create_unavailable_tool("tts_generator_server")
+generate_audio_batch = create_unavailable_tool("tts_generator_server")
+
+video_server = {}
+generate_painting_video = create_unavailable_tool("video_generator_server")
+check_video_status = create_unavailable_tool("video_generator_server")
+combine_video_audio = create_unavailable_tool("video_generator_server")
+
+web_search_server = {}
+get_headlines_by_topic = create_unavailable_tool("web_search_server")
+fetch_article_text = create_unavailable_tool("web_search_server")
+
+# Import attempts
 try:
     from .vision_analysis_server import vision_server, analyze_children_drawing
-except Exception:
-    pass
+    MCP_SERVER_STATUS["vision_analysis_server"] = "ok"
+except Exception as exc:
+    MCP_SERVER_STATUS["vision_analysis_server"] = f"error: {exc}"
+    logger.error("❌ Failed to import MCP server 'vision_analysis_server': %s", exc, exc_info=True)
 
 try:
-    from .vector_search_server import vector_server, search_similar_drawings, store_drawing_embedding, store_story_embedding, search_similar_stories
-except Exception:
-    pass
+    from .vector_search_server import (
+        vector_server,
+        search_similar_drawings,
+        store_drawing_embedding,
+        store_story_embedding,
+        search_similar_stories
+    )
+    MCP_SERVER_STATUS["vector_search_server"] = "ok"
+except Exception as exc:
+    MCP_SERVER_STATUS["vector_search_server"] = f"error: {exc}"
+    logger.error("❌ Failed to import MCP server 'vector_search_server': %s", exc, exc_info=True)
 
 try:
     from .safety_check_server import safety_server, check_content_safety, suggest_content_improvements
-except Exception:
-    pass
+    MCP_SERVER_STATUS["safety_check_server"] = "ok"
+except Exception as exc:
+    MCP_SERVER_STATUS["safety_check_server"] = f"error: {exc}"
+    logger.error("❌ Failed to import MCP server 'safety_check_server': %s", exc, exc_info=True)
 
 try:
     from .tts_generator_server import tts_server, generate_story_audio, list_available_voices, generate_audio_batch
-except Exception:
-    pass
+    MCP_SERVER_STATUS["tts_generator_server"] = "ok"
+except Exception as exc:
+    MCP_SERVER_STATUS["tts_generator_server"] = f"error: {exc}"
+    logger.error("❌ Failed to import MCP server 'tts_generator_server': %s", exc, exc_info=True)
 
 try:
     from .video_generator_server import (
@@ -61,8 +104,10 @@ try:
         check_video_status,
         combine_video_audio,
     )
-except Exception:
-    pass
+    MCP_SERVER_STATUS["video_generator_server"] = "ok"
+except Exception as exc:
+    MCP_SERVER_STATUS["video_generator_server"] = f"error: {exc}"
+    logger.error("❌ Failed to import MCP server 'video_generator_server': %s", exc, exc_info=True)
 
 try:
     from .web_search_server import (
@@ -70,11 +115,14 @@ try:
         get_headlines_by_topic,
         fetch_article_text,
     )
-except Exception:
-    pass
+    MCP_SERVER_STATUS["web_search_server"] = "ok"
+except Exception as exc:
+    MCP_SERVER_STATUS["web_search_server"] = f"error: {exc}"
+    logger.error("❌ Failed to import MCP server 'web_search_server': %s", exc, exc_info=True)
 
 
 __all__ = [
+    "MCP_SERVER_STATUS",
     "vision_server",
     "analyze_children_drawing",
     "vector_server",

--- a/backend/tests/api/test_health.py
+++ b/backend/tests/api/test_health.py
@@ -61,10 +61,16 @@ class TestHealthCheck:
             assert result["status"] in ["healthy", "degraded", "unhealthy"]
 
             services = result["services"]
-            valid_statuses = ["running", "degraded", "configured", "missing_keys"]
+            valid_statuses = ["running", "degraded", "configured", "missing_keys",
+                              "disabled", "stopped"]
 
             for service, status in services.items():
-                assert status in valid_statuses
+                if isinstance(status, dict):
+                    # Nested status (e.g. mcp_servers) — each value is "ok" or "error: ..."
+                    for sub_key, sub_val in status.items():
+                        assert isinstance(sub_val, str), f"{service}.{sub_key} must be str"
+                else:
+                    assert status in valid_statuses
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_mcp_import_diagnostics.py
+++ b/backend/tests/api/test_mcp_import_diagnostics.py
@@ -1,0 +1,133 @@
+"""
+Tests for MCP import failure diagnostics (#183)
+
+Verify that:
+1. Import failures are logged with module name and exception
+2. MCP_SERVER_STATUS tracks loaded vs failed servers
+3. Health endpoint reports MCP server availability
+"""
+
+import importlib
+import logging
+import types
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+
+class TestMCPImportLogging:
+    """Import failures must be logged at WARNING with module + exception."""
+
+    def test_successful_import_tracked(self):
+        """Successfully imported MCP servers appear as 'ok' in status dict."""
+        # Re-import to get fresh status
+        import backend.src.mcp_servers as pkg
+
+        importlib.reload(pkg)
+
+        # At minimum, the status dict should exist and have entries
+        assert hasattr(pkg, "MCP_SERVER_STATUS")
+        assert isinstance(pkg.MCP_SERVER_STATUS, dict)
+        # All six servers must be tracked
+        expected_servers = {
+            "vision_analysis_server",
+            "vector_search_server",
+            "safety_check_server",
+            "tts_generator_server",
+            "video_generator_server",
+            "web_search_server",
+        }
+        assert expected_servers == set(pkg.MCP_SERVER_STATUS.keys())
+
+    def test_failed_import_logged_with_module_and_exception(self, caplog):
+        """When an MCP server import fails, WARNING log includes module name and exception."""
+        # Sabotage one import by making it raise
+        bad_module = types.ModuleType("backend.src.mcp_servers.vision_analysis_server")
+        bad_module.__spec__ = None  # force ImportError on reload
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"backend.src.mcp_servers.vision_analysis_server": None},
+            ),
+            caplog.at_level(logging.WARNING, logger="backend.src.mcp_servers"),
+        ):
+            import backend.src.mcp_servers as pkg
+
+            importlib.reload(pkg)
+
+        # Should have logged at WARNING or ERROR mentioning the module name
+        relevant_messages = [
+            r.message for r in caplog.records
+            if r.levelno >= logging.WARNING
+        ]
+        assert any("vision_analysis_server" in m for m in relevant_messages), (
+            f"Expected log mentioning 'vision_analysis_server', got: {relevant_messages}"
+        )
+
+    def test_failed_import_status_is_error(self):
+        """Failed imports are recorded as 'error: ...' in MCP_SERVER_STATUS."""
+        with patch.dict(
+            "sys.modules",
+            {"backend.src.mcp_servers.vision_analysis_server": None},
+        ):
+            import backend.src.mcp_servers as pkg
+
+            importlib.reload(pkg)
+
+        assert pkg.MCP_SERVER_STATUS["vision_analysis_server"].startswith("error:")
+
+
+@pytest.mark.asyncio
+class TestHealthEndpointMCPStatus:
+    """Health endpoint must include mcp_servers in services."""
+
+    async def test_health_includes_mcp_servers(self):
+        """GET /health response includes mcp_servers key."""
+        from backend.src.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health")
+
+        assert response.status_code == 200
+        result = response.json()
+        services = result["services"]
+        assert "mcp_servers" in services
+
+    async def test_health_mcp_servers_shows_individual_status(self):
+        """mcp_servers value is a dict with per-server status."""
+        from backend.src.main import app
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/health")
+
+        result = response.json()
+        mcp_status = result["services"]["mcp_servers"]
+        assert isinstance(mcp_status, dict)
+        assert "vision_analysis_server" in mcp_status
+        assert "safety_check_server" in mcp_status
+
+    async def test_health_degraded_when_mcp_server_fails(self):
+        """Overall status should be degraded if any MCP server failed to load."""
+        import backend.src.mcp_servers as pkg
+
+        original_status = dict(pkg.MCP_SERVER_STATUS)
+        try:
+            pkg.MCP_SERVER_STATUS["vision_analysis_server"] = "error: ModuleNotFoundError"
+
+            from backend.src.main import app
+
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get("/health")
+
+            result = response.json()
+            assert result["status"] == "degraded"
+        finally:
+            pkg.MCP_SERVER_STATUS.update(original_status)


### PR DESCRIPTION
## Summary
- Log MCP server import failures at ERROR level with module name and traceback
- Track per-server status in `MCP_SERVER_STATUS` dict
- Expose degraded MCP availability in `/health` endpoint and startup diagnostics
- Return descriptive error messages from unavailable tool stubs

Fixes #183

## Changes
- `backend/src/mcp_servers/__init__.py`: Logging, status tracking, descriptive stubs
- `backend/src/main.py`: Startup print + health endpoint integration
- `backend/src/api/models.py`: `services` type widened to `Dict[str, Any]`
- `backend/tests/api/test_mcp_import_diagnostics.py`: 6 new tests
- `backend/tests/api/test_health.py`: Updated for nested dict values

## Test plan
- [ ] Run `pytest tests/api/test_mcp_import_diagnostics.py -v`
- [ ] Run `pytest tests/api/test_health.py -v`
- [ ] Start server and verify MCP status prints at startup
- [ ] Hit `/health` and verify `mcp_servers` key in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)