### PR TITLE
feat(auth): add parent role with Growth Timeline visibility

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -67,6 +67,7 @@ async def get_current_user(authorization: Optional[str] = Header(None)) -> UserD
                 avatar_url=None,
                 is_active=True,
                 is_verified=True,
+                role="child",
                 created_at="",
                 updated_at="",
                 last_login_at=None,

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -685,6 +685,7 @@ class UserResponse(BaseModel):
     avatar_url: Optional[str] = Field(None, description="头像URL")
     is_active: bool = Field(..., description="是否激活")
     is_verified: bool = Field(..., description="是否已验证")
+    role: str = Field(default="child", description="User role: 'child' or 'parent'")
     created_at: datetime = Field(..., description="注册时间")
     last_login_at: Optional[datetime] = Field(None, description="最后登录时间")
 

--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -51,6 +51,7 @@ def _user_to_response(user: UserData) -> UserResponse:
         avatar_url=user.avatar_url,
         is_active=user.is_active,
         is_verified=user.is_verified,
+        role=user.role,
         created_at=datetime.fromisoformat(user.created_at),
         last_login_at=datetime.fromisoformat(user.last_login_at) if user.last_login_at else None
     )
@@ -272,6 +273,7 @@ async def get_me_stats(user: UserData = Depends(get_current_user)):
         avatar_url=user_with_stats.avatar_url,
         is_active=user_with_stats.is_active,
         is_verified=user_with_stats.is_verified,
+        role=user_with_stats.role,
         created_at=datetime.fromisoformat(user_with_stats.created_at),
         last_login_at=datetime.fromisoformat(user_with_stats.last_login_at) if user_with_stats.last_login_at else None,
         story_count=user_with_stats.story_count,

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -119,6 +119,7 @@ CREATE TABLE IF NOT EXISTS users (
     avatar_url TEXT,
     is_active INTEGER DEFAULT 1,
     is_verified INTEGER DEFAULT 0,
+    role TEXT DEFAULT 'child',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     last_login_at TEXT
@@ -284,6 +285,7 @@ async def init_schema(db: "DatabaseManager") -> None:
     # Run migrations FIRST to add user_id columns if they don't exist
     await _migrate_add_user_id(db)
     await _migrate_add_story_type(db)
+    await _migrate_add_user_role(db)
     await _migrate_backfill_word_counts(db)
 
     # Now create all indexes (including user_id indexes) after migration
@@ -351,6 +353,16 @@ async def _migrate_add_story_type(db: "DatabaseManager") -> None:
 
     if 'story_type' not in stories_columns:
         await db.execute("ALTER TABLE stories ADD COLUMN story_type TEXT DEFAULT 'image_to_story'")
+        await db.commit()
+
+
+async def _migrate_add_user_role(db: "DatabaseManager") -> None:
+    """Migration: Add role column to users table (#232)."""
+    users_info = await db.fetchall("PRAGMA table_info(users)")
+    users_columns = [col['name'] for col in users_info]
+
+    if 'role' not in users_columns:
+        await db.execute("ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'child'")
         await db.commit()
 
 

--- a/backend/src/services/database/user_repository.py
+++ b/backend/src/services/database/user_repository.py
@@ -23,6 +23,7 @@ class UserData:
     avatar_url: Optional[str] = None
     is_active: bool = True
     is_verified: bool = False
+    role: str = "child"
     created_at: str = ""
     updated_at: str = ""
     last_login_at: Optional[str] = None
@@ -46,7 +47,8 @@ class UserRepository:
         username: str,
         email: str,
         password_hash: str,
-        display_name: Optional[str] = None
+        display_name: Optional[str] = None,
+        role: str = "child",
     ) -> UserData:
         """
         Create a new user.
@@ -67,8 +69,8 @@ class UserRepository:
             """
             INSERT INTO users (
                 user_id, username, email, password_hash, display_name,
-                is_active, is_verified, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                is_active, is_verified, role, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 user_id,
@@ -78,6 +80,7 @@ class UserRepository:
                 display_name or username,
                 1,
                 0,
+                role,
                 now,
                 now
             )
@@ -92,6 +95,7 @@ class UserRepository:
             display_name=display_name or username,
             is_active=True,
             is_verified=False,
+            role=role,
             created_at=now,
             updated_at=now,
             last_login_at=None
@@ -447,6 +451,7 @@ class UserRepository:
             avatar_url=row.get('avatar_url'),
             is_active=bool(row.get('is_active', 1)),
             is_verified=bool(row.get('is_verified', 0)),
+            role=row.get('role', 'child'),
             created_at=row['created_at'],
             updated_at=row['updated_at'],
             last_login_at=row.get('last_login_at')

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -14,7 +14,7 @@ from httpx import AsyncClient, ASGITransport
 
 from backend.src.main import app
 from backend.src.api.deps import get_current_user
-from backend.src.services.user_service import UserData
+from backend.src.services.database.user_repository import UserData
 from backend.src.services.database import db_manager
 from backend.src.services.database.schema import init_schema
 

--- a/backend/tests/api/test_parent_role.py
+++ b/backend/tests/api/test_parent_role.py
@@ -1,0 +1,124 @@
+"""
+Tests for parent role feature (#232).
+
+Verifies:
+1. UserResponse includes `role` field
+2. Authenticated /me endpoint returns role
+3. Parent role is NOT exposed on public profile
+4. Role defaults to 'child' for existing users
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from backend.src.services.database.user_repository import UserData
+
+
+# A parent user
+_PARENT_USER = UserData(
+    user_id="parent_user_1",
+    username="parent_jane",
+    email="jane@example.com",
+    password_hash="hashed_pw",
+    display_name="Jane (Parent)",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    role="parent",
+    created_at="2025-06-01T00:00:00",
+    updated_at="2025-06-01T00:00:00",
+    last_login_at="2025-06-15T12:00:00",
+)
+
+# A child user (default role)
+_CHILD_USER = UserData(
+    user_id="child_user_1",
+    username="kid_sam",
+    email="sam@example.com",
+    password_hash="hashed_pw",
+    display_name="Sam",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    role="child",
+    created_at="2025-06-01T00:00:00",
+    updated_at="2025-06-01T00:00:00",
+    last_login_at=None,
+)
+
+
+@pytest.mark.asyncio
+async def test_me_endpoint_returns_role_for_parent(test_client):
+    """GET /api/v1/users/me must include role='parent' for parent users."""
+    from backend.src.main import app
+    from backend.src.api.deps import get_current_user
+
+    async def _override():
+        return _PARENT_USER
+
+    app.dependency_overrides[get_current_user] = _override
+    try:
+        resp = await test_client.get(
+            "/api/v1/users/me",
+            headers={"Authorization": "Bearer fake_token"},
+        )
+    finally:
+        from backend.tests.api.conftest import _fake_get_current_user
+        app.dependency_overrides[get_current_user] = _fake_get_current_user
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "role" in data, "UserResponse must include 'role' field"
+    assert data["role"] == "parent"
+
+
+@pytest.mark.asyncio
+async def test_me_endpoint_returns_role_child_by_default(test_client):
+    """GET /api/v1/users/me must include role='child' for child users."""
+    from backend.src.main import app
+    from backend.src.api.deps import get_current_user
+
+    async def _override():
+        return _CHILD_USER
+
+    app.dependency_overrides[get_current_user] = _override
+    try:
+        resp = await test_client.get(
+            "/api/v1/users/me",
+            headers={"Authorization": "Bearer fake_token"},
+        )
+    finally:
+        from backend.tests.api.conftest import _fake_get_current_user
+        app.dependency_overrides[get_current_user] = _fake_get_current_user
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["role"] == "child"
+
+
+@pytest.mark.asyncio
+async def test_public_profile_does_not_expose_role(test_client):
+    """GET /api/v1/users/{user_id} must NOT expose role field."""
+    with patch(
+        "backend.src.services.database.user_repo",
+    ) as mock_repo:
+        mock_repo.get_by_id = AsyncMock(return_value=_PARENT_USER)
+        resp = await test_client.get(f"/api/v1/users/{_PARENT_USER.user_id}")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "role" not in data, "Public profile must NOT expose 'role' field"
+
+
+@pytest.mark.asyncio
+async def test_role_defaults_to_child():
+    """UserData without explicit role should default to 'child'."""
+    user = UserData(
+        user_id="u1",
+        username="test",
+        email="t@t.com",
+        password_hash="h",
+        created_at="",
+        updated_at="",
+    )
+    assert user.role == "child"

--- a/frontend/src/pages/LibraryPage/index.tsx
+++ b/frontend/src/pages/LibraryPage/index.tsx
@@ -612,10 +612,12 @@ function LibraryPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { storyHistory, clearHistory, setCurrentStory, removeStory } = useStoryStore()
-  const { isAuthenticated } = useAuthStore()
+  const { isAuthenticated, user } = useAuthStore()
   const { currentChild } = useChildStore()
   const { viewMode, toggleViewMode } = useLibraryPreferences()
   const ageLayout = getAgeLayoutConfig(currentChild?.age_group)
+  const isParent = user?.role === 'parent'
+  const canShowGrowthTimeline = ageLayout.showGrowthTimeline || isParent
 
   const [activeTab, setActiveTab] = useState<ContentTab>('all')
   const [sortOrder, setSortOrder] = useState<LibrarySortOrder>('newest')
@@ -773,8 +775,8 @@ function LibraryPage() {
           My Library
         </h1>
         <div className="flex items-center gap-2">
-          {/* Growth Timeline toggle — only for 9-12 age group (#134) */}
-          {ageLayout.showGrowthTimeline && isAuthenticated && (
+          {/* Growth Timeline toggle — 9-12 age group or parent role (#134, #232) */}
+          {canShowGrowthTimeline && isAuthenticated && (
             <motion.button
               onClick={() => setShowGrowthView((v) => !v)}
               className={`p-2 rounded-lg transition-colors ${showGrowthView
@@ -869,8 +871,8 @@ function LibraryPage() {
         </select>
       </motion.div>
 
-      {/* Growth Timeline view (#134) — replaces content area when active */}
-      {showGrowthView && ageLayout.showGrowthTimeline && isAuthenticated ? (
+      {/* Growth Timeline view (#134, #232) — replaces content area when active */}
+      {showGrowthView && canShowGrowthTimeline && isAuthenticated ? (
         <GrowthTimeline />
       ) : (
         <>

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -25,6 +25,7 @@ export interface User {
   avatar_url: string | null
   is_active: boolean
   is_verified: boolean
+  role: 'child' | 'parent'
   created_at: string
   last_login_at: string | null
 }


### PR DESCRIPTION
## Summary

Fixes #232

**Parent Epic**: #49 (My Library)

- Add `role` field (`'child'` | `'parent'`) to the user model across all layers (DB schema, repository, API model, frontend type)
- Parents see the Growth Timeline toggle on the Library page regardless of the child's age group (3-5, 6-8, 9-12)
- Non-parent users in 3-5 and 6-8 age groups still do NOT see the timeline
- Role is NOT exposed on the public profile endpoint (privacy)
- Includes safe SQLite migration for existing databases (defaults to `'child'`)

## Changes

| File | What changed |
|------|-------------|
| `backend/src/services/database/schema.py` | Add `role` column + migration |
| `backend/src/services/database/user_repository.py` | Add `role` to UserData, create_user, _row_to_user |
| `backend/src/api/models.py` | Add `role` to UserResponse |
| `backend/src/api/routes/users.py` | Pass `role` through response builders |
| `backend/src/api/deps.py` | Add `role` to test auth bypass |
| `frontend/src/types/auth.ts` | Add `role` to User interface |
| `frontend/src/pages/LibraryPage/index.tsx` | Show timeline for parent role |
| `backend/tests/api/test_parent_role.py` | 4 new tests |

## Test plan

- [x] `test_me_endpoint_returns_role_for_parent` — parent role returned on /me
- [x] `test_me_endpoint_returns_role_child_by_default` — child role is default
- [x] `test_public_profile_does_not_expose_role` — role hidden on public endpoint
- [x] `test_role_defaults_to_child` — UserData default
- [x] Existing user profile tests still pass (8/8)
- [x] Library, image-to-story, and stats tests still pass (26/26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)