### PR TITLE
feat: animal emoji avatar picker for Profile (#262, #263)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -4,6 +4,7 @@ API Request/Response Models
 Pydantic 模型定义所有 API 端点的请求和响应格式
 """
 
+import re
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Dict, Any, Literal
@@ -738,8 +739,24 @@ class UpdateProfileRequest(BaseModel):
     )
     avatar_url: Optional[str] = Field(
         None,
-        description="头像URL"
+        description="头像URL — emoji:🐼 格式或 https:// URL"
     )
+
+    @field_validator('avatar_url', mode='before')
+    @classmethod
+    def validate_avatar_url(cls, v: Any) -> Any:
+        if v is None:
+            return v
+        if not isinstance(v, str):
+            raise ValueError('avatar_url must be a string')
+        if v.startswith('https://'):
+            return v
+        if v.startswith('emoji:'):
+            emoji_part = v[6:]
+            if emoji_part and re.match(r'^[\U0001F300-\U0001FAFF\U00002702-\U000027B0\U0000FE00-\U0000FE0F\U0000200D]{1,7}$', emoji_part):
+                return v
+            raise ValueError('emoji: prefix must be followed by a valid emoji character')
+        raise ValueError('avatar_url must be emoji:🐼 format or a valid https:// URL')
 
 
 # ============================================================================

--- a/backend/tests/contracts/test_avatar_validation.py
+++ b/backend/tests/contracts/test_avatar_validation.py
@@ -1,0 +1,57 @@
+"""Contract tests for avatar_url validation on UpdateProfileRequest (#263)."""
+
+import pytest
+from pydantic import ValidationError
+
+from src.api.models import UpdateProfileRequest
+
+
+class TestAvatarUrlValidation:
+    def test_accepts_emoji_format(self):
+        req = UpdateProfileRequest(avatar_url="emoji:🐼")
+        assert req.avatar_url == "emoji:🐼"
+
+    def test_accepts_https_url(self):
+        req = UpdateProfileRequest(avatar_url="https://example.com/pic.png")
+        assert req.avatar_url == "https://example.com/pic.png"
+
+    def test_accepts_none(self):
+        req = UpdateProfileRequest(avatar_url=None)
+        assert req.avatar_url is None
+
+    def test_accepts_omitted(self):
+        req = UpdateProfileRequest()
+        assert req.avatar_url is None
+
+    def test_rejects_script_injection(self):
+        with pytest.raises(ValidationError):
+            UpdateProfileRequest(avatar_url="<script>alert(1)</script>")
+
+    def test_rejects_http_url(self):
+        with pytest.raises(ValidationError):
+            UpdateProfileRequest(avatar_url="http://example.com/pic.png")
+
+    def test_rejects_arbitrary_string(self):
+        with pytest.raises(ValidationError):
+            UpdateProfileRequest(avatar_url="some random text")
+
+    def test_rejects_javascript_url(self):
+        with pytest.raises(ValidationError):
+            UpdateProfileRequest(avatar_url="javascript:alert(1)")
+
+    def test_rejects_data_url(self):
+        with pytest.raises(ValidationError):
+            UpdateProfileRequest(avatar_url="data:image/png;base64,abc")
+
+    def test_rejects_empty_emoji_prefix(self):
+        with pytest.raises(ValidationError):
+            UpdateProfileRequest(avatar_url="emoji:")
+
+    def test_rejects_emoji_prefix_with_text(self):
+        with pytest.raises(ValidationError):
+            UpdateProfileRequest(avatar_url="emoji:hello")
+
+    def test_accepts_various_animal_emojis(self):
+        for emoji in ['🐶', '🐱', '🦊', '🐙', '🦁', '🐼', '🦄', '🐲']:
+            req = UpdateProfileRequest(avatar_url=f"emoji:{emoji}")
+            assert req.avatar_url == f"emoji:{emoji}"

--- a/frontend/src/components/common/AvatarDisplay.tsx
+++ b/frontend/src/components/common/AvatarDisplay.tsx
@@ -1,0 +1,59 @@
+import { resolveMediaUrl } from '@/utils/mediaUrl'
+
+const SIZE_CLASSES = {
+  sm: 'w-8 h-8 text-lg',
+  md: 'w-12 h-12 text-2xl',
+  lg: 'w-16 h-16 text-3xl',
+} as const
+
+type AvatarSize = keyof typeof SIZE_CLASSES
+
+interface AvatarDisplayProps {
+  avatarUrl?: string | null
+  size?: AvatarSize
+  className?: string
+}
+
+/**
+ * Renders a user avatar — emoji, image URL, or default fallback.
+ * Detects `emoji:🐼` prefix and renders as large emoji span.
+ */
+function AvatarDisplay({ avatarUrl, size = 'md', className = '' }: AvatarDisplayProps) {
+  const sizeClass = SIZE_CLASSES[size]
+
+  // Emoji avatar: stored as "emoji:🐼"
+  if (avatarUrl?.startsWith('emoji:')) {
+    const emoji = avatarUrl.slice(6)
+    return (
+      <div
+        className={`${sizeClass} rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0 ${className}`}
+      >
+        {emoji}
+      </div>
+    )
+  }
+
+  // Image URL avatar
+  if (avatarUrl) {
+    return (
+      <div className={`${sizeClass} rounded-full overflow-hidden flex-shrink-0 ${className}`}>
+        <img
+          src={resolveMediaUrl(avatarUrl) || avatarUrl}
+          alt="avatar"
+          className="w-full h-full object-cover"
+        />
+      </div>
+    )
+  }
+
+  // Default fallback
+  return (
+    <div
+      className={`${sizeClass} rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0 ${className}`}
+    >
+      👤
+    </div>
+  )
+}
+
+export default AvatarDisplay

--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -4,6 +4,7 @@ import { AnimatedBackground } from '@/components/depth/AnimatedBackground'
 import { ConfettiController } from '@/components/effects/Confetti'
 import GenerationStatusBar from '@/components/layout/GenerationStatusBar'
 import useGenerationNavigator from '@/hooks/useGenerationNavigator'
+import AvatarDisplay from '@/components/common/AvatarDisplay'
 import useAuthStore from '@/store/useAuthStore'
 import { authService } from '@/api/services/authService'
 import { performFullLogout } from '@/utils/logout'
@@ -62,17 +63,7 @@ function PageContainer() {
                       className="flex items-center gap-2 text-gray-600"
                       whileHover={{ scale: 1.02 }}
                     >
-                      <span className="text-xl">
-                        {user?.avatar_url ? (
-                          <img
-                            src={user.avatar_url}
-                            alt="avatar"
-                            className="w-7 h-7 rounded-full object-cover"
-                          />
-                        ) : (
-                          '👤'
-                        )}
-                      </span>
+                      <AvatarDisplay avatarUrl={user?.avatar_url} size="sm" />
                       <span className="text-sm font-medium hidden sm:inline">
                         {user?.display_name || user?.username}
                       </span>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -9,6 +9,13 @@ import useAuthStore from '@/store/useAuthStore'
 import { authService } from '@/api/services/authService'
 import type { UpdateProfileRequest } from '@/types/auth'
 import { resolveMediaUrl } from '@/utils/mediaUrl'
+import AvatarDisplay from '@/components/common/AvatarDisplay'
+
+const ANIMAL_EMOJIS = [
+  '🐶', '🐱', '🐼', '🐨', '🦊', '🐰', '🐸', '🦁',
+  '🐯', '🐮', '🐷', '🐵', '🐔', '🐧', '🦄', '🐲',
+  '🐢', '🦋', '🐬', '🐙',
+]
 
 function ProfilePage() {
   const navigate = useNavigate()
@@ -94,17 +101,7 @@ function ProfilePage() {
       >
         <Card className="p-6">
           <div className="flex flex-col items-center text-center sm:flex-row sm:items-center sm:text-left gap-4">
-            <div className="w-16 h-16 rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center text-3xl overflow-hidden flex-shrink-0">
-              {user?.avatar_url ? (
-                <img
-                  src={resolveMediaUrl(user.avatar_url) || user.avatar_url}
-                  alt="avatar"
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                '👤'
-              )}
-            </div>
+            <AvatarDisplay avatarUrl={user?.avatar_url} size="lg" />
             <div className="flex-1 min-w-0">
               <h1 className="text-2xl font-bold text-gray-800 truncate">
                 {user?.display_name || user?.username}
@@ -155,18 +152,41 @@ function ProfilePage() {
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-600 mb-1">
-                  Avatar URL
+                <label className="block text-sm font-medium text-gray-600 mb-2">
+                  Choose Your Avatar
                 </label>
-                <input
-                  type="text"
-                  value={editForm.avatar_url || ''}
-                  onChange={(e) =>
-                    setEditForm({ ...editForm, avatar_url: e.target.value })
-                  }
-                  className="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
-                  placeholder="https://example.com/avatar.png"
-                />
+                <div className="flex items-center gap-3 mb-3">
+                  <AvatarDisplay avatarUrl={editForm.avatar_url || undefined} size="md" />
+                  <span className="text-sm text-gray-500">
+                    {editForm.avatar_url?.startsWith('emoji:')
+                      ? 'Tap an animal to change'
+                      : 'Pick your favorite animal!'}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {ANIMAL_EMOJIS.map((emoji) => {
+                    const emojiValue = `emoji:${emoji}`
+                    const isSelected = editForm.avatar_url === emojiValue
+                    return (
+                      <motion.button
+                        key={emoji}
+                        type="button"
+                        className={`w-10 h-10 rounded-lg text-xl flex items-center justify-center transition-all ${
+                          isSelected
+                            ? 'border-2 border-primary bg-primary/10 shadow-md'
+                            : 'border border-gray-200 hover:border-gray-300 hover:shadow-sm'
+                        }`}
+                        onClick={() =>
+                          setEditForm({ ...editForm, avatar_url: emojiValue })
+                        }
+                        whileHover={{ scale: 1.15, y: -2 }}
+                        whileTap={{ scale: 0.9 }}
+                      >
+                        {emoji}
+                      </motion.button>
+                    )
+                  })}
+                </div>
               </div>
               <Button
                 size="sm"


### PR DESCRIPTION
## Summary
- **Emoji avatar picker**: Replaces the useless "Avatar URL" text input with a fun grid of 20 animal emojis that children can tap to personalize their profile
- **Shared AvatarDisplay component**: Handles `emoji:🐼` prefix, image URLs, and `👤` fallback — used in both ProfilePage header and nav bar
- **Backend validation**: `avatar_url` now only accepts `emoji:<emoji>`, `https://` URLs, or `null` — blocks XSS/injection vectors
- **12 contract tests**: Comprehensive validation coverage

Fixes #262
Fixes #263

**Parent Epic**: #49

## Changes
| File | Change |
|------|--------|
| `frontend/src/components/common/AvatarDisplay.tsx` | **New** — shared avatar renderer |
| `frontend/src/pages/ProfilePage/index.tsx` | Emoji grid picker + AvatarDisplay in header |
| `frontend/src/components/layout/PageContainer/index.tsx` | Nav bar uses AvatarDisplay |
| `backend/src/api/models.py` | `@field_validator('avatar_url')` on UpdateProfileRequest |
| `backend/tests/contracts/test_avatar_validation.py` | **New** — 12 contract tests |
| `docs/product/PRD.md` | Avatar Emoji Picker feature spec |

## Test plan
- [x] `python -m pytest tests/contracts/test_avatar_validation.py -v` — 12/12 pass
- [x] `npx tsc --noEmit` — no type errors
- [ ] Manual: open Profile → Edit → tap animal emoji → Save → verify nav bar updates
- [ ] Manual: verify backward compat with existing image URL avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)