### PR TITLE
feat: unified FeatureTile for homepage navigation (#265)

### DIFF
--- a/frontend/src/components/common/FeatureTile.tsx
+++ b/frontend/src/components/common/FeatureTile.tsx
@@ -1,0 +1,64 @@
+import { Link } from 'react-router-dom'
+import { motion } from 'framer-motion'
+
+const ACCENT_STYLES = {
+  primary: {
+    bg: 'bg-gradient-to-br from-primary/15 to-primary/5',
+    border: 'border-primary/20',
+    iconBg: 'bg-primary/20',
+    hoverShadow: '0 8px 25px rgba(255, 107, 107, 0.25)',
+  },
+  secondary: {
+    bg: 'bg-gradient-to-br from-secondary/15 to-secondary/5',
+    border: 'border-secondary/20',
+    iconBg: 'bg-secondary/20',
+    hoverShadow: '0 8px 25px rgba(78, 205, 196, 0.25)',
+  },
+  accent: {
+    bg: 'bg-gradient-to-br from-accent/25 to-accent/10',
+    border: 'border-accent/30',
+    iconBg: 'bg-accent/30',
+    hoverShadow: '0 8px 25px rgba(255, 230, 109, 0.35)',
+  },
+} as const
+
+type AccentColor = keyof typeof ACCENT_STYLES
+
+interface FeatureTileProps {
+  to: string
+  icon: string
+  label: string
+  accentColor: AccentColor
+  description?: string
+}
+
+function FeatureTile({ to, icon, label, accentColor, description }: FeatureTileProps) {
+  const style = ACCENT_STYLES[accentColor]
+
+  return (
+    <Link to={to} className="block">
+      <motion.div
+        className={`${style.bg} ${style.border} border rounded-card p-5 shadow-card text-center cursor-pointer`}
+        whileHover={{
+          scale: 1.05,
+          y: -4,
+          boxShadow: style.hoverShadow,
+        }}
+        whileTap={{ scale: 0.97 }}
+        transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+      >
+        <div
+          className={`${style.iconBg} w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3`}
+        >
+          <span className="text-2xl">{icon}</span>
+        </div>
+        <span className="font-bold text-gray-800 text-sm block">{label}</span>
+        {description && (
+          <span className="text-xs text-gray-500 mt-1 block">{description}</span>
+        )}
+      </motion.div>
+    </Link>
+  )
+}
+
+export default FeatureTile

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { motion, useSpring, useTransform } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import Button from '@/components/common/Button'
+import FeatureTile from '@/components/common/FeatureTile'
 import TiltCard from '@/components/depth/TiltCard'
 import { FloatingElement } from '@/components/depth/ParallaxContainer'
 import { DepthLayer } from '@/components/depth/DepthLayer'
@@ -224,40 +224,32 @@ function HomePage() {
                 Transform your artwork into magical stories!
               </motion.p>
               <motion.div
-                className="flex flex-col sm:flex-row gap-3 mt-2"
+                className="grid grid-cols-3 gap-3 mt-2 w-full"
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: 0.4 }}
               >
-                <Link to="/upload">
-                  <Button
-                    size="lg"
-                    rightIcon={<span>🖼️</span>}
-                    className="shadow-lg hover:shadow-xl transition-shadow w-full sm:w-auto"
-                  >
-                    Art to Story
-                  </Button>
-                </Link>
-                <Link to="/interactive">
-                  <Button
-                    size="lg"
-                    variant="secondary"
-                    rightIcon={<span>🎭</span>}
-                    className="shadow-lg hover:shadow-xl transition-shadow w-full sm:w-auto"
-                  >
-                    Interactive Tales
-                  </Button>
-                </Link>
-                <Link to="/news">
-                  <Button
-                    size="lg"
-                    variant="outline"
-                    rightIcon={<span>📰</span>}
-                    className="shadow-lg hover:shadow-xl transition-shadow w-full sm:w-auto"
-                  >
-                    Kids News
-                  </Button>
-                </Link>
+                <FeatureTile
+                  to="/upload"
+                  icon="🖼️"
+                  label="Art to Story"
+                  accentColor="primary"
+                  description="Draw & narrate"
+                />
+                <FeatureTile
+                  to="/interactive"
+                  icon="🎭"
+                  label="Interactive Tales"
+                  accentColor="secondary"
+                  description="Choose your path"
+                />
+                <FeatureTile
+                  to="/news"
+                  icon="📰"
+                  label="Kids News"
+                  accentColor="accent"
+                  description="World made simple"
+                />
               </motion.div>
             </div>
           </div>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -8,7 +8,6 @@ import TiltCard from '@/components/depth/TiltCard'
 import useAuthStore from '@/store/useAuthStore'
 import { authService } from '@/api/services/authService'
 import type { UpdateProfileRequest } from '@/types/auth'
-import { resolveMediaUrl } from '@/utils/mediaUrl'
 import AvatarDisplay from '@/components/common/AvatarDisplay'
 
 const ANIMAL_EMOJIS = [


### PR DESCRIPTION
## Summary
- **New `FeatureTile` component**: Purpose-built tile with soft gradient background, icon circle, label, and optional description — consistent across all three homepage features
- **Replaced mismatched buttons**: The old primary/secondary/outline Button variants had different visual weights, shadows, and hover behaviors. Now all three tiles share identical structure with distinct but harmonious colors (primary coral, secondary teal, accent yellow)
- **Grid layout**: Switched from `flex` to `grid-cols-3` for equal-width tiles on all screen sizes

Fixes #265

**Parent Epic**: #49

## Changes
| File | Change |
|------|--------|
| `frontend/src/components/common/FeatureTile.tsx` | **New** — reusable feature navigation tile |
| `frontend/src/pages/HomePage/index.tsx` | Replace 3 Button blocks with FeatureTile grid |
| `frontend/src/pages/ProfilePage/index.tsx` | Remove unused `resolveMediaUrl` import |

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [ ] Visual: all 3 tiles same height/width/padding at mobile and desktop
- [ ] Hover: uniform scale+lift+glow animation on all tiles
- [ ] Navigation: each tile routes to correct page (/upload, /interactive, /news)

🤖 Generated with [Claude Code](https://claude.com/claude-code)