### PR TITLE
feat: art style transfer for children's drawings

### DIFF
--- a/backend/src/agents/image_to_story_agent.py
+++ b/backend/src/agents/image_to_story_agent.py
@@ -85,7 +85,8 @@ from ..mcp_servers import (
     vision_server,
     vector_server,
     safety_server,
-    tts_server
+    tts_server,
+    image_style_server,
 )
 from ..services.story_memory import get_story_memory_prompt
 
@@ -99,7 +100,7 @@ def _should_use_mock() -> bool:
     )
 
 
-def _mock_image_to_story_result(interests: list[str]) -> Dict[str, Any]:
+def _mock_image_to_story_result(interests: list[str], art_theme: str = None) -> Dict[str, Any]:
     """Deterministic mock result for test environments.
 
     The story text is sized for the 6-8 age group (200-400 words) so that
@@ -141,6 +142,7 @@ def _mock_image_to_story_result(interests: list[str]) -> Dict[str, Any]:
         "analysis": {"objects": ["drawing"], "colors": ["blue", "green"]},
         "safety_score": 0.95,
         "audio_path": None,
+        "styled_image_path": f"data/styled/mock_{art_theme}.jpg" if art_theme else None,
     }
 
 
@@ -197,7 +199,8 @@ async def image_to_story(
     child_age: int,
     interests: list[str] = None,
     enable_audio: bool = True,
-    voice: str = None
+    voice: str = None,
+    art_theme: str = None,
 ) -> Dict[str, Any]:
     """
     将儿童画作转化为个性化故事
@@ -209,12 +212,13 @@ async def image_to_story(
         interests: 儿童兴趣标签列表
         enable_audio: 是否生成语音
         voice: 语音类型（可选，默认根据年龄组选择）
+        art_theme: 艺术风格主题（可选，如 "cartoon", "watercolor" 等）
 
     Returns:
         包含故事、音频等信息的字典
     """
     if _should_use_mock():
-        return _mock_image_to_story_result(interests or [])
+        return _mock_image_to_story_result(interests or [], art_theme=art_theme)
     # 验证输入
     if not Path(image_path).exists():
         raise FileNotFoundError(f"图片文件不存在: {image_path}")
@@ -272,6 +276,20 @@ async def image_to_story(
 安全检查通过后才能继续后续步骤。
 """
 
+    # Add style transfer instruction if art_theme is specified
+    if art_theme and art_theme != "none":
+        prompt += f"""
+**画作风格转换**：
+在分析画作之后、创作故事之前，使用 `mcp__image-style__transform_art_style` 工具将画作转换为"{art_theme}"风格。参数：
+- image_path: {image_path}
+- theme: {art_theme}
+- child_age: {child_age}
+- session_id: {child_id}
+
+转换后的图片将作为故事封面。请在故事创作中考虑这种艺术风格，让故事的语调和氛围与风格相配。
+如果风格转换失败，请继续使用原始画作。
+"""
+
     # Add TTS instruction if audio should be generated
     if should_generate_audio:
         prompt += f"""
@@ -283,25 +301,33 @@ async def image_to_story(
 """
 
     # 配置 Agent 选项（使用 Structured Output）
+    mcp_servers = {
+        "vision-analysis": vision_server,
+        "vector-search": vector_server,
+        "safety-check": safety_server,
+        "tts-generation": tts_server,
+    }
+
+    allowed_tools = [
+        # Vision Analysis Tools
+        "mcp__vision-analysis__analyze_children_drawing",
+        # Vector Search Tools
+        "mcp__vector-search__search_similar_drawings",
+        "mcp__vector-search__store_drawing_embedding",
+        # Safety Check Tools
+        "mcp__safety-check__check_content_safety",
+        "mcp__safety-check__suggest_content_improvements",
+        # TTS Tools
+        "mcp__tts-generation__generate_story_audio",
+    ]
+
+    if art_theme and art_theme != "none":
+        mcp_servers["image-style"] = image_style_server
+        allowed_tools.append("mcp__image-style__transform_art_style")
+
     options = ClaudeAgentOptions(
-        mcp_servers={
-            "vision-analysis": vision_server,
-            "vector-search": vector_server,
-            "safety-check": safety_server,
-            "tts-generation": tts_server
-        },
-        allowed_tools=[
-            # Vision Analysis Tools
-            "mcp__vision-analysis__analyze_children_drawing",
-            # Vector Search Tools
-            "mcp__vector-search__search_similar_drawings",
-            "mcp__vector-search__store_drawing_embedding",
-            # Safety Check Tools
-            "mcp__safety-check__check_content_safety",
-            "mcp__safety-check__suggest_content_improvements",
-            # TTS Tools
-            "mcp__tts-generation__generate_story_audio",
-        ],
+        mcp_servers=mcp_servers,
+        allowed_tools=allowed_tools,
         cwd=".",
         permission_mode="acceptEdits",
         max_turns=15,  # 增加 turns 以适应更多工具调用
@@ -315,6 +341,7 @@ async def image_to_story(
     # 使用 ClaudeSDKClient 调用 Agent
     result_data = {}
     audio_path = None
+    styled_image_path = None
 
     async with ClaudeSDKClient(options=options) as client:
         await client.query(prompt)
@@ -333,6 +360,8 @@ async def image_to_story(
                                     result_json = json.loads(result_content)
                                     if 'audio_path' in result_json:
                                         audio_path = result_json['audio_path']
+                                    if 'styled_image_path' in result_json:
+                                        styled_image_path = result_json['styled_image_path']
                                 except (json.JSONDecodeError, TypeError):
                                     pass
 
@@ -360,6 +389,10 @@ async def image_to_story(
     if audio_path:
         result_data["audio_path"] = audio_path
 
+    # Add styled image path to result if available
+    if styled_image_path:
+        result_data["styled_image_path"] = styled_image_path
+
     return result_data
 
 
@@ -369,7 +402,8 @@ async def stream_image_to_story(
     child_age: int,
     interests: list[str] = None,
     enable_audio: bool = True,
-    voice: str = None
+    voice: str = None,
+    art_theme: str = None,
 ) -> AsyncGenerator[Dict[str, Any], None]:
     """
     流式返回故事生成过程
@@ -381,13 +415,14 @@ async def stream_image_to_story(
         interests: 兴趣标签列表
         enable_audio: 是否生成语音
         voice: 语音类型（可选）
+        art_theme: 艺术风格主题（可选，如 "cartoon", "watercolor" 等）
 
     Yields:
         流式事件字典，包含 type 和 data 字段
     """
     if _should_use_mock():
         yield {"type": "status", "data": {"status": "started", "message": "正在分析画作..."}}
-        yield {"type": "result", "data": _mock_image_to_story_result(interests or [])}
+        yield {"type": "result", "data": _mock_image_to_story_result(interests or [], art_theme=art_theme)}
         yield {"type": "complete", "data": {"status": "completed", "message": "故事生成完成"}}
         return
     # 验证输入
@@ -469,6 +504,20 @@ async def stream_image_to_story(
 安全检查通过后才能继续后续步骤。
 """
 
+    # Add style transfer instruction if art_theme is specified
+    if art_theme and art_theme != "none":
+        prompt += f"""
+**画作风格转换**：
+在分析画作之后、创作故事之前，使用 `mcp__image-style__transform_art_style` 工具将画作转换为"{art_theme}"风格。参数：
+- image_path: {image_path}
+- theme: {art_theme}
+- child_age: {child_age}
+- session_id: {child_id}
+
+转换后的图片将作为故事封面。请在故事创作中考虑这种艺术风格，让故事的语调和氛围与风格相配。
+如果风格转换失败，请继续使用原始画作。
+"""
+
     # Add TTS instruction if audio should be generated
     if should_generate_audio:
         prompt += f"""
@@ -479,21 +528,29 @@ async def stream_image_to_story(
 - 儿童ID: {child_id}
 """
 
+    mcp_servers = {
+        "vision-analysis": vision_server,
+        "vector-search": vector_server,
+        "safety-check": safety_server,
+        "tts-generation": tts_server,
+    }
+
+    allowed_tools = [
+        "mcp__vision-analysis__analyze_children_drawing",
+        "mcp__vector-search__search_similar_drawings",
+        "mcp__vector-search__store_drawing_embedding",
+        "mcp__safety-check__check_content_safety",
+        "mcp__safety-check__suggest_content_improvements",
+        "mcp__tts-generation__generate_story_audio",
+    ]
+
+    if art_theme and art_theme != "none":
+        mcp_servers["image-style"] = image_style_server
+        allowed_tools.append("mcp__image-style__transform_art_style")
+
     options = ClaudeAgentOptions(
-        mcp_servers={
-            "vision-analysis": vision_server,
-            "vector-search": vector_server,
-            "safety-check": safety_server,
-            "tts-generation": tts_server
-        },
-        allowed_tools=[
-            "mcp__vision-analysis__analyze_children_drawing",
-            "mcp__vector-search__search_similar_drawings",
-            "mcp__vector-search__store_drawing_embedding",
-            "mcp__safety-check__check_content_safety",
-            "mcp__safety-check__suggest_content_improvements",
-            "mcp__tts-generation__generate_story_audio",
-        ],
+        mcp_servers=mcp_servers,
+        allowed_tools=allowed_tools,
         cwd=".",
         permission_mode="acceptEdits",
         max_turns=15,  # 增加 turns 以适应更多工具调用
@@ -506,6 +563,7 @@ async def stream_image_to_story(
     result_data = {}
     turn_count = 0
     audio_path = None
+    styled_image_path = None
 
     try:
         async with ClaudeSDKClient(options=options) as client:
@@ -537,6 +595,7 @@ async def stream_image_to_story(
                                     "mcp__vector-search__store_drawing_embedding": "正在保存画作到记忆库...",
                                     "mcp__safety-check__check_content_safety": "正在检查内容安全...",
                                     "mcp__tts-generation__generate_story_audio": "正在生成语音...",
+                                    "mcp__image-style__transform_art_style": "正在转换画作风格...",
                                 }
                                 yield {
                                     "type": "tool_use",
@@ -546,7 +605,7 @@ async def stream_image_to_story(
                                     }
                                 }
                             elif isinstance(block, ToolResultBlock):
-                                # Try to extract audio path from TTS result
+                                # Try to extract audio/styled image path from tool results
                                 result_content = getattr(block, 'content', None)
                                 if result_content and isinstance(result_content, str):
                                     try:
@@ -560,6 +619,8 @@ async def stream_image_to_story(
                                                     "message": "语音生成完成"
                                                 }
                                             }
+                                        if 'styled_image_path' in result_json:
+                                            styled_image_path = result_json['styled_image_path']
                                     except (json.JSONDecodeError, TypeError):
                                         pass
 
@@ -612,6 +673,10 @@ async def stream_image_to_story(
     # Add audio path to result if available
     if audio_path:
         result_data["audio_path"] = audio_path
+
+    # Add styled image path to result if available
+    if styled_image_path:
+        result_data["styled_image_path"] = styled_image_path
 
     # 发送最终结果
     yield {

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -76,6 +76,18 @@ class VideoStyle(str, Enum):
     STORYBOOK = "storybook"                # 绘本风格
 
 
+class ArtTheme(str, Enum):
+    """Art style transfer theme for image-to-story (PRD §3.1.1)"""
+    CARTOON = "cartoon"
+    OIL_PAINTING = "oil_painting"
+    WATERCOLOR = "watercolor"
+    PIXEL_ART = "pixel_art"
+    ANIME = "anime"
+    CRAYON = "crayon"
+    STORYBOOK = "storybook"
+    NONE = "none"
+
+
 class VideoStatus(str, Enum):
     """视频生成状态"""
     PENDING = "pending"

--- a/backend/src/api/routes/image_to_story.py
+++ b/backend/src/api/routes/image_to_story.py
@@ -22,7 +22,8 @@ from ..models import (
     StoryContent,
     EducationalValue,
     CharacterMemory,
-    AgeGroup
+    AgeGroup,
+    ArtTheme,
 )
 from ..deps import get_current_user, get_story_for_owner
 from ...agents.image_to_story_agent import (
@@ -199,6 +200,7 @@ async def create_story_from_image(
     interests: Optional[str] = Form(None, description="Interest tags, comma-separated (max 5)"),
     voice: str = Form("nova", description="Voice type"),
     enable_audio: bool = Form(True, description="Whether to generate audio"),
+    art_theme: ArtTheme = Form(ArtTheme.NONE, description="Art style theme for image transformation"),
     user: UserData = Depends(get_current_user),
 ):
     """
@@ -230,6 +232,15 @@ async def create_story_from_image(
 
         # 3. Parse parameters
         child_age = parse_age_group(age_group.value)
+
+        # Validate art_theme for age group (#270)
+        YOUNG_CHILD_THEMES = {ArtTheme.CARTOON, ArtTheme.CRAYON, ArtTheme.WATERCOLOR, ArtTheme.STORYBOOK, ArtTheme.NONE}
+        if child_age <= 5 and art_theme not in YOUNG_CHILD_THEMES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Art theme '{art_theme.value}' is not available for age group 3-5"
+            )
+
         interests_list = None
         if interests:
             interests_list = [i.strip() for i in interests.split(",") if i.strip()]
@@ -250,7 +261,8 @@ async def create_story_from_image(
             child_age=child_age,
             interests=interests_list if interests_list is not None else [],
             enable_audio=enable_audio,
-            voice=voice
+            voice=voice,
+            art_theme=art_theme.value if art_theme != ArtTheme.NONE else None,
         )
 
         # 4b. Validate story length per age group (#233)
@@ -268,6 +280,7 @@ async def create_story_from_image(
                 interests=interests_list if interests_list is not None else [],
                 enable_audio=enable_audio,
                 voice=voice,
+                art_theme=art_theme.value if art_theme != ArtTheme.NONE else None,
             )
             length_info = validate_story_length(result.get("story", ""), age_group.value)
 
@@ -301,6 +314,12 @@ async def create_story_from_image(
         if result.get("audio_path"):
             audio_filename = Path(result["audio_path"]).name
             audio_url = f"/data/audio/{audio_filename}"
+
+        # Use styled image as cover if available (#273)
+        styled_image_path = result.get("styled_image_path")
+        cover_image_url = image_url
+        if styled_image_path and Path(styled_image_path).exists():
+            cover_image_url = f"/data/styled/{Path(styled_image_path).name}"
 
         # Build response
         created_at = datetime.now()
@@ -354,7 +373,10 @@ async def create_story_from_image(
             "created_at": created_at.isoformat(),
             "child_id": safe_child_id,
             "age_group": age_group.value,
-            "image_path": str(image_path)
+            "image_path": str(image_path),
+            "art_theme": art_theme.value if art_theme != ArtTheme.NONE else None,
+            "styled_image_path": styled_image_path,
+            "cover_image_url": cover_image_url,
         }
         story_data["user_id"] = user.user_id
         await story_repo.create(story_data)
@@ -402,11 +424,32 @@ async def create_story_from_image(
             except Exception:
                 logger.warning("Failed to record image artifact", exc_info=True)
 
+        styled_artifact_id = None
+        if run_id and styled_image_path and Path(styled_image_path).exists():
+            try:
+                styled_step_id = await tracker.start_step(
+                    run_id, "style_transfer", 2,
+                    input_data={"image_path": str(image_path), "theme": art_theme.value if art_theme else "none"},
+                )
+                styled_mime, _ = mimetypes.guess_type(styled_image_path)
+                styled_file_size = Path(styled_image_path).stat().st_size
+                styled_artifact_id = await tracker.record_artifact(
+                    styled_step_id, ArtifactType.IMAGE, run_id=run_id,
+                    artifact_path=styled_image_path,
+                    description=f"Style-transferred image ({art_theme.value if art_theme else 'none'})",
+                    mime_type=styled_mime, file_size=styled_file_size,
+                    agent_name="style_transfer",
+                    input_artifact_ids=[image_artifact_id] if image_artifact_id else None,
+                )
+                await tracker.complete_step(styled_step_id, output_data={"artifact_id": styled_artifact_id})
+            except Exception:
+                logger.warning("Failed to record styled image artifact", exc_info=True)
+
         text_artifact_id = None
         if run_id:
             try:
                 text_step_id = await tracker.start_step(
-                    run_id, "text_artifact", 2, input_data={"story_id": story_id},
+                    run_id, "text_artifact", 3, input_data={"story_id": story_id},
                 )
                 text_artifact_id = await tracker.record_artifact(
                     text_step_id, ArtifactType.TEXT, run_id=run_id,
@@ -423,7 +466,7 @@ async def create_story_from_image(
         if run_id and audio_url and result.get("audio_path"):
             try:
                 audio_step_id = await tracker.start_step(
-                    run_id, "tts_artifact", 3, input_data={"audio_path": result["audio_path"]},
+                    run_id, "tts_artifact", 4, input_data={"audio_path": result["audio_path"]},
                 )
                 audio_mime, _ = mimetypes.guess_type(result["audio_path"])
                 audio_artifact_id = await tracker.record_artifact(
@@ -442,6 +485,7 @@ async def create_story_from_image(
                 art_repo = tracker._artifact_repo
                 for artifact_id, role in [
                     (image_artifact_id, StoryArtifactRole.COVER),
+                    (styled_artifact_id, StoryArtifactRole.COVER),
                     (text_artifact_id, StoryArtifactRole.STORY_TEXT),
                     (audio_artifact_id, StoryArtifactRole.FINAL_AUDIO),
                 ]:
@@ -451,7 +495,7 @@ async def create_story_from_image(
                     await art_repo.update_lifecycle_state(artifact_id, "published")
                     await tracker.link_to_story(story_id, artifact_id, role)
                 await tracker.complete_run(run_id, result_summary={
-                    "artifacts_created": sum(1 for a in [image_artifact_id, text_artifact_id, audio_artifact_id] if a),
+                    "artifacts_created": sum(1 for a in [image_artifact_id, styled_artifact_id, text_artifact_id, audio_artifact_id] if a),
                     "story_id": story_id,
                 })
             except Exception:
@@ -511,6 +555,7 @@ async def create_story_from_image_stream(
     interests: Optional[str] = Form(None, description="Interest tags, comma-separated (max 5)"),
     voice: str = Form("nova", description="Voice type"),
     enable_audio: bool = Form(True, description="Whether to generate audio"),
+    art_theme: ArtTheme = Form(ArtTheme.NONE, description="Art style theme for image transformation"),
     user: UserData = Depends(get_current_user),
 ):
     """
@@ -546,6 +591,15 @@ async def create_story_from_image_stream(
 
     # Parse parameters
     child_age = parse_age_group(age_group.value)
+
+    # Validate art_theme for age group (#270)
+    YOUNG_CHILD_THEMES = {ArtTheme.CARTOON, ArtTheme.CRAYON, ArtTheme.WATERCOLOR, ArtTheme.STORYBOOK, ArtTheme.NONE}
+    if child_age <= 5 and art_theme not in YOUNG_CHILD_THEMES:
+        err_msg = f"Art theme '{art_theme.value}' is not available for age group 3-5"
+        async def error_generator():
+            yield f"event: error\ndata: {json.dumps({'error': 'ValidationError', 'message': err_msg}, ensure_ascii=False)}\n\n"
+        return StreamingResponse(error_generator(), media_type="text/event-stream")
+
     interests_list = None
     if interests:
         interests_list = [i.strip() for i in interests.split(",") if i.strip()]
@@ -571,7 +625,8 @@ async def create_story_from_image_stream(
                 child_age=child_age,
                 interests=interests_list if interests_list is not None else [],
                 enable_audio=enable_audio,
-                voice=voice
+                voice=voice,
+                art_theme=art_theme.value if art_theme != ArtTheme.NONE else None,
             ):
                 if await request.is_disconnected():
                     logger.info("Client disconnected during story generation (story_id=%s), aborting", story_id)
@@ -603,6 +658,12 @@ async def create_story_from_image_stream(
                         audio_filename = Path(result_data["audio_path"]).name
                         audio_url = f"/data/audio/{audio_filename}"
 
+                    # Use styled image as cover if available (#273)
+                    styled_image_path = result_data.get("styled_image_path")
+                    cover_image_url = image_url
+                    if styled_image_path and Path(styled_image_path).exists():
+                        cover_image_url = f"/data/styled/{Path(styled_image_path).name}"
+
                     # Build complete response data
                     response_data = {
                         "story_id": story_id,
@@ -629,7 +690,7 @@ async def create_story_from_image_stream(
                     }
 
                     # Save story to database (must happen before provenance — FK constraint)
-                    story_save_data = {**response_data, "child_id": safe_child_id, "age_group": age_group.value, "image_path": str(image_path)}
+                    story_save_data = {**response_data, "child_id": safe_child_id, "age_group": age_group.value, "image_path": str(image_path), "art_theme": art_theme.value if art_theme != ArtTheme.NONE else None, "styled_image_path": styled_image_path, "cover_image_url": cover_image_url}
                     story_save_data["user_id"] = user.user_id
                     await story_repo.create(story_save_data)
 
@@ -652,7 +713,7 @@ async def create_story_from_image_stream(
                     # --- Provenance: record run + all artifacts (Issue #234) ---
                     # Provenance is recorded after story_repo.create() so that the
                     # runs.story_id FK constraint is satisfied.
-                    image_artifact_id = text_artifact_id = audio_artifact_id = None
+                    image_artifact_id = styled_artifact_id = text_artifact_id = audio_artifact_id = None
                     try:
                         run_id = await tracker.start_run(story_id, WorkflowType.IMAGE_TO_STORY)
                     except Exception:
@@ -668,9 +729,20 @@ async def create_story_from_image_stream(
                         except Exception:
                             logger.warning("Failed to record image artifact (streaming)", exc_info=True)
 
+                    styled_artifact_id = None
+                    if run_id and styled_image_path and Path(styled_image_path).exists():
+                        try:
+                            styled_step_id = await tracker.start_step(run_id, "style_transfer", 2, input_data={"image_path": str(image_path), "theme": art_theme.value if art_theme else "none"})
+                            styled_mime, _ = mimetypes.guess_type(styled_image_path)
+                            styled_file_size = Path(styled_image_path).stat().st_size
+                            styled_artifact_id = await tracker.record_artifact(styled_step_id, ArtifactType.IMAGE, run_id=run_id, artifact_path=styled_image_path, description=f"Style-transferred image ({art_theme.value if art_theme else 'none'})", mime_type=styled_mime, file_size=styled_file_size, agent_name="style_transfer", input_artifact_ids=[image_artifact_id] if image_artifact_id else None)
+                            await tracker.complete_step(styled_step_id, output_data={"artifact_id": styled_artifact_id})
+                        except Exception:
+                            logger.warning("Failed to record styled image artifact (streaming)", exc_info=True)
+
                     if run_id:
                         try:
-                            text_step_id = await tracker.start_step(run_id, "text_artifact", 2, input_data={"story_id": story_id})
+                            text_step_id = await tracker.start_step(run_id, "text_artifact", 3, input_data={"story_id": story_id})
                             text_artifact_id = await tracker.record_artifact(text_step_id, ArtifactType.TEXT, run_id=run_id, artifact_payload=story_text, description="Generated story text", safety_score=result_data.get("safety_score", 0.0), agent_name="story_generation", input_artifact_ids=[image_artifact_id] if image_artifact_id else None, metadata=ArtifactMetadata(char_count=len(story_text), word_count=word_count))
                             await tracker.complete_step(text_step_id, output_data={"artifact_id": text_artifact_id})
                         except Exception:
@@ -678,7 +750,7 @@ async def create_story_from_image_stream(
 
                     if run_id and audio_url and result_data.get("audio_path"):
                         try:
-                            audio_step_id = await tracker.start_step(run_id, "tts_artifact", 3, input_data={"audio_path": result_data["audio_path"]})
+                            audio_step_id = await tracker.start_step(run_id, "tts_artifact", 4, input_data={"audio_path": result_data["audio_path"]})
                             audio_mime, _ = mimetypes.guess_type(result_data["audio_path"])
                             audio_artifact_id = await tracker.record_artifact(audio_step_id, ArtifactType.AUDIO, run_id=run_id, artifact_path=result_data["audio_path"], artifact_url=audio_url, description="TTS narration audio", mime_type=audio_mime, agent_name="tts_generation", input_artifact_ids=[text_artifact_id] if text_artifact_id else None)
                             await tracker.complete_step(audio_step_id, output_data={"artifact_id": audio_artifact_id})
@@ -690,6 +762,7 @@ async def create_story_from_image_stream(
                             art_repo = tracker._artifact_repo
                             for artifact_id, role in [
                                 (image_artifact_id, StoryArtifactRole.COVER),
+                                (styled_artifact_id, StoryArtifactRole.COVER),
                                 (text_artifact_id, StoryArtifactRole.STORY_TEXT),
                                 (audio_artifact_id, StoryArtifactRole.FINAL_AUDIO),
                             ]:
@@ -699,7 +772,7 @@ async def create_story_from_image_stream(
                                 await art_repo.update_lifecycle_state(artifact_id, "published")
                                 await tracker.link_to_story(story_id, artifact_id, role)
                             await tracker.complete_run(run_id, result_summary={
-                                "artifacts_created": sum(1 for a in [image_artifact_id, text_artifact_id, audio_artifact_id] if a),
+                                "artifacts_created": sum(1 for a in [image_artifact_id, styled_artifact_id, text_artifact_id, audio_artifact_id] if a),
                                 "story_id": story_id,
                             })
                             run_id = None  # Prevent double-close in finally

--- a/backend/src/mcp_servers/__init__.py
+++ b/backend/src/mcp_servers/__init__.py
@@ -58,6 +58,9 @@ generate_painting_video = create_unavailable_tool("video_generator_server")
 check_video_status = create_unavailable_tool("video_generator_server")
 combine_video_audio = create_unavailable_tool("video_generator_server")
 
+image_style_server = {}
+transform_art_style = create_unavailable_tool("image_style_server")
+
 web_search_server = {}
 get_headlines_by_topic = create_unavailable_tool("web_search_server")
 fetch_article_text = create_unavailable_tool("web_search_server")
@@ -110,6 +113,13 @@ except Exception as exc:
     logger.error("❌ Failed to import MCP server 'video_generator_server': %s", exc, exc_info=True)
 
 try:
+    from .image_style_server import image_style_server, transform_art_style
+    MCP_SERVER_STATUS["image_style_server"] = "ok"
+except Exception as exc:
+    MCP_SERVER_STATUS["image_style_server"] = f"error: {exc}"
+    logger.error("❌ Failed to import MCP server 'image_style_server': %s", exc, exc_info=True)
+
+try:
     from .web_search_server import (
         web_search_server,
         get_headlines_by_topic,
@@ -141,6 +151,8 @@ __all__ = [
     "generate_painting_video",
     "check_video_status",
     "combine_video_audio",
+    "image_style_server",
+    "transform_art_style",
     "web_search_server",
     "get_headlines_by_topic",
     "fetch_article_text",

--- a/backend/src/mcp_servers/image_style_server.py
+++ b/backend/src/mcp_servers/image_style_server.py
@@ -1,0 +1,255 @@
+"""
+Image Style Transfer MCP Server
+
+Transforms children's drawings into different art styles using
+black-forest-labs/flux-kontext-pro on Replicate.
+"""
+
+import os
+import json
+from typing import Any, Dict
+from pathlib import Path
+import uuid
+
+try:
+    import replicate
+except Exception:  # pragma: no cover - import fallback for test env
+    replicate = None
+
+try:
+    from claude_agent_sdk import tool, create_sdk_mcp_server
+except Exception:  # pragma: no cover - import fallback for test env
+    def tool(*_args, **_kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    def create_sdk_mcp_server(**kwargs):
+        return kwargs
+
+
+# Ensure output directory exists
+Path("data/styled").mkdir(parents=True, exist_ok=True)
+
+
+# Art theme prompts for style transfer
+ART_THEME_PROMPTS = {
+    "cartoon": "Transform this children's drawing into a colorful cartoon illustration, keeping all the original elements and characters",
+    "oil_painting": "Transform this children's drawing into a beautiful oil painting style, preserving the original composition and characters",
+    "watercolor": "Transform this children's drawing into a soft, dreamy watercolor painting, keeping all original elements",
+    "pixel_art": "Convert this children's drawing into a charming pixel art style illustration, preserving the characters and scene",
+    "anime": "Transform this children's drawing into a cute anime illustration style, keeping all original characters and elements",
+    "crayon": "Make this children's drawing look like a professional crayon illustration, enhancing the colors while keeping the original composition",
+    "storybook": "Transform this children's drawing into a beautiful storybook illustration, preserving all characters and the scene",
+}
+
+# Themes safe for younger children (age <= 5)
+YOUNG_CHILD_THEMES = {"cartoon", "crayon", "watercolor", "storybook"}
+
+
+def get_allowed_themes(child_age: int) -> set:
+    """Return allowed art themes based on the child's age."""
+    if child_age <= 5:
+        return YOUNG_CHILD_THEMES
+    return set(ART_THEME_PROMPTS.keys())
+
+
+def _mock_style_result(image_path: str, theme: str, session_id: str) -> Dict[str, Any]:
+    """Return a deterministic mock result for test environments."""
+    mock_path = f"data/styled/{session_id}_{theme}.jpg"
+    return {
+        "content": [{
+            "type": "text",
+            "text": json.dumps({
+                "success": True,
+                "styled_image_path": mock_path,
+                "original_preserved": True,
+                "theme_applied": theme,
+            }, ensure_ascii=False)
+        }]
+    }
+
+
+@tool(
+    "transform_art_style",
+    """Transform a children's drawing into a different art style using AI image generation.
+
+    Supported themes: cartoon, oil_painting, watercolor, pixel_art, anime, crayon, storybook.
+    Age 3-5 only supports: cartoon, crayon, watercolor, storybook.""",
+    {
+        "image_path": str,
+        "theme": str,
+        "child_age": int,
+        "session_id": str,
+    }
+)
+async def transform_art_style(args: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Transform a children's drawing into a specified art style.
+
+    Args:
+        args: Dict containing image_path, theme, child_age, session_id
+
+    Returns:
+        Dict with styled image path and metadata
+    """
+    image_path = args["image_path"]
+    theme = args.get("theme", "cartoon")
+    child_age = args.get("child_age", 6)
+    session_id = args.get("session_id", str(uuid.uuid4()))
+
+    # Validate theme is in allowed list for the child's age
+    allowed = get_allowed_themes(child_age)
+    if theme not in allowed:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "success": False,
+                    "error": f"Theme '{theme}' is not allowed for age {child_age}. "
+                             f"Allowed themes: {sorted(allowed)}",
+                }, ensure_ascii=False)
+            }]
+        }
+
+    # Validate theme exists at all
+    if theme not in ART_THEME_PROMPTS:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "success": False,
+                    "error": f"Unknown theme '{theme}'. "
+                             f"Available themes: {sorted(ART_THEME_PROMPTS.keys())}",
+                }, ensure_ascii=False)
+            }]
+        }
+
+    # Mock result for test environments or when replicate SDK is unavailable
+    if replicate is None or os.environ.get("PYTEST_CURRENT_TEST"):
+        return _mock_style_result(image_path, theme, session_id)
+
+    # Validate image file exists
+    if not Path(image_path).exists():
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "success": False,
+                    "error": f"Image file not found: {image_path}",
+                }, ensure_ascii=False)
+            }]
+        }
+
+    try:
+        prompt = ART_THEME_PROMPTS[theme]
+
+        # Call Replicate flux-kontext-pro model
+        with open(image_path, "rb") as img_file:
+            output = replicate.run(
+                "black-forest-labs/flux-kontext-pro",
+                input={
+                    "prompt": prompt,
+                    "input_image": img_file,
+                    "output_format": "jpg",
+                }
+            )
+
+        # Save output image
+        styled_dir = Path("data/styled")
+        styled_dir.mkdir(parents=True, exist_ok=True)
+        output_filename = f"{session_id}_{theme}.jpg"
+        output_path = styled_dir / output_filename
+
+        # output is typically a URL or file-like object from replicate
+        if hasattr(output, "read"):
+            with open(output_path, "wb") as f:
+                f.write(output.read())
+        elif isinstance(output, (list, tuple)) and len(output) > 0:
+            # Some replicate models return a list of URLs
+            import httpx
+            response = httpx.get(str(output[0]))
+            with open(output_path, "wb") as f:
+                f.write(response.content)
+        elif isinstance(output, str) and output.startswith("http"):
+            import httpx
+            response = httpx.get(output)
+            with open(output_path, "wb") as f:
+                f.write(response.content)
+        else:
+            # Try writing raw bytes
+            with open(output_path, "wb") as f:
+                f.write(output if isinstance(output, bytes) else str(output).encode())
+
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "success": True,
+                    "styled_image_path": str(output_path),
+                    "original_preserved": True,
+                    "theme_applied": theme,
+                }, ensure_ascii=False)
+            }]
+        }
+
+    except Exception as e:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "success": False,
+                    "error": f"Style transfer failed: {str(e)}",
+                }, ensure_ascii=False)
+            }]
+        }
+
+
+# Create MCP Server
+image_style_server = create_sdk_mcp_server(
+    name="image-style",
+    version="1.0.0",
+    tools=[transform_art_style]
+)
+
+
+if __name__ == "__main__":
+    """Test the image style transfer tool."""
+    import asyncio
+
+    async def test():
+        print("=== Test Image Style Transfer ===\n")
+
+        # Test with mock (no replicate SDK needed)
+        print("1. Mock style transfer...")
+        result = await transform_art_style({
+            "image_path": "test.png",
+            "theme": "cartoon",
+            "child_age": 6,
+            "session_id": "test-session-123",
+        })
+        print(json.loads(result["content"][0]["text"]))
+        print()
+
+        # Test age restriction
+        print("2. Age restriction (age 4, anime theme)...")
+        result = await transform_art_style({
+            "image_path": "test.png",
+            "theme": "anime",
+            "child_age": 4,
+            "session_id": "test-session-456",
+        })
+        print(json.loads(result["content"][0]["text"]))
+        print()
+
+        # Test invalid theme
+        print("3. Invalid theme...")
+        result = await transform_art_style({
+            "image_path": "test.png",
+            "theme": "nonexistent",
+            "child_age": 10,
+            "session_id": "test-session-789",
+        })
+        print(json.loads(result["content"][0]["text"]))
+
+    asyncio.run(test())

--- a/backend/tests/contracts/test_image_style_contract.py
+++ b/backend/tests/contracts/test_image_style_contract.py
@@ -1,0 +1,160 @@
+"""
+Contract tests for Art Style Transfer (#269, #270, #275).
+
+Verifies:
+- ArtTheme enum has exactly 8 values including 'none'
+- transform_art_style MCP tool returns correct output shape
+- All 7 art themes produce valid output
+- Invalid theme is rejected
+- Age-based theme filtering works correctly
+- Mock mode returns deterministic output
+"""
+
+import pytest
+import json
+
+
+class TestArtThemeEnumContract:
+    """ArtTheme enum must have exactly 8 values."""
+
+    def test_enum_has_8_values(self):
+        from backend.src.api.models import ArtTheme
+        assert len(ArtTheme) == 8
+
+    def test_enum_has_none(self):
+        from backend.src.api.models import ArtTheme
+        assert ArtTheme.NONE.value == "none"
+
+    def test_enum_has_all_themes(self):
+        from backend.src.api.models import ArtTheme
+        expected = {"cartoon", "oil_painting", "watercolor", "pixel_art", "anime", "crayon", "storybook", "none"}
+        actual = {t.value for t in ArtTheme}
+        assert actual == expected
+
+
+class TestAgeThemeFilterContract:
+    """Age-based theme filtering must restrict young children to safe themes."""
+
+    def test_age_3_5_gets_4_themes(self):
+        from backend.src.mcp_servers.image_style_server import get_allowed_themes
+        allowed = get_allowed_themes(4)
+        assert allowed == {"cartoon", "crayon", "watercolor", "storybook"}
+
+    def test_age_5_gets_young_themes(self):
+        from backend.src.mcp_servers.image_style_server import get_allowed_themes
+        allowed = get_allowed_themes(5)
+        assert allowed == {"cartoon", "crayon", "watercolor", "storybook"}
+
+    def test_age_6_gets_all_themes(self):
+        from backend.src.mcp_servers.image_style_server import get_allowed_themes
+        allowed = get_allowed_themes(6)
+        assert len(allowed) == 7
+
+    def test_age_12_gets_all_themes(self):
+        from backend.src.mcp_servers.image_style_server import get_allowed_themes
+        allowed = get_allowed_themes(12)
+        assert len(allowed) == 7
+
+
+class TestTransformArtStyleOutputContract:
+    """transform_art_style must return MCP-compliant output shape."""
+
+    @pytest.mark.asyncio
+    async def test_mock_output_has_required_fields(self):
+        """In test env (PYTEST_CURRENT_TEST set), tool returns mock with correct shape."""
+        from backend.src.mcp_servers.image_style_server import transform_art_style
+
+        result = await transform_art_style({
+            "image_path": "/tmp/test.png",
+            "theme": "cartoon",
+            "child_age": 7,
+            "session_id": "test-session",
+        })
+
+        # MCP tool output format
+        assert "content" in result
+        assert len(result["content"]) == 1
+        assert result["content"][0]["type"] == "text"
+
+        data = json.loads(result["content"][0]["text"])
+        assert data["success"] is True
+        assert "styled_image_path" in data
+        assert data["original_preserved"] is True
+        assert data["theme_applied"] == "cartoon"
+
+    @pytest.mark.asyncio
+    async def test_all_themes_produce_valid_output(self):
+        from backend.src.mcp_servers.image_style_server import transform_art_style, ART_THEME_PROMPTS
+
+        for theme in ART_THEME_PROMPTS:
+            result = await transform_art_style({
+                "image_path": "/tmp/test.png",
+                "theme": theme,
+                "child_age": 10,
+                "session_id": f"test-{theme}",
+            })
+            data = json.loads(result["content"][0]["text"])
+            assert data["success"] is True
+            assert data["theme_applied"] == theme
+
+    @pytest.mark.asyncio
+    async def test_invalid_theme_returns_error(self):
+        from backend.src.mcp_servers.image_style_server import transform_art_style
+
+        result = await transform_art_style({
+            "image_path": "/tmp/test.png",
+            "theme": "invalid_theme",
+            "child_age": 7,
+            "session_id": "test-session",
+        })
+
+        data = json.loads(result["content"][0]["text"])
+        assert data["success"] is False
+        assert "error" in data
+
+    @pytest.mark.asyncio
+    async def test_age_restricted_theme_returns_error(self):
+        """3-5 year old should not be able to use pixel_art theme."""
+        from backend.src.mcp_servers.image_style_server import transform_art_style
+
+        result = await transform_art_style({
+            "image_path": "/tmp/test.png",
+            "theme": "pixel_art",
+            "child_age": 4,
+            "session_id": "test-session",
+        })
+
+        data = json.loads(result["content"][0]["text"])
+        assert data["success"] is False
+        assert "not available" in data["error"].lower() or "not allowed" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_age_restricted_anime_returns_error(self):
+        """3-5 year old should not be able to use anime theme."""
+        from backend.src.mcp_servers.image_style_server import transform_art_style
+
+        result = await transform_art_style({
+            "image_path": "/tmp/test.png",
+            "theme": "anime",
+            "child_age": 5,
+            "session_id": "test-session",
+        })
+
+        data = json.loads(result["content"][0]["text"])
+        assert data["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_young_child_can_use_cartoon(self):
+        """3-5 year old should be able to use cartoon theme."""
+        from backend.src.mcp_servers.image_style_server import transform_art_style
+
+        result = await transform_art_style({
+            "image_path": "/tmp/test.png",
+            "theme": "cartoon",
+            "child_age": 4,
+            "session_id": "test-session",
+        })
+
+        data = json.loads(result["content"][0]["text"])
+        assert data["success"] is True
+        assert data["theme_applied"] == "cartoon"

--- a/frontend/src/api/services/storyService.ts
+++ b/frontend/src/api/services/storyService.ts
@@ -67,6 +67,7 @@ export const storyService = {
       interests?: string[]
       voice?: string
       enableAudio?: boolean
+      artTheme?: string
     }
   ): Promise<ImageToStoryResponse> {
     const formData = new FormData()
@@ -82,6 +83,9 @@ export const storyService = {
     }
     if (params.enableAudio !== undefined) {
       formData.append('enable_audio', String(params.enableAudio))
+    }
+    if (params.artTheme && params.artTheme !== 'none') {
+      formData.append('art_theme', params.artTheme)
     }
 
     const response = await apiClient.post<ImageToStoryResponse>(
@@ -110,6 +114,7 @@ export const storyService = {
       interests?: string[]
       voice?: string
       enableAudio?: boolean
+      artTheme?: string
     },
     callbacks: StreamCallbacks,
     signal?: AbortSignal
@@ -127,6 +132,9 @@ export const storyService = {
     }
     if (params.enableAudio !== undefined) {
       formData.append('enable_audio', String(params.enableAudio))
+    }
+    if (params.artTheme && params.artTheme !== 'none') {
+      formData.append('art_theme', params.artTheme)
     }
 
     const response = await fetch(`${API_BASE_URL}/image-to-story/stream`, {

--- a/frontend/src/hooks/useStoryGeneration.ts
+++ b/frontend/src/hooks/useStoryGeneration.ts
@@ -20,6 +20,7 @@ export function useStoryGeneration(options?: UseStoryGenerationOptions) {
     selectedImage,
     selectedVoice,
     enableAudio,
+    selectedArtTheme,
     uploadStatus,
     streaming,
     generationInProgress,
@@ -40,6 +41,7 @@ export function useStoryGeneration(options?: UseStoryGenerationOptions) {
       interests?: string[]
       voice?: string
       enableAudio?: boolean
+      artTheme?: string
     }) => {
       setUploadStatus('uploading')
       setUploadError(null)
@@ -52,6 +54,7 @@ export function useStoryGeneration(options?: UseStoryGenerationOptions) {
         interests: params.interests,
         voice: params.voice || selectedVoice,
         enableAudio: params.enableAudio ?? enableAudio,
+        artTheme: params.artTheme || selectedArtTheme,
       })
     },
     onMutate: () => {

--- a/frontend/src/pages/UploadPage/index.tsx
+++ b/frontend/src/pages/UploadPage/index.tsx
@@ -23,15 +23,30 @@ const AGE_GROUPS: { value: AgeGroup; label: string; emoji: string; description: 
   { value: '9-12', label: '9-12 yrs', emoji: '🧑', description: 'Rich Stories' },
 ]
 
+const ART_THEMES = [
+  { value: 'none', label: 'Keep Original', emoji: '🖼️', description: 'Use your drawing as-is' },
+  { value: 'cartoon', label: 'Cartoon', emoji: '🎨', description: 'Fun cartoon style' },
+  { value: 'oil_painting', label: 'Oil Painting', emoji: '🖌️', description: 'Classic oil painting' },
+  { value: 'watercolor', label: 'Watercolor', emoji: '💧', description: 'Soft watercolor' },
+  { value: 'pixel_art', label: 'Pixel Art', emoji: '👾', description: 'Retro pixel style' },
+  { value: 'anime', label: 'Anime', emoji: '✨', description: 'Anime illustration' },
+  { value: 'crayon', label: 'Crayon', emoji: '🖍️', description: 'Crayon drawing' },
+  { value: 'storybook', label: 'Storybook', emoji: '📖', description: 'Storybook illustration' },
+] as const
+
+const YOUNG_CHILD_THEMES = new Set(['none', 'cartoon', 'crayon', 'watercolor', 'storybook'])
+
 function UploadPage() {
   const {
     selectedImage,
     imagePreviewUrl,
     selectedVoice,
+    selectedArtTheme,
     enableAudio,
     uploadError,
     setSelectedImage,
     setSelectedVoice,
+    setSelectedArtTheme,
     setEnableAudio,
   } = useStoryStore()
 
@@ -253,7 +268,50 @@ function UploadPage() {
         </TiltCard>
       </motion.div>
 
-      {/* Step 3: Interests with floating tags */}
+      {/* Step 3: Art Style */}
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.25 }}
+      >
+        <TiltCard maxTilt={4} glare={false} dynamicShadow className="w-full">
+          <div className="bg-white rounded-card p-6">
+            <StepHeader number={3} title="Choose Art Style" emoji="🎨" optional />
+            <p className="text-gray-500 text-sm mb-4">
+              Transform your drawing into a different art style
+            </p>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              {ART_THEMES
+                .filter(t => {
+                  if (!selectedAgeGroup || selectedAgeGroup !== '3-5') return true
+                  return YOUNG_CHILD_THEMES.has(t.value)
+                })
+                .map((theme, index) => (
+                  <motion.button
+                    key={theme.value}
+                    className={`p-3 rounded-card border-2 transition-all text-center ${
+                      selectedArtTheme === theme.value
+                        ? 'border-primary bg-primary/10 shadow-lg'
+                        : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
+                    }`}
+                    onClick={() => setSelectedArtTheme(theme.value)}
+                    whileHover={prefersReducedMotion ? {} : { scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    initial={{ opacity: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: 0.25 + index * 0.03 }}
+                  >
+                    <span className="text-2xl block mb-1">{theme.emoji}</span>
+                    <span className="font-medium text-gray-800 text-sm block">{theme.label}</span>
+                    <span className="text-xs text-gray-500">{theme.description}</span>
+                  </motion.button>
+                ))}
+            </div>
+          </div>
+        </TiltCard>
+      </motion.div>
+
+      {/* Step 4: Interests with floating tags */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -262,7 +320,7 @@ function UploadPage() {
         <TiltCard maxTilt={4} glare={false} dynamicShadow className="w-full">
           <div className="bg-white rounded-card p-6">
             <StepHeader
-              number={3}
+              number={4}
               title="What Do You Like?"
               emoji="❤️"
               optional
@@ -305,7 +363,7 @@ function UploadPage() {
         </TiltCard>
       </motion.div>
 
-      {/* Step 4: Voice selection with 3D effect */}
+      {/* Step 5: Voice selection with 3D effect */}
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
@@ -314,7 +372,7 @@ function UploadPage() {
         <TiltCard maxTilt={4} glare={false} dynamicShadow className="w-full">
           <div className="bg-white rounded-card p-6">
             <StepHeader
-              number={4}
+              number={5}
               title="Choose a Narrator"
               emoji="🎙️"
               optional

--- a/frontend/src/services/storyGenerationManager.ts
+++ b/frontend/src/services/storyGenerationManager.ts
@@ -32,7 +32,7 @@ export const storyGenerationManager = {
       return
     }
 
-    const { selectedImage, selectedVoice, enableAudio } = store
+    const { selectedImage, selectedVoice, enableAudio, selectedArtTheme } = store
     if (!selectedImage) {
       store.setUploadError('Please select an image first')
       return
@@ -99,6 +99,7 @@ export const storyGenerationManager = {
           interests,
           voice: selectedVoice,
           enableAudio,
+          artTheme: selectedArtTheme,
         },
         callbacks,
         abortController.signal

--- a/frontend/src/store/useStoryStore.ts
+++ b/frontend/src/store/useStoryStore.ts
@@ -35,6 +35,9 @@ interface StoryState {
   selectedProvider: string | null
   enableAudio: boolean
 
+  // Art theme
+  selectedArtTheme: string
+
   // Story history (local cache)
   storyHistory: ImageToStoryResponse[]
 
@@ -51,6 +54,7 @@ interface StoryState {
   setSelectedImage: (file: File | null) => void
   setSelectedVoice: (voice: string, provider?: string) => void
   setEnableAudio: (enable: boolean) => void
+  setSelectedArtTheme: (theme: string) => void
   addToHistory: (story: ImageToStoryResponse) => void
   removeStory: (storyId: string) => void
   clearHistory: () => void
@@ -76,6 +80,7 @@ const useStoryStore = create<StoryState>((set, get) => ({
   selectedVoice: 'nova',
   selectedProvider: null,
   enableAudio: true,
+  selectedArtTheme: 'none',
   storyHistory: [],
   streaming: initialStreamingState,
   generationInProgress: false,
@@ -124,6 +129,8 @@ const useStoryStore = create<StoryState>((set, get) => ({
 
   setEnableAudio: (enable) => set({ enableAudio: enable }),
 
+  setSelectedArtTheme: (theme) => set({ selectedArtTheme: theme }),
+
   addToHistory: (story) => {
     const history = get().storyHistory
     // 避免重复
@@ -155,6 +162,7 @@ const useStoryStore = create<StoryState>((set, get) => ({
       uploadError: null,
       selectedImage: null,
       imagePreviewUrl: null,
+      selectedArtTheme: 'none',
       streaming: initialStreamingState,
       generationInProgress: false,
       generationError: null,


### PR DESCRIPTION
## Summary

- New `image_style_server.py` MCP server using Replicate `flux-kontext-pro` to transform drawings into 7 art styles (cartoon, watercolor, oil painting, pixel art, anime, crayon, storybook)
- Age-gated theme validation: ages 3-5 restricted to cartoon/crayon/watercolor/storybook only (age-appropriate safety)
- `ArtTheme` enum added to `models.py`; `art_theme` form param wired end-to-end through route → agent → MCP tool
- Agent prompt instructs Claude to call `mcp__image-style__transform_art_style` before story generation, using the styled image as cover art
- Frontend: art theme selector on UploadPage, store/hook/service updated
- Contract tests added in `backend/tests/contracts/test_image_style_contract.py`

**Parent Epic**: #40

Fixes #269

## Test plan

- [ ] Run `python -m pytest backend/tests/contracts/test_image_style_contract.py -v` — all contract tests pass
- [ ] POST `/api/story/image-to-story` with `art_theme=cartoon` — styled image path returned in response
- [ ] POST with `art_theme=pixel_art` and `age_group=3-5` — returns 400 (age gate)
- [ ] POST with `art_theme=none` — no style transfer, behaves as before
- [ ] Frontend: upload page shows art theme selector; selection passes through to API
- [ ] Replicate unavailable (no API key) → mock result returned, story generation continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)