### PR TITLE
feat(frontend): conditional success banner in StoryPage (#278)

### DIFF
--- a/frontend/src/hooks/useStoryGeneration.ts
+++ b/frontend/src/hooks/useStoryGeneration.ts
@@ -63,6 +63,7 @@ export function useStoryGeneration(options?: UseStoryGenerationOptions) {
     onSuccess: (data) => {
       setUploadStatus('success')
       setCurrentStory(data)
+      useStoryStore.getState().setJustGenerated(true)
       options?.onSuccess?.()
       navigate(`/story/${data.story_id}`)
     },

--- a/frontend/src/pages/StoryPage/index.tsx
+++ b/frontend/src/pages/StoryPage/index.tsx
@@ -17,8 +17,18 @@ function StoryPage() {
   const { storyId } = useParams<{ storyId: string }>()
   const navigate = useNavigate()
 
-  const { currentStory, setCurrentStory, reset } = useStoryStore()
+  const { currentStory, setCurrentStory, reset, justGenerated, setJustGenerated } = useStoryStore()
   const { currentChild } = useChildStore()
+
+  // Show banner only when navigating directly from the upload/generation flow
+  const [showBanner, setShowBanner] = useState(false)
+
+  useEffect(() => {
+    if (justGenerated) {
+      setShowBanner(true)
+      setJustGenerated(false) // clear from store immediately so re-mounts don't re-show
+    }
+  }, [justGenerated, setJustGenerated])
 
   // On-demand audio state (for 9-12 age group)
   const [onDemandAudioUrl, setOnDemandAudioUrl] = useState<string | null>(null)
@@ -128,27 +138,29 @@ function StoryPage() {
         <div className="w-10" />
       </motion.header>
 
-      {/* Success notification */}
-      <motion.div
-        className="success-banner"
-        initial={{ opacity: 0, y: -10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.1 }}
-      >
-        <motion.span
-          className="text-2xl"
-          animate={{ scale: [1, 1.2, 1] }}
-          transition={{ duration: 0.5 }}
+      {/* Success notification — only shown when navigating from the generation flow */}
+      {showBanner && (
+        <motion.div
+          className="success-banner"
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1 }}
         >
-          🎉
-        </motion.span>
-        <div>
-          <p className="font-bold text-gray-800">Story created successfully!</p>
-          <p className="text-sm text-gray-600">
-            AI crafted this unique story from your artwork
-          </p>
-        </div>
-      </motion.div>
+          <motion.span
+            className="text-2xl"
+            animate={{ scale: [1, 1.2, 1] }}
+            transition={{ duration: 0.5 }}
+          >
+            🎉
+          </motion.span>
+          <div>
+            <p className="font-bold text-gray-800">Story created successfully!</p>
+            <p className="text-sm text-gray-600">
+              AI crafted this unique story from your artwork
+            </p>
+          </div>
+        </motion.div>
+      )}
 
       {/* Book container with story - age-aware display */}
       <AgeAwareContent

--- a/frontend/src/services/storyGenerationManager.ts
+++ b/frontend/src/services/storyGenerationManager.ts
@@ -70,6 +70,7 @@ export const storyGenerationManager = {
         const s = useStoryStore.getState()
         s.setUploadStatus('success')
         s.setCurrentStory(storyData)
+        s.setJustGenerated(true)
         s.stopStreaming()
 
         const path = `/story/${storyData.story_id}`

--- a/frontend/src/store/useStoryStore.ts
+++ b/frontend/src/store/useStoryStore.ts
@@ -46,6 +46,9 @@ interface StoryState {
   generationInProgress: boolean
   generationError: string | null
 
+  // Flag: true only when story was just generated (not when browsing library)
+  justGenerated: boolean
+
   // Actions
   setCurrentStory: (story: ImageToStoryResponse | null) => void
   setUploadStatus: (status: UploadStatus) => void
@@ -68,6 +71,7 @@ interface StoryState {
   stopStreaming: () => void
   setGenerationError: (error: string | null) => void
   resetStreaming: () => void
+  setJustGenerated: (value: boolean) => void
 }
 
 const useStoryStore = create<StoryState>((set, get) => ({
@@ -85,6 +89,7 @@ const useStoryStore = create<StoryState>((set, get) => ({
   streaming: initialStreamingState,
   generationInProgress: false,
   generationError: null,
+  justGenerated: false,
 
   setCurrentStory: (story) => {
     set({ currentStory: story })
@@ -166,6 +171,7 @@ const useStoryStore = create<StoryState>((set, get) => ({
       streaming: initialStreamingState,
       generationInProgress: false,
       generationError: null,
+      justGenerated: false,
     })
   },
 
@@ -235,6 +241,8 @@ const useStoryStore = create<StoryState>((set, get) => ({
       generationError: null,
     })
   },
+
+  setJustGenerated: (value) => set({ justGenerated: value }),
 }))
 
 export default useStoryStore


### PR DESCRIPTION
## Summary

- Add `justGenerated` boolean flag to `useStoryStore` (state, action `setJustGenerated`, reset to `false` in `reset()`)
- Set `justGenerated=true` in `storyGenerationManager.ts` (`onResult` callback) and `useStoryGeneration.ts` (`onSuccess`) when story generation completes
- Update `StoryPage` to copy the flag into local `showBanner` state on mount, then immediately clear it from the store — so the banner shows once after generation and never on library navigation

## Test plan

- [ ] Upload a drawing and generate a story → success banner appears on StoryPage
- [ ] Navigate to a story from My Library → no success banner shown
- [ ] Refresh StoryPage after generation → no banner on reload (flag was cleared)
- [ ] `reset()` called on "Create New Story" clears `justGenerated` as expected

Fixes #278
Related to #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)