### PR TITLE
fix(api,frontend): expose styled_image_url in story response (#294)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -173,6 +173,7 @@ class ImageToStoryResponse(BaseModel):
     story_id: str = Field(..., description="故事唯一ID")
     story: StoryContent = Field(..., description="故事内容")
     image_url: Optional[str] = Field(None, description="画作图片URL")
+    styled_image_url: Optional[str] = Field(None, description="风格化图片URL")
     audio_url: Optional[str] = Field(None, description="语音文件URL")
     video_url: Optional[str] = Field(None, description="视频文件URL")
     video_job_id: Optional[str] = Field(None, description="视频生成任务ID")

--- a/backend/src/api/routes/image_to_story.py
+++ b/backend/src/api/routes/image_to_story.py
@@ -330,10 +330,13 @@ async def create_story_from_image(
             age_adapted=True,
             degraded_length=degraded_length,
         )
+        styled_image_url = cover_image_url if cover_image_url != image_url else None
+
         response = ImageToStoryResponse(
             story_id=story_id,
             story=story_content,
             image_url=image_url,
+            styled_image_url=styled_image_url,
             audio_url=audio_url,
             video_url=None,
             video_job_id=None,
@@ -674,6 +677,7 @@ async def create_story_from_image_stream(
                             "degraded_length": degraded_length,
                         },
                         "image_url": image_url,
+                        "styled_image_url": cover_image_url if cover_image_url != image_url else None,
                         "audio_url": audio_url,
                         "educational_value": {
                             "themes": result_data.get("themes", []),

--- a/frontend/src/pages/LibraryPage/index.tsx
+++ b/frontend/src/pages/LibraryPage/index.tsx
@@ -1060,7 +1060,7 @@ function buildLocalItems(
         type: 'art-story',
         title: `Story #${s.story_id.slice(0, 8)}`,
         preview: text.slice(0, 150),
-        image_url: s.image_url ?? null,
+        image_url: s.styled_image_url || s.cover_image_url || (s.image_url ?? null),
         audio_url: s.audio_url ?? null,
         created_at: s.created_at,
         is_favorited: false,

--- a/frontend/src/pages/StoryPage/index.tsx
+++ b/frontend/src/pages/StoryPage/index.tsx
@@ -107,7 +107,7 @@ function StoryPage() {
     )
   }
 
-  const imageUrl = resolveMediaUrl(story.image_url)
+  const imageUrl = resolveMediaUrl(story.styled_image_url || story.cover_image_url || story.image_url)
   // Use the story's age_group (content was generated for it), fall back to child store
   const ageGroup = story.age_group || currentChild?.age_group || null
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -46,6 +46,8 @@ export interface ImageToStoryResponse {
   story_id: string;
   story: StoryContent;
   image_url: string | null;
+  styled_image_url?: string | null;
+  cover_image_url?: string | null;
   audio_url: string | null;
   age_group?: AgeGroup;
   educational_value: EducationalValue;


### PR DESCRIPTION
## Summary
- Added `styled_image_url` field to `ImageToStoryResponse` Pydantic model and both regular/streaming route responses
- Added `styled_image_url` and `cover_image_url` to frontend TypeScript interface
- StoryPage and LibraryPage now prefer styled image over original when available

**Root cause**: The art style transfer MCP tool generates a styled image and saves it to disk, the agent returns `styled_image_path`, and the route saves it to the DB — but the API response model never included the field, so the frontend couldn't display it.

Fixes #294
**Parent Epic**: #40

## Test plan
- [ ] Upload a drawing, select an art style, generate story → styled image should display in StoryPage
- [ ] Open the same story from Library → styled image should display as thumbnail and in story view
- [ ] Generate story without art style → original image displays (no regression)
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Backend tests pass (`python -m pytest tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)