### PR TITLE
feat(safety): add image safety validation for styled images (#273)

### DIFF
--- a/backend/src/api/routes/image_to_story.py
+++ b/backend/src/api/routes/image_to_story.py
@@ -39,6 +39,7 @@ from ...services.models.artifact_models import (
     ArtifactType, WorkflowType, StoryArtifactRole,
     ArtifactMetadata, RunArtifactStage,
 )
+from ...mcp_servers.image_style_server import validate_and_fallback
 
 logger = logging.getLogger(__name__)
 
@@ -371,11 +372,30 @@ async def create_story_from_image(
             audio_filename = Path(result["audio_path"]).name
             audio_url = f"/data/audio/{audio_filename}"
 
-        # Use styled image as cover if available (#273)
+        # Validate styled image safety before use (#273)
         styled_image_path = result.get("styled_image_path")
         cover_image_url = image_url
+        styled_image_safety = None
         if styled_image_path and Path(styled_image_path).exists():
-            cover_image_url = f"/data/styled/{Path(styled_image_path).name}"
+            try:
+                styled_image_safety = await validate_and_fallback(
+                    styled_image_path=styled_image_path,
+                    original_image_path=str(image_path),
+                    child_age=child_age,
+                    theme=art_theme.value if art_theme else "none",
+                    session_id=safe_child_id,
+                )
+                if styled_image_safety["safety_passed"]:
+                    cover_image_url = f"/data/styled/{Path(styled_image_path).name}"
+                else:
+                    # Unsafe: discard styled image, fall back to original
+                    styled_image_path = None
+            except Exception:
+                logger.warning(
+                    "Styled image safety validation failed, using original",
+                    exc_info=True,
+                )
+                styled_image_path = None
 
         # Build response
         created_at = datetime.now()
@@ -519,7 +539,12 @@ async def create_story_from_image(
                     agent_name="style_transfer",
                     input_artifact_ids=[image_artifact_id] if image_artifact_id else None,
                 )
-                await tracker.complete_step(styled_step_id, output_data={"artifact_id": styled_artifact_id})
+                step_output = {"artifact_id": styled_artifact_id}
+                if styled_image_safety:
+                    step_output["image_safety_passed"] = styled_image_safety["safety_passed"]
+                    step_output["image_safety_fell_back"] = styled_image_safety["fell_back"]
+                    step_output["image_safety_flagged"] = styled_image_safety.get("flagged_keywords", [])
+                await tracker.complete_step(styled_step_id, output_data=step_output)
             except Exception:
                 logger.warning("Failed to record styled image artifact", exc_info=True)
 
@@ -737,11 +762,29 @@ async def create_story_from_image_stream(
                         audio_filename = Path(result_data["audio_path"]).name
                         audio_url = f"/data/audio/{audio_filename}"
 
-                    # Use styled image as cover if available (#273)
+                    # Validate styled image safety before use (#273)
                     styled_image_path = result_data.get("styled_image_path")
                     cover_image_url = image_url
+                    styled_image_safety = None
                     if styled_image_path and Path(styled_image_path).exists():
-                        cover_image_url = f"/data/styled/{Path(styled_image_path).name}"
+                        try:
+                            styled_image_safety = await validate_and_fallback(
+                                styled_image_path=styled_image_path,
+                                original_image_path=str(image_path),
+                                child_age=child_age,
+                                theme=art_theme.value if art_theme else "none",
+                                session_id=safe_child_id,
+                            )
+                            if styled_image_safety["safety_passed"]:
+                                cover_image_url = f"/data/styled/{Path(styled_image_path).name}"
+                            else:
+                                styled_image_path = None
+                        except Exception:
+                            logger.warning(
+                                "Styled image safety validation failed (streaming), using original",
+                                exc_info=True,
+                            )
+                            styled_image_path = None
 
                     # Build complete response data
                     response_data = {
@@ -834,7 +877,12 @@ async def create_story_from_image_stream(
                             styled_mime, _ = mimetypes.guess_type(styled_image_path)
                             styled_file_size = Path(styled_image_path).stat().st_size
                             styled_artifact_id = await tracker.record_artifact(styled_step_id, ArtifactType.IMAGE, run_id=run_id, artifact_path=styled_image_path, description=f"Style-transferred image ({art_theme.value if art_theme else 'none'})", mime_type=styled_mime, file_size=styled_file_size, agent_name="style_transfer", input_artifact_ids=[image_artifact_id] if image_artifact_id else None)
-                            await tracker.complete_step(styled_step_id, output_data={"artifact_id": styled_artifact_id})
+                            stream_step_output = {"artifact_id": styled_artifact_id}
+                            if styled_image_safety:
+                                stream_step_output["image_safety_passed"] = styled_image_safety["safety_passed"]
+                                stream_step_output["image_safety_fell_back"] = styled_image_safety["fell_back"]
+                                stream_step_output["image_safety_flagged"] = styled_image_safety.get("flagged_keywords", [])
+                            await tracker.complete_step(styled_step_id, output_data=stream_step_output)
                         except Exception:
                             logger.warning("Failed to record styled image artifact (streaming)", exc_info=True)
 

--- a/backend/src/mcp_servers/image_style_server.py
+++ b/backend/src/mcp_servers/image_style_server.py
@@ -3,13 +3,19 @@ Image Style Transfer MCP Server
 
 Transforms children's drawings into different art styles using
 black-forest-labs/flux-kontext-pro on Replicate.
+
+Includes post-generation safety validation (#273): every styled image
+is checked via vision analysis for child-appropriateness before use.
 """
 
+import logging
 import os
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 from pathlib import Path
 import uuid
+
+logger = logging.getLogger(__name__)
 
 try:
     import replicate
@@ -202,6 +208,169 @@ async def transform_art_style(args: Dict[str, Any]) -> Dict[str, Any]:
                     "error": f"Style transfer failed: {str(e)}",
                 }, ensure_ascii=False)
             }]
+        }
+
+
+# ============================================================================
+# Styled image safety validation (#273)
+# ============================================================================
+
+# Keywords that indicate the styled image may not be child-appropriate.
+# Matched case-insensitively against all text fields in vision analysis output.
+UNSAFE_IMAGE_KEYWORDS: List[str] = [
+    # Violence
+    "violence", "violent", "weapon", "gun", "knife", "sword", "blood",
+    "bleeding", "gore", "fighting", "attack", "kill", "murder", "war",
+    # Horror / fear
+    "horror", "scary", "terrifying", "nightmare", "demon", "devil",
+    "zombie", "corpse", "skull", "death", "dead",
+    # Inappropriate content
+    "nudity", "nude", "sexual", "drug", "alcohol", "smoking",
+    "tobacco", "injection",
+    # Distressing themes
+    "abuse", "torture", "suicide", "self-harm",
+]
+
+
+def check_styled_image_safety(analysis: Dict[str, Any]) -> Dict[str, Any]:
+    """Check vision analysis output for unsafe content using keyword heuristic.
+
+    Scans all string values in the analysis dict (objects, scene, mood,
+    story_potential, etc.) for flagged keywords.
+
+    Args:
+        analysis: Parsed JSON from vision analysis tool output.
+
+    Returns:
+        Dict with keys: safe (bool), reason (str|None), flagged_keywords (list[str]).
+    """
+    if not analysis:
+        return {"safe": True, "reason": None, "flagged_keywords": []}
+
+    # Collect all text from the analysis into one searchable blob
+    text_parts: List[str] = []
+    for key, value in analysis.items():
+        if isinstance(value, str):
+            text_parts.append(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, str):
+                    text_parts.append(item)
+                elif isinstance(item, dict):
+                    text_parts.extend(
+                        str(v) for v in item.values() if isinstance(v, str)
+                    )
+
+    combined_text = " ".join(text_parts).lower()
+
+    flagged: List[str] = []
+    for keyword in UNSAFE_IMAGE_KEYWORDS:
+        if keyword.lower() in combined_text:
+            flagged.append(keyword.lower())
+
+    if flagged:
+        reason = (
+            f"Styled image flagged as unsafe: found keywords [{', '.join(flagged)}] "
+            f"in vision analysis output"
+        )
+        return {"safe": False, "reason": reason, "flagged_keywords": flagged}
+
+    return {"safe": True, "reason": None, "flagged_keywords": []}
+
+
+async def validate_and_fallback(
+    styled_image_path: str,
+    original_image_path: str,
+    child_age: int,
+    theme: str,
+    session_id: str,
+) -> Dict[str, Any]:
+    """Validate a styled image for child safety and fall back if unsafe.
+
+    Calls the vision analysis tool on the styled image, then checks the
+    analysis for concerning content. If the image is unsafe or vision
+    analysis fails, falls back to the original drawing (fail-closed).
+
+    Args:
+        styled_image_path: Path to the AI-generated styled image.
+        original_image_path: Path to the original child's drawing.
+        child_age: Age of the child (for vision analysis context).
+        theme: Art theme that was applied.
+        session_id: Session/child ID for logging.
+
+    Returns:
+        Dict with: used_image_path, safety_passed, fell_back,
+        flagged_keywords, reason.
+    """
+    from . import analyze_children_drawing
+
+    try:
+        # Call vision analysis on the styled image
+        vision_result = await analyze_children_drawing({
+            "image_path": styled_image_path,
+            "child_age": child_age,
+        })
+
+        # Parse analysis JSON from MCP tool output
+        analysis_text = vision_result["content"][0]["text"]
+        analysis = json.loads(analysis_text)
+
+        # If vision returned an error, treat as unsafe (fail-closed)
+        if "error" in analysis:
+            logger.warning(
+                "Styled image safety check failed — vision analysis error: %s | "
+                "original=%s styled=%s theme=%s session=%s",
+                analysis.get("error", "unknown"),
+                original_image_path, styled_image_path, theme, session_id,
+            )
+            return {
+                "used_image_path": original_image_path,
+                "safety_passed": False,
+                "fell_back": True,
+                "flagged_keywords": [],
+                "reason": f"Vision analysis error: {analysis.get('error', 'unknown')}",
+            }
+
+        # Check analysis for unsafe content
+        safety_result = check_styled_image_safety(analysis)
+
+        if not safety_result["safe"]:
+            logger.warning(
+                "Styled image unsafe — falling back to original | "
+                "reason=%s flagged=%s original=%s styled=%s theme=%s session=%s",
+                safety_result["reason"], safety_result["flagged_keywords"],
+                original_image_path, styled_image_path, theme, session_id,
+            )
+            return {
+                "used_image_path": original_image_path,
+                "safety_passed": False,
+                "fell_back": True,
+                "flagged_keywords": safety_result["flagged_keywords"],
+                "reason": safety_result["reason"],
+            }
+
+        # Image is safe — use styled version
+        return {
+            "used_image_path": styled_image_path,
+            "safety_passed": True,
+            "fell_back": False,
+            "flagged_keywords": [],
+            "reason": None,
+        }
+
+    except Exception as exc:
+        # Any exception = fail-closed, use original
+        logger.warning(
+            "Styled image safety validation exception — falling back to original | "
+            "error=%s original=%s styled=%s theme=%s session=%s",
+            str(exc), original_image_path, styled_image_path, theme, session_id,
+        )
+        return {
+            "used_image_path": original_image_path,
+            "safety_passed": False,
+            "fell_back": True,
+            "flagged_keywords": [],
+            "reason": f"Safety validation exception: {str(exc)}",
         }
 
 

--- a/backend/tests/contracts/test_styled_image_safety_contract.py
+++ b/backend/tests/contracts/test_styled_image_safety_contract.py
@@ -1,0 +1,300 @@
+"""
+Contract tests for styled image safety validation (#273).
+
+Verifies:
+- UNSAFE_IMAGE_KEYWORDS list contains required flagged terms
+- check_styled_image_safety returns safe=True for benign analysis
+- check_styled_image_safety returns safe=False for analysis with flagged keywords
+- Fallback to original image when styled image is unsafe
+- Safety check result includes required fields (safe, reason, original_image_path, styled_image_path)
+- validate_and_fallback returns styled path when safe
+- validate_and_fallback returns original path when unsafe
+- Safety failure is logged with full context
+"""
+
+import json
+import logging
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class TestUnsafeImageKeywordsContract:
+    """UNSAFE_IMAGE_KEYWORDS must cover key safety categories."""
+
+    def test_keywords_list_exists(self):
+        from backend.src.mcp_servers.image_style_server import UNSAFE_IMAGE_KEYWORDS
+        assert isinstance(UNSAFE_IMAGE_KEYWORDS, (list, tuple, set, frozenset))
+        assert len(UNSAFE_IMAGE_KEYWORDS) > 0
+
+    def test_violence_keywords_present(self):
+        from backend.src.mcp_servers.image_style_server import UNSAFE_IMAGE_KEYWORDS
+        keywords_lower = {k.lower() for k in UNSAFE_IMAGE_KEYWORDS}
+        violence_terms = {"violence", "weapon", "blood"}
+        assert violence_terms.issubset(keywords_lower), (
+            f"Missing violence keywords: {violence_terms - keywords_lower}"
+        )
+
+    def test_inappropriate_keywords_present(self):
+        from backend.src.mcp_servers.image_style_server import UNSAFE_IMAGE_KEYWORDS
+        keywords_lower = {k.lower() for k in UNSAFE_IMAGE_KEYWORDS}
+        inappropriate_terms = {"nudity", "drug", "horror"}
+        assert inappropriate_terms.issubset(keywords_lower), (
+            f"Missing inappropriate keywords: {inappropriate_terms - keywords_lower}"
+        )
+
+
+class TestCheckStyledImageSafetyContract:
+    """check_styled_image_safety must return correct safety verdicts."""
+
+    def test_safe_analysis_returns_safe(self):
+        from backend.src.mcp_servers.image_style_server import check_styled_image_safety
+
+        safe_analysis = {
+            "objects": ["tree", "sun", "house", "flowers"],
+            "scene": "outdoor park",
+            "mood": "happy",
+            "colors": ["green", "yellow", "blue"],
+            "story_potential": "A happy day in the park",
+            "confidence_score": 0.95,
+        }
+        result = check_styled_image_safety(safe_analysis)
+        assert result["safe"] is True
+        assert result["reason"] is None or result["reason"] == ""
+
+    def test_unsafe_analysis_with_violence_returns_unsafe(self):
+        from backend.src.mcp_servers.image_style_server import check_styled_image_safety
+
+        unsafe_analysis = {
+            "objects": ["weapon", "sword", "shield"],
+            "scene": "battlefield",
+            "mood": "aggressive",
+            "colors": ["red", "black"],
+            "story_potential": "A violent battle scene",
+            "confidence_score": 0.9,
+        }
+        result = check_styled_image_safety(unsafe_analysis)
+        assert result["safe"] is False
+        assert result["reason"]  # Must include a reason
+        assert "weapon" in result["reason"].lower()
+
+    def test_unsafe_analysis_with_horror_returns_unsafe(self):
+        from backend.src.mcp_servers.image_style_server import check_styled_image_safety
+
+        unsafe_analysis = {
+            "objects": ["ghost", "skeleton"],
+            "scene": "haunted house",
+            "mood": "horror",
+            "colors": ["black", "grey"],
+            "story_potential": "A scary night",
+            "confidence_score": 0.85,
+        }
+        result = check_styled_image_safety(unsafe_analysis)
+        assert result["safe"] is False
+
+    def test_result_has_required_fields(self):
+        from backend.src.mcp_servers.image_style_server import check_styled_image_safety
+
+        analysis = {"objects": ["cat"], "mood": "calm"}
+        result = check_styled_image_safety(analysis)
+        assert "safe" in result
+        assert "reason" in result
+        assert "flagged_keywords" in result
+
+    def test_flagged_keywords_returned_on_unsafe(self):
+        from backend.src.mcp_servers.image_style_server import check_styled_image_safety
+
+        analysis = {
+            "objects": ["knife", "blood"],
+            "mood": "scary",
+            "scene": "dark room",
+        }
+        result = check_styled_image_safety(analysis)
+        assert result["safe"] is False
+        assert len(result["flagged_keywords"]) > 0
+
+    def test_empty_analysis_is_safe(self):
+        from backend.src.mcp_servers.image_style_server import check_styled_image_safety
+
+        result = check_styled_image_safety({})
+        assert result["safe"] is True
+
+    def test_keyword_matching_is_case_insensitive(self):
+        from backend.src.mcp_servers.image_style_server import check_styled_image_safety
+
+        analysis = {"objects": ["WEAPON", "Gun"], "mood": "Violence"}
+        result = check_styled_image_safety(analysis)
+        assert result["safe"] is False
+
+
+class TestValidateAndFallbackContract:
+    """validate_and_fallback must return correct image path based on safety."""
+
+    @pytest.mark.asyncio
+    async def test_returns_styled_path_when_safe(self):
+        from backend.src.mcp_servers.image_style_server import validate_and_fallback
+
+        safe_analysis = {
+            "objects": ["tree", "sun"],
+            "mood": "happy",
+            "confidence_score": 0.95,
+        }
+
+        mock_vision = AsyncMock(return_value={
+            "content": [{"type": "text", "text": json.dumps(safe_analysis)}]
+        })
+
+        with patch(
+            "backend.src.mcp_servers.analyze_children_drawing",
+            mock_vision,
+        ):
+            result = await validate_and_fallback(
+                styled_image_path="data/styled/test_cartoon.jpg",
+                original_image_path="data/uploads/test.png",
+                child_age=7,
+                theme="cartoon",
+                session_id="test-session",
+            )
+
+        assert result["used_image_path"] == "data/styled/test_cartoon.jpg"
+        assert result["safety_passed"] is True
+        assert result["fell_back"] is False
+
+    @pytest.mark.asyncio
+    async def test_returns_original_path_when_unsafe(self):
+        from backend.src.mcp_servers.image_style_server import validate_and_fallback
+
+        unsafe_analysis = {
+            "objects": ["weapon", "blood"],
+            "mood": "violence",
+            "confidence_score": 0.9,
+        }
+
+        mock_vision = AsyncMock(return_value={
+            "content": [{"type": "text", "text": json.dumps(unsafe_analysis)}]
+        })
+
+        with patch(
+            "backend.src.mcp_servers.analyze_children_drawing",
+            mock_vision,
+        ):
+            result = await validate_and_fallback(
+                styled_image_path="data/styled/test_cartoon.jpg",
+                original_image_path="data/uploads/test.png",
+                child_age=7,
+                theme="cartoon",
+                session_id="test-session",
+            )
+
+        assert result["used_image_path"] == "data/uploads/test.png"
+        assert result["safety_passed"] is False
+        assert result["fell_back"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_original_on_vision_error(self):
+        """If vision analysis fails, fall back to original (fail-closed)."""
+        from backend.src.mcp_servers.image_style_server import validate_and_fallback
+
+        error_analysis = {"error": "Vision API failed", "objects": []}
+
+        mock_vision = AsyncMock(return_value={
+            "content": [{"type": "text", "text": json.dumps(error_analysis)}]
+        })
+
+        with patch(
+            "backend.src.mcp_servers.analyze_children_drawing",
+            mock_vision,
+        ):
+            result = await validate_and_fallback(
+                styled_image_path="data/styled/test_cartoon.jpg",
+                original_image_path="data/uploads/test.png",
+                child_age=7,
+                theme="cartoon",
+                session_id="test-session",
+            )
+
+        # Fail-closed: if vision errors, discard styled image
+        assert result["used_image_path"] == "data/uploads/test.png"
+        assert result["fell_back"] is True
+
+    @pytest.mark.asyncio
+    async def test_returns_original_on_exception(self):
+        """If vision analysis raises exception, fall back to original."""
+        from backend.src.mcp_servers.image_style_server import validate_and_fallback
+
+        mock_vision = AsyncMock(side_effect=Exception("API timeout"))
+
+        with patch(
+            "backend.src.mcp_servers.analyze_children_drawing",
+            mock_vision,
+        ):
+            result = await validate_and_fallback(
+                styled_image_path="data/styled/test_cartoon.jpg",
+                original_image_path="data/uploads/test.png",
+                child_age=7,
+                theme="cartoon",
+                session_id="test-session",
+            )
+
+        assert result["used_image_path"] == "data/uploads/test.png"
+        assert result["fell_back"] is True
+
+    @pytest.mark.asyncio
+    async def test_result_has_required_fields(self):
+        from backend.src.mcp_servers.image_style_server import validate_and_fallback
+
+        safe_analysis = {"objects": ["cat"], "mood": "calm", "confidence_score": 0.9}
+        mock_vision = AsyncMock(return_value={
+            "content": [{"type": "text", "text": json.dumps(safe_analysis)}]
+        })
+
+        with patch(
+            "backend.src.mcp_servers.analyze_children_drawing",
+            mock_vision,
+        ):
+            result = await validate_and_fallback(
+                styled_image_path="data/styled/test.jpg",
+                original_image_path="data/uploads/test.png",
+                child_age=7,
+                theme="cartoon",
+                session_id="test-session",
+            )
+
+        required_fields = [
+            "used_image_path", "safety_passed", "fell_back",
+            "flagged_keywords", "reason",
+        ]
+        for field in required_fields:
+            assert field in result, f"Missing required field: {field}"
+
+    @pytest.mark.asyncio
+    async def test_safety_failure_logs_warning(self, caplog):
+        """Safety failure must log a warning with context."""
+        from backend.src.mcp_servers.image_style_server import validate_and_fallback
+
+        unsafe_analysis = {
+            "objects": ["weapon"],
+            "mood": "violence",
+            "confidence_score": 0.9,
+        }
+        mock_vision = AsyncMock(return_value={
+            "content": [{"type": "text", "text": json.dumps(unsafe_analysis)}]
+        })
+
+        with patch(
+            "backend.src.mcp_servers.analyze_children_drawing",
+            mock_vision,
+        ):
+            with caplog.at_level(logging.WARNING):
+                await validate_and_fallback(
+                    styled_image_path="data/styled/test_cartoon.jpg",
+                    original_image_path="data/uploads/test.png",
+                    child_age=7,
+                    theme="cartoon",
+                    session_id="test-session",
+                )
+
+        # Should log with context about the failure
+        assert any("unsafe" in r.message.lower() or "safety" in r.message.lower()
+                    for r in caplog.records), (
+            f"Expected safety warning in logs, got: {[r.message for r in caplog.records]}"
+        )


### PR DESCRIPTION
## Summary

Fixes #273
**Parent Epic:** #40

- Add post-generation safety validation for styled images using the existing vision analysis MCP tool
- Implement keyword-based safety heuristic that scans vision analysis output for violence, horror, and inappropriate content
- Fall back to original drawing automatically when styled image is flagged as unsafe (fail-closed design)
- Track safety check results (passed/failed, flagged keywords) in artifact provenance
- Log safety failures with full context: original path, styled path, theme, session, and reason

## Implementation Details

### New functions in `backend/src/mcp_servers/image_style_server.py`:
- `UNSAFE_IMAGE_KEYWORDS` - comprehensive keyword list covering violence, horror, inappropriate content, and distressing themes
- `check_styled_image_safety(analysis)` - pure function that scans vision analysis output for flagged keywords
- `validate_and_fallback(styled_image_path, original_image_path, ...)` - async orchestrator that calls vision analysis, checks safety, and returns fallback decision

### Integration in `backend/src/api/routes/image_to_story.py`:
- Both streaming and non-streaming paths now validate styled images before use
- Provenance steps record `image_safety_passed`, `image_safety_fell_back`, and `image_safety_flagged` fields

### Contract tests in `backend/tests/contracts/test_styled_image_safety_contract.py`:
- 16 tests covering keyword presence, safe/unsafe verdicts, fallback behavior, error handling, logging, and result shape

## Test plan

- [x] All 16 new contract tests pass
- [x] No regressions in existing contract tests (350 passing; 6 pre-existing SdkMcpTool failures unrelated)
- [ ] Manual test: upload drawing with art style, verify styled image is used when safe
- [ ] Manual test: verify fallback to original when vision analysis flags unsafe content
- [ ] Verify provenance records include safety check metadata

Generated with [Claude Code](https://claude.com/claude-code)