### PR TITLE
fix(frontend): handle CJK punctuation in drop cap and deduplicate title

### DIFF
--- a/frontend/src/components/story/StoryDisplay/index.tsx
+++ b/frontend/src/components/story/StoryDisplay/index.tsx
@@ -33,8 +33,11 @@ function StoryDisplay({ story, title, imageUrl, originalImageUrl, styledImageUrl
   const displayImageUrl = hasBothImages
     ? (showStyled ? styledImageUrl : originalImageUrl)
     : imageUrl
-  // Split story text into paragraphs
-  const paragraphs = story.text.split('\n\n').filter(p => p.trim())
+  // Split story text into paragraphs, dedup title from first paragraph
+  const rawParagraphs = story.text.split('\n\n').filter(p => p.trim())
+  const paragraphs = title && rawParagraphs.length > 0 && rawParagraphs[0].trim() === title.trim()
+    ? rawParagraphs.slice(1)
+    : rawParagraphs
 
   return (
     <motion.article
@@ -88,19 +91,43 @@ function StoryDisplay({ story, title, imageUrl, originalImageUrl, styledImageUrl
           </div>
         )}
 
-        {/* Story paragraphs with drop cap */}
+        {/* Story paragraphs with JS-rendered drop cap (handles CJK punctuation) */}
         <div className="story-text">
-          {paragraphs.map((paragraph, index) => (
-            <motion.p
-              key={index}
-              className={`story-paragraph ${index === 0 ? 'first-paragraph' : ''}`}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.2 + index * 0.1, duration: 0.3 }}
-            >
-              {paragraph}
-            </motion.p>
-          ))}
+          {paragraphs.map((paragraph, index) => {
+            if (index === 0) {
+              // Find the first real character, skipping CJK/Western punctuation
+              const match = paragraph.match(/^([\s\u3000-\u303F\uFF00-\uFFEF「」『』【】（）《》〈〉""''、。！？；：，…—·\-–—\[\](){}<>"'.,!?;:]+)?(.)([\s\S]*)/)
+              if (match) {
+                const leading = match[1] || ''
+                const dropChar = match[2]
+                const rest = match[3] || ''
+                return (
+                  <motion.p
+                    key={index}
+                    className="story-paragraph first-paragraph"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: 0.2, duration: 0.3 }}
+                  >
+                    {leading && <span className="text-gray-400">{leading}</span>}
+                    <span className="story-drop-cap">{dropChar}</span>
+                    {rest}
+                  </motion.p>
+                )
+              }
+            }
+            return (
+              <motion.p
+                key={index}
+                className="story-paragraph"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: 0.2 + index * 0.1, duration: 0.3 }}
+              >
+                {paragraph}
+              </motion.p>
+            )
+          })}
         </div>
       </div>
 

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -769,16 +769,16 @@
   text-indent: 0;
 }
 
-/* Drop cap for first paragraph */
-.story-paragraph.first-paragraph::first-letter {
+/* JS-rendered drop cap — handles CJK punctuation correctly */
+.story-drop-cap {
   float: left;
-  font-size: 4rem;
+  font-size: 3.5rem;
   line-height: 1;
   font-weight: bold;
   color: var(--color-primary);
   margin-right: 8px;
   margin-top: 4px;
-  font-family: 'Georgia', serif;
+  font-family: 'Georgia', 'Noto Serif SC', serif;
 }
 
 .story-meta {
@@ -993,8 +993,8 @@
     @apply text-xl;
   }
 
-  .story-paragraph.first-paragraph::first-letter {
-    font-size: 3rem;
+  .story-drop-cap {
+    font-size: 2.8rem;
   }
 
   .tabbed-metadata-tabs {


### PR DESCRIPTION
## Summary
- **CJK drop cap fix**: Replace CSS `::first-letter` (which grabs `《` brackets as the drop cap) with JS-rendered drop cap that uses regex to skip CJK/Western punctuation and find the first real character
- **Title deduplication**: Strip the title from the first paragraph when they match, preventing `《森林守护者》` from appearing both in the header and as paragraph text

Related to #40
**Parent Epic**: #40

## Before / After

| Before | After |
|--------|-------|
| Giant red `《` bracket as drop cap | Correct `还` character as drop cap |
| Title repeated in first paragraph | Title shown only in header |

## Test plan
- [x] Verified via Playwright: drop cap shows `还` not `《`
- [x] Title `《森林守护者》` only in header, not duplicated in body
- [x] TypeScript compiles cleanly
- [x] Text still wraps around floating image on desktop
- [x] Mobile responsive drop cap size (2.8rem)

🤖 Generated with [Claude Code](https://claude.com/claude-code)