### PR TITLE
fix(backend): pass user_id to all preference update calls

### DIFF
--- a/backend/src/api/routes/image_to_story.py
+++ b/backend/src/api/routes/image_to_story.py
@@ -476,7 +476,7 @@ async def create_story_from_image(
 
         # Update child preferences (Advanced Memory)
         try:
-            await preference_repo.update_from_story_result(safe_child_id, result)
+            await preference_repo.update_from_story_result(safe_child_id, result, user_id=user.user_id)
         except Exception:
             pass  # Non-critical: don't fail the request
 
@@ -832,7 +832,7 @@ async def create_story_from_image_stream(
                         logger.debug("store_story_embedding skipped (non-critical)", exc_info=True)
 
                     try:
-                        await preference_repo.update_from_story_result(safe_child_id, result_data)
+                        await preference_repo.update_from_story_result(safe_child_id, result_data, user_id=user.user_id)
                     except Exception:
                         pass
 

--- a/backend/src/api/routes/interactive_story.py
+++ b/backend/src/api/routes/interactive_story.py
@@ -610,10 +610,12 @@ async def choose_story_branch_stream(
                                     "theme": session.theme,
                                     "interests": session.interests,
                                 },
+                                user_id=user.user_id,
                             )
                             if next_data.get("educational_summary"):
                                 await preference_repo.update_from_story_result(
-                                    session.child_id, next_data["educational_summary"]
+                                    session.child_id, next_data["educational_summary"],
+                                    user_id=user.user_id,
                                 )
                         except Exception:
                             pass  # Non-critical
@@ -792,10 +794,12 @@ async def choose_story_branch(
                         "theme": session.theme,
                         "interests": session.interests,
                     },
+                    user_id=user.user_id,
                 )
                 if next_data.get("educational_summary"):
                     await preference_repo.update_from_story_result(
-                        session.child_id, next_data["educational_summary"]
+                        session.child_id, next_data["educational_summary"],
+                        user_id=user.user_id,
                     )
             except Exception:
                 pass  # Non-critical

--- a/backend/src/api/routes/news_to_kids.py
+++ b/backend/src/api/routes/news_to_kids.py
@@ -158,6 +158,7 @@ async def convert_news(
                 child_id=request.child_id,
                 category=request.category.value,
                 key_concepts=result.get("key_concepts", []),
+                user_id=user.user_id,
             )
         except Exception:
             pass  # Non-critical
@@ -359,6 +360,7 @@ async def convert_news_stream(
                             child_id=request.child_id,
                             category=request.category.value,
                             key_concepts=event_data.get("key_concepts", []),
+                            user_id=user.user_id,
                         )
                     except Exception:
                         pass  # Non-critical


### PR DESCRIPTION
## Summary
8 preference update call sites were missing `user_id`, causing writes under `child_id`-only key while reads used `user_id:child_id` composite key. This made the Profile page "Favorite Themes & Interests" appear empty for all content types except Morning Show.

**Parent Epic**: #42

## Fixed Call Sites

| File | Method | Count |
|------|--------|-------|
| `image_to_story.py` | `update_from_story_result` | 2 (sync + stream) |
| `interactive_story.py` | `update_from_choices` + `update_from_story_result` | 4 (2 stream + 2 non-stream) |
| `news_to_kids.py` | `update_from_news` | 2 (sync + stream) |

## Test plan
- [x] 28 preference-related tests pass (scoping, interactive memory, API)
- [ ] Generate interactive story, check profile shows themes from it
- [ ] Generate news article, check profile shows themes from it

🤖 Generated with [Claude Code](https://claude.com/claude-code)