### PR TITLE
feat(quota): per-user daily generation quota and usage tracking (#314)

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -8,11 +8,20 @@ from typing import Optional
 import hmac
 import os
 
-from fastapi import Header, HTTPException, status
+from fastapi import Header, HTTPException, status, Depends
 
 from ..services.user_service import user_service, UserData
-from ..services.database import story_repo, session_repo, db_manager
+from ..services.database import story_repo, session_repo, db_manager, usage_repo
 from ..services.database.session_repository import SessionData
+
+_DEFAULT_DAILY_QUOTA = 3
+
+
+def _get_daily_quota() -> int:
+    try:
+        return int(os.getenv("DAILY_GENERATION_QUOTA", _DEFAULT_DAILY_QUOTA))
+    except (ValueError, TypeError):
+        return _DEFAULT_DAILY_QUOTA
 
 
 def _is_pytest_runtime() -> bool:
@@ -124,6 +133,35 @@ async def get_admin_user(
             detail="Admin privileges required",
         )
 
+    return user
+
+
+async def check_generation_quota(
+    user: UserData = Depends(get_current_user),
+) -> UserData:
+    """Raise HTTP 429 if the user has hit their daily generation quota.
+
+    Usage: user: UserData = Depends(check_generation_quota)
+    The caller receives the same UserData as get_current_user so no extra
+    dep is needed.
+    """
+    if _allow_test_auth_bypass():
+        return user
+
+    quota = _get_daily_quota()
+    used = await usage_repo.get_usage_today(user.user_id)
+    if used >= quota:
+        resets_at = (
+            await usage_repo.get_quota_status(user.user_id, quota)
+        )["resets_at"]
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "error": "quota_exceeded",
+                "quota_remaining": 0,
+                "resets_at": resets_at,
+            },
+        )
     return user
 
 

--- a/backend/src/api/routes/image_to_story.py
+++ b/backend/src/api/routes/image_to_story.py
@@ -25,14 +25,14 @@ from ..models import (
     AgeGroup,
     ArtTheme,
 )
-from ..deps import get_current_user, get_story_for_owner
+from ..deps import get_current_user, get_story_for_owner, check_generation_quota
 from ...agents.image_to_story_agent import (
     image_to_story,
     stream_image_to_story,
     validate_story_length,
 )
 from ...utils.audio_strategy import get_audio_strategy
-from ...services.database import story_repo, preference_repo, character_repo, db_manager
+from ...services.database import story_repo, preference_repo, character_repo, db_manager, usage_repo
 from ...services.user_service import UserData
 from ...services.provenance_tracker import ProvenanceTracker
 from ...services.models.artifact_models import (
@@ -255,7 +255,7 @@ async def create_story_from_image(
     voice: str = Form("nova", description="Voice type"),
     enable_audio: bool = Form(True, description="Whether to generate audio"),
     art_theme: ArtTheme = Form(ArtTheme.NONE, description="Art style theme for image transformation"),
-    user: UserData = Depends(get_current_user),
+    user: UserData = Depends(check_generation_quota),
 ):
     """
     Image to Story API
@@ -439,6 +439,7 @@ async def create_story_from_image(
         }
         story_data["user_id"] = user.user_id
         await story_repo.create(story_data)
+        await usage_repo.increment(user.user_id, "image_to_story")  # quota tracking (#314)
 
         # Store story embedding for dedup detection (#290)
         try:
@@ -634,7 +635,7 @@ async def create_story_from_image_stream(
     voice: str = Form("nova", description="Voice type"),
     enable_audio: bool = Form(True, description="Whether to generate audio"),
     art_theme: ArtTheme = Form(ArtTheme.NONE, description="Art style theme for image transformation"),
-    user: UserData = Depends(get_current_user),
+    user: UserData = Depends(check_generation_quota),
 ):
     """
     Streaming Image to Story API
@@ -773,6 +774,7 @@ async def create_story_from_image_stream(
                     story_save_data = {**response_data, "child_id": safe_child_id, "age_group": age_group.value, "image_path": str(image_path), "art_theme": art_theme.value if art_theme != ArtTheme.NONE else None, "styled_image_path": styled_image_path, "cover_image_url": cover_image_url}
                     story_save_data["user_id"] = user.user_id
                     await story_repo.create(story_save_data)
+                    await usage_repo.increment(user.user_id, "image_to_story")  # quota tracking (#314)
 
                     # Store story embedding for dedup detection (#290)
                     try:

--- a/backend/src/api/routes/interactive_story.py
+++ b/backend/src/api/routes/interactive_story.py
@@ -29,8 +29,8 @@ from ..models import (
     AgeGroup,
     SessionStatus as SessionStatusEnum
 )
-from ..deps import get_current_user, get_session_for_owner
-from ...services.database import session_repo, story_repo, preference_repo, character_repo, db_manager
+from ..deps import get_current_user, get_session_for_owner, check_generation_quota
+from ...services.database import session_repo, story_repo, preference_repo, character_repo, db_manager, usage_repo
 from ...services.user_service import UserData
 from ...services.provenance_tracker import ProvenanceTracker
 from ...services.models.artifact_models import (
@@ -94,7 +94,7 @@ async def _check_story_safety(text: str, age_group: str) -> float:
 )
 async def start_interactive_story(
     request: InteractiveStoryStartRequest,
-    user: UserData = Depends(get_current_user),
+    user: UserData = Depends(check_generation_quota),
 ):
     """
     Start an interactive story
@@ -150,6 +150,7 @@ async def start_interactive_story(
             total_segments=total_segments,
             user_id=user.user_id,
         )
+        await usage_repo.increment(user.user_id, "interactive_story")  # quota tracking (#314)
 
         # 3. Save opening segment
         segment_data = opening_data["segment"]
@@ -265,7 +266,7 @@ async def start_interactive_story(
 async def start_interactive_story_stream(
     http_request: Request,
     request: InteractiveStoryStartRequest,
-    user: UserData = Depends(get_current_user),
+    user: UserData = Depends(check_generation_quota),
 ):
     """
     Start an interactive story with streaming
@@ -355,6 +356,7 @@ async def start_interactive_story_stream(
                         total_segments=total_segments,
                         user_id=user.user_id,
                     )
+                    await usage_repo.increment(user.user_id, "interactive_story")  # quota tracking (#314)
 
                     # Save opening segment
                     segment_data = opening_data.get("segment", {})

--- a/backend/src/api/routes/morning_show.py
+++ b/backend/src/api/routes/morning_show.py
@@ -38,7 +38,8 @@ from ...services.tts_service import generate_multi_speaker_audio
 from ...services.user_service import UserData
 from ...utils.text import count_words
 from ...paths import AUDIO_DIR, UPLOAD_DIR
-from ..deps import get_current_user
+from ..deps import get_current_user, check_generation_quota
+from ...services.database import usage_repo
 from ..models import (
     DialogueScript,
     EpisodeIllustration,
@@ -608,9 +609,11 @@ async def _build_episode(
 )
 async def generate_morning_show(
     request: MorningShowRequest,
-    user: UserData = Depends(get_current_user),
+    user: UserData = Depends(check_generation_quota),
 ):
-    return await _build_episode(request, user)
+    result = await _build_episode(request, user)
+    await usage_repo.increment(user.user_id, "morning_show")  # quota tracking (#314)
+    return result
 
 
 @router.post(
@@ -620,7 +623,7 @@ async def generate_morning_show(
 async def generate_morning_show_stream(
     http_request: Request,
     request: MorningShowRequest,
-    user: UserData = Depends(get_current_user),
+    user: UserData = Depends(check_generation_quota),
 ):
     if not request.news_url and not request.news_text:
         raise HTTPException(
@@ -659,6 +662,7 @@ async def generate_morning_show_stream(
             return
 
         response = await _build_episode(request, user)
+        await usage_repo.increment(user.user_id, "morning_show")  # quota tracking (#314)
 
         yield f"event: result\ndata: {json.dumps(response.model_dump(mode='json'), ensure_ascii=False)}\n\n"
         yield f"event: complete\ndata: {json.dumps({'message': 'Morning Show generation complete'}, ensure_ascii=False)}\n\n"

--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -1,0 +1,30 @@
+"""Usage / quota API routes.
+
+Exposes the current user's daily generation quota status so the
+frontend can display "X of 3 used today".
+
+Issue: #314 | Parent Epic: #313
+"""
+
+from fastapi import APIRouter, Depends
+
+from ..deps import get_current_user, _get_daily_quota
+from ...services.user_service import UserData
+from ...services.database import usage_repo
+
+router = APIRouter(
+    prefix="/api/v1/usage",
+    tags=["Usage"],
+)
+
+
+@router.get(
+    "/today",
+    summary="Get today's generation quota status",
+)
+async def get_usage_today(
+    user: UserData = Depends(get_current_user),
+):
+    """Return the current user's daily generation usage and remaining quota."""
+    quota = _get_daily_quota()
+    return await usage_repo.get_quota_status(user.user_id, limit=quota)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -297,6 +297,7 @@ from .api.routes import (
     admin_artifacts,
     library,
     memory,
+    usage,
 )
 
 app.include_router(image_to_story.router)
@@ -312,6 +313,7 @@ app.include_router(artifacts.router)
 app.include_router(admin_artifacts.router)
 app.include_router(library.router)
 app.include_router(memory.router)
+app.include_router(usage.router)
 
 
 # ============================================================================

--- a/backend/src/services/database/__init__.py
+++ b/backend/src/services/database/__init__.py
@@ -18,6 +18,7 @@ from .subscription_repository import (
     DuplicateSubscriptionError,
     MaxSubscriptionsExceededError,
 )
+from .usage_repository import UsageRepository, usage_repo
 
 __all__ = [
     "DatabaseManager",
@@ -41,4 +42,6 @@ __all__ = [
     "subscription_repo",
     "DuplicateSubscriptionError",
     "MaxSubscriptionsExceededError",
+    "UsageRepository",
+    "usage_repo",
 ]

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -236,6 +236,25 @@ CREATE INDEX IF NOT EXISTS idx_cloned_voices_child_id ON cloned_voices(child_id)
 CREATE INDEX IF NOT EXISTS idx_cloned_voices_active ON cloned_voices(is_active);
 """
 
+# ============================================================================
+# Daily Usage Table (#314)
+# ============================================================================
+
+DAILY_USAGE_TABLE = """
+CREATE TABLE IF NOT EXISTS daily_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id TEXT NOT NULL,
+    usage_date TEXT NOT NULL,
+    feature TEXT NOT NULL,
+    count INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(user_id, usage_date, feature)
+);
+"""
+
+DAILY_USAGE_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_daily_usage_user_date ON daily_usage(user_id, usage_date);
+"""
+
 
 # ============================================================================
 # Schema Initialization
@@ -309,6 +328,15 @@ async def init_schema(db: "DatabaseManager") -> None:
     # Create cloned voices table (#150)
     await db.execute(CLONED_VOICES_TABLE)
     for stmt in CLONED_VOICES_INDEXES.strip().split(";"):
+        if stmt.strip():
+            try:
+                await db.execute(stmt)
+            except Exception:
+                pass
+
+    # Create daily usage quota table (#314)
+    await db.execute(DAILY_USAGE_TABLE)
+    for stmt in DAILY_USAGE_INDEXES.strip().split(";"):
         if stmt.strip():
             try:
                 await db.execute(stmt)

--- a/backend/src/services/database/usage_repository.py
+++ b/backend/src/services/database/usage_repository.py
@@ -1,0 +1,62 @@
+"""Usage repository — daily AI generation quota tracking.
+
+Tracks how many AI generations each user has consumed on a given date.
+All features share a single daily pool (image_to_story, interactive_story,
+morning_show all count against the same limit).
+
+Issue: #314 | Parent Epic: #313
+"""
+
+from datetime import date, timedelta
+from typing import Dict, Any
+
+from .connection import db_manager
+
+
+class UsageRepository:
+    def __init__(self):
+        self._db = db_manager
+
+    async def get_usage_today(self, user_id: str) -> int:
+        """Return total generation count for user_id today (UTC date)."""
+        today = date.today().isoformat()
+        row = await self._db.fetchone(
+            "SELECT COALESCE(SUM(count), 0) as total FROM daily_usage WHERE user_id = ? AND usage_date = ?",
+            (user_id, today),
+        )
+        if row is None:
+            return 0
+        return int(row["total"])
+
+    async def increment(self, user_id: str, feature: str) -> None:
+        """Increment usage count for user_id + feature by 1 for today.
+
+        Uses INSERT OR REPLACE with count+1 so it's safe to call without
+        checking whether the row exists first.
+        """
+        today = date.today().isoformat()
+        await self._db.execute(
+            """
+            INSERT INTO daily_usage (user_id, usage_date, feature, count)
+            VALUES (?, ?, ?, 1)
+            ON CONFLICT(user_id, usage_date, feature)
+            DO UPDATE SET count = count + 1
+            """,
+            (user_id, today, feature),
+        )
+        await self._db.commit()
+
+    async def get_quota_status(self, user_id: str, limit: int) -> Dict[str, Any]:
+        """Return full quota status dict for the API response."""
+        used = await self.get_usage_today(user_id)
+        remaining = max(0, limit - used)
+        tomorrow = (date.today() + timedelta(days=1)).isoformat()
+        return {
+            "used": used,
+            "limit": limit,
+            "remaining": remaining,
+            "resets_at": f"{tomorrow}T00:00:00Z",
+        }
+
+
+usage_repo = UsageRepository()

--- a/backend/tests/contracts/test_usage_repository_contract.py
+++ b/backend/tests/contracts/test_usage_repository_contract.py
@@ -1,0 +1,104 @@
+"""Contract tests for UsageRepository — daily generation quota tracking.
+
+Verifies the schema and query invariants before implementation.
+
+Issue: #314 | Parent Epic: #313
+"""
+
+import pytest
+from datetime import date, timedelta
+
+from src.services.database.connection import DatabaseManager
+from src.services.database.usage_repository import UsageRepository
+from src.services.database.schema import init_schema
+
+
+@pytest.fixture
+async def repo():
+    manager = DatabaseManager(":memory:")
+    await manager.connect()
+    await init_schema(manager)
+    repo = UsageRepository()
+    repo._db = manager
+    yield repo
+    await manager.disconnect()
+
+
+class TestGetUsageToday:
+    async def test_returns_zero_for_new_user(self, repo):
+        result = await repo.get_usage_today("user_a")
+        assert result == 0
+
+    async def test_returns_correct_count_after_increment(self, repo):
+        await repo.increment("user_a", "image_to_story")
+        await repo.increment("user_a", "image_to_story")
+        result = await repo.get_usage_today("user_a")
+        assert result == 2
+
+    async def test_different_features_share_daily_pool(self, repo):
+        await repo.increment("user_a", "image_to_story")
+        await repo.increment("user_a", "interactive_story")
+        result = await repo.get_usage_today("user_a")
+        assert result == 2
+
+    async def test_different_users_are_independent(self, repo):
+        await repo.increment("user_a", "image_to_story")
+        await repo.increment("user_a", "image_to_story")
+        await repo.increment("user_b", "image_to_story")
+        assert await repo.get_usage_today("user_a") == 2
+        assert await repo.get_usage_today("user_b") == 1
+
+    async def test_only_counts_todays_usage(self, repo):
+        yesterday = (date.today() - timedelta(days=1)).isoformat()
+        await repo._db.execute(
+            "INSERT INTO daily_usage (user_id, usage_date, feature, count) VALUES (?, ?, ?, ?)",
+            ("user_a", yesterday, "image_to_story", 5),
+        )
+        await repo._db.commit()
+        result = await repo.get_usage_today("user_a")
+        assert result == 0
+
+
+class TestIncrement:
+    async def test_first_increment_creates_row(self, repo):
+        await repo.increment("user_a", "image_to_story")
+        result = await repo.get_usage_today("user_a")
+        assert result == 1
+
+    async def test_second_increment_updates_row(self, repo):
+        await repo.increment("user_a", "image_to_story")
+        await repo.increment("user_a", "image_to_story")
+        result = await repo.get_usage_today("user_a")
+        assert result == 2
+
+    async def test_increment_is_idempotent_per_feature(self, repo):
+        for _ in range(5):
+            await repo.increment("user_a", "interactive_story")
+        result = await repo.get_usage_today("user_a")
+        assert result == 5
+
+
+class TestGetQuotaStatus:
+    async def test_returns_full_status_dict(self, repo):
+        status = await repo.get_quota_status("user_a", limit=3)
+        assert status["used"] == 0
+        assert status["limit"] == 3
+        assert status["remaining"] == 3
+        assert "resets_at" in status
+
+    async def test_remaining_decreases_after_use(self, repo):
+        await repo.increment("user_a", "image_to_story")
+        status = await repo.get_quota_status("user_a", limit=3)
+        assert status["used"] == 1
+        assert status["remaining"] == 2
+
+    async def test_remaining_never_negative(self, repo):
+        for _ in range(5):
+            await repo.increment("user_a", "image_to_story")
+        status = await repo.get_quota_status("user_a", limit=3)
+        assert status["remaining"] == 0
+
+    async def test_resets_at_is_tomorrow_midnight_utc(self, repo):
+        status = await repo.get_quota_status("user_a", limit=3)
+        tomorrow = (date.today() + timedelta(days=1)).isoformat()
+        assert status["resets_at"].startswith(tomorrow)

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -932,7 +932,13 @@ Month 3: 儿童创作了 20+ 个故事，形成自己的"故事宇宙"
 - ✅ 基础记忆（识别重复角色）
 - 🔲 我的创作库（统一内容浏览、搜索、收藏）
 
-### Phase 2 - 第二阶段
+### Phase 2 - 第二阶段 (Launch Gate — §3.9)
+
+**生产发布前置条件 (blocks public launch)**:
+- 🔲 每用户每日生成配额 + 用量追踪（§3.9.1）
+- 🔲 邮箱注册 + 邮件验证（§3.9.2）
+- 🔲 Railway 后端部署 + Vercel 前端部署（§3.9.3）
+- 🔲 "Buy Me a Coffee" 捐赠入口（§3.9.4）
 
 **应该有**:
 - ✅ 互动故事生成（多分支）— 核心流程已完成，增强功能见 §3.2
@@ -1012,6 +1018,58 @@ Month 3: 儿童创作了 20+ 个故事，形成自己的"故事宇宙"
 
 ---
 
+## 3.9 Production Launch & Cost Sustainability [Phase 2 — Launch Gate]
+
+Goal: deploy the product to a public URL so real users can register and use it, while keeping AI API costs predictable.
+
+### 3.9.1 Per-User Generation Quota
+
+Every authenticated user has a daily generation quota (default: **3 AI generations per day**, resets midnight UTC).
+Quota covers: image-to-story, interactive story opening, morning show episode generation.
+
+**Acceptance Criteria:**
+- [ ] `usage_repository` tracks (user_id, date, feature, count) in SQLite
+- [ ] Quota middleware returns HTTP 429 with `{"quota_remaining": 0, "resets_at": "..."}` when exceeded
+- [ ] Frontend shows "X / 3 generations used today" on UploadPage and InteractiveStory start screen
+- [ ] Quota is configurable via env var `DAILY_GENERATION_QUOTA` (default 3)
+
+### 3.9.2 Email-Based Account Registration
+
+Users register with email + password. A verification email must be confirmed before AI features are accessible.
+Prevents throwaway accounts that drain quota.
+
+**Acceptance Criteria:**
+- [ ] Registration requires email + password (min 8 chars)
+- [ ] Verification email sent on signup; unverified accounts blocked from AI endpoints
+- [ ] Password reset flow (email link)
+- [ ] Implementation: Supabase Auth (free tier) or self-hosted with FastAPI + email via SendGrid free tier
+
+### 3.9.3 Production Hosting
+
+| Layer | Service | Notes |
+|-------|---------|-------|
+| Frontend | Vercel (free) | Auto-deploys from `main` |
+| Backend | Railway ($5–7/month) | FastAPI + SQLite + ChromaDB on same instance |
+| Domain | Optional Cloudflare domain | ~$10/year |
+
+**Acceptance Criteria:**
+- [ ] Backend live at a stable public URL with all env vars set
+- [ ] Frontend live on Vercel pointing to backend URL via `VITE_API_BASE_URL`
+- [ ] CORS configured for production frontend origin
+- [ ] Health check endpoint returns 200
+
+### 3.9.4 "Buy Me a Coffee" Donation Widget
+
+A voluntary tip widget on the home or profile page. Non-commercial — users choose to donate.
+Lets the creator receive appreciation without gating any features.
+
+**Acceptance Criteria:**
+- [ ] BMC widget/button visible on HomePage or ProfilePage
+- [ ] Clicking opens buymeacoffee.com/[creator] in a new tab
+- [ ] Does not obstruct any child-facing UI
+
+---
+
 ## 8. 风险与限制
 
 ### 产品风险
@@ -1024,12 +1082,15 @@ Month 3: 儿童创作了 20+ 个故事，形成自己的"故事宇宙"
 - **隐私担忧**: 家长担心儿童数据安全
   - 缓解：符合 COPPA 标准，透明的隐私政策
 
+- **API 成本失控**: 真实用户大量使用 AI 接口导致费用超出预算
+  - 缓解：每用户每日配额限制（§3.9.1）+ Anthropic/OpenAI 控制台月度消费上限（外部硬限制）
+
 ### 技术限制
 - **生成速度**: AI 生成需要 5-10 秒
   - 缓解：优化模型，使用流式输出
 
 - **成本**: TTS 和 AI 调用成本较高
-  - 缓解：缓存常用内容，批量处理
+  - 缓解：每用户配额限制（3次/天）；缓存常用内容；批量处理
 
 ---
 


### PR DESCRIPTION
## Summary

- `daily_usage` SQLite table — tracks `(user_id, usage_date, feature, count)` with ON CONFLICT upsert
- `UsageRepository` — `get_usage_today`, `increment`, `get_quota_status`
- `check_generation_quota` FastAPI dependency — raises HTTP 429 when daily limit exceeded (default: 3/day, configurable via `DAILY_GENERATION_QUOTA` env var)
- `GET /api/v1/usage/today` — returns `{used, limit, remaining, resets_at}` for frontend display
- Quota enforced on all 6 AI generation endpoints (image-to-story sync/stream, interactive-story sync/stream, morning-show sync/stream)
- Usage only incremented after successful story/session save — failed/errored generations never count against quota

Fixes #314
**Parent Epic**: #313

## Test plan
- [x] `pytest tests/contracts/test_usage_repository_contract.py` — 12/12 passed
- [x] `pytest tests/contracts/test_character_repository_contract.py tests/api/test_memory.py` — 26/26 passed (no regressions)
- [ ] Manual: generate 3 stories → 4th returns 429 with `quota_exceeded` body
- [ ] Manual: `GET /api/v1/usage/today` returns correct `remaining` count

🤖 Generated with [Claude Code](https://claude.com/claude-code)