### PR TITLE
fix(backend,frontend): resolve child_id for profile preferences across all content types

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -11,7 +11,7 @@ import re
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..deps import get_current_user
-from ...services.database import preference_repo, character_repo
+from ...services.database import preference_repo, character_repo, story_repo
 from ...services.theme_recommender import theme_recommender
 from ...services.user_service import UserData
 
@@ -127,3 +127,18 @@ async def get_recommendations(
         user.user_id, child_id, limit=limit,
     )
     return {"child_id": child_id, "recommendations": recommendations}
+
+
+@router.get(
+    "/child-id",
+    summary="Get user's primary child_id",
+)
+async def get_child_id(
+    user: UserData = Depends(get_current_user),
+):
+    """Return the child_id most recently used by this user, derived from story history."""
+    row = await story_repo._db.fetchone(
+        "SELECT child_id FROM stories WHERE user_id = ? ORDER BY created_at DESC LIMIT 1",
+        (user.user_id,),
+    )
+    return {"child_id": row["child_id"] if row else None}

--- a/backend/src/services/database/preference_repository.py
+++ b/backend/src/services/database/preference_repository.py
@@ -104,7 +104,14 @@ class PreferenceRepository:
 
     async def get_profile(self, child_id: str, *, user_id: str = "") -> Dict[str, Any]:
         key = self._composite_key(user_id, child_id) if user_id else child_id
-        return await self._get_profile(key)
+        profile = await self._get_profile(key)
+        # Fallback: if composite key is empty, try bare child_id and migrate
+        if user_id and self._is_empty_profile(profile):
+            legacy = await self._get_profile(child_id)
+            if not self._is_empty_profile(legacy):
+                await self._save_profile(key, legacy)
+                profile = legacy
+        return profile
 
     async def get_profile_with_metadata(self, child_id: str, *, user_id: str = "") -> Dict[str, Any]:
         """Return profile with data_collected_since and last_updated_at timestamps."""
@@ -113,6 +120,21 @@ class PreferenceRepository:
             "SELECT profile_json, updated_at FROM child_preferences WHERE child_id = ?",
             (key,),
         )
+        # Fallback: if composite key has no row, try bare child_id and migrate
+        if not row and user_id:
+            legacy_row = await self._db.fetchone(
+                "SELECT profile_json, updated_at FROM child_preferences WHERE child_id = ?",
+                (child_id,),
+            )
+            if legacy_row:
+                row = legacy_row
+                # Migrate: copy to composite key so future reads hit it directly
+                try:
+                    loaded = json.loads(legacy_row.get("profile_json") or "{}")
+                    await self._save_profile(key, self._normalize_profile(loaded))
+                except Exception:
+                    pass
+
         if not row:
             profile = self._empty_profile()
             return {"profile": profile, "data_collected_since": None, "last_updated_at": None}
@@ -176,6 +198,15 @@ class PreferenceRepository:
             (child_id, json.dumps(payload, ensure_ascii=False), now),
         )
         await self._db.commit()
+
+    def _is_empty_profile(self, profile: Dict[str, Any]) -> bool:
+        """Check if a profile has no meaningful data."""
+        return (
+            not profile.get("themes")
+            and not profile.get("concepts")
+            and not profile.get("interests")
+            and not profile.get("recent_choices")
+        )
 
     def _empty_profile(self) -> Dict[str, Any]:
         return {

--- a/frontend/src/api/services/memoryService.ts
+++ b/frontend/src/api/services/memoryService.ts
@@ -43,6 +43,16 @@ export const memoryService = {
   },
 
   /**
+   * Get user's primary child_id from story history
+   */
+  async getChildId(): Promise<{ child_id: string | null }> {
+    const response = await apiClient.get<{ child_id: string | null }>(
+      `${MEMORY_BASE}/child-id`
+    )
+    return response.data
+  },
+
+  /**
    * Get personalised theme recommendations based on preference history (#292)
    */
   async getRecommendations(

--- a/frontend/src/hooks/useMemoryApi.ts
+++ b/frontend/src/hooks/useMemoryApi.ts
@@ -1,5 +1,8 @@
 /**
  * useMemoryApi - React Query hook for character gallery and preference data
+ *
+ * When childId is null, automatically resolves the user's primary child_id
+ * from story history via GET /memory/child-id.
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -8,14 +11,24 @@ import { memoryService } from '@/api/services/memoryService'
 export function useMemoryApi(childId: string | null) {
   const queryClient = useQueryClient()
 
+  // Auto-resolve child_id from story history when not provided
+  const { data: resolvedChildData } = useQuery({
+    queryKey: ['memory-child-id'],
+    queryFn: () => memoryService.getChildId(),
+    enabled: !childId,
+    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
+  })
+
+  const effectiveChildId = childId || resolvedChildData?.child_id || null
+
   const {
     data: charactersData,
     isLoading: charactersLoading,
     error: charactersError,
   } = useQuery({
-    queryKey: ['memory-characters', childId],
-    queryFn: () => memoryService.getCharacters(childId!),
-    enabled: !!childId,
+    queryKey: ['memory-characters', effectiveChildId],
+    queryFn: () => memoryService.getCharacters(effectiveChildId!),
+    enabled: !!effectiveChildId,
   })
 
   const {
@@ -23,20 +36,21 @@ export function useMemoryApi(childId: string | null) {
     isLoading: preferencesLoading,
     error: preferencesError,
   } = useQuery({
-    queryKey: ['memory-preferences', childId],
-    queryFn: () => memoryService.getPreferences(childId!),
-    enabled: !!childId,
+    queryKey: ['memory-preferences', effectiveChildId],
+    queryFn: () => memoryService.getPreferences(effectiveChildId!),
+    enabled: !!effectiveChildId,
   })
 
   const deletePreferencesMutation = useMutation({
-    mutationFn: () => memoryService.deletePreferences(childId!),
+    mutationFn: () => memoryService.deletePreferences(effectiveChildId!),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['memory-characters', childId] })
-      queryClient.invalidateQueries({ queryKey: ['memory-preferences', childId] })
+      queryClient.invalidateQueries({ queryKey: ['memory-characters', effectiveChildId] })
+      queryClient.invalidateQueries({ queryKey: ['memory-preferences', effectiveChildId] })
     },
   })
 
   return {
+    childId: effectiveChildId,
     characters: charactersData?.characters ?? [],
     preferences: preferencesData?.profile ?? null,
     isLoading: charactersLoading || preferencesLoading,

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -23,8 +23,8 @@ const ANIMAL_EMOJIS = [
 function ProfilePage() {
   const navigate = useNavigate()
   const { isAuthenticated, user, setUser } = useAuthStore()
-  const { currentChild, defaultChildId } = useChildStore()
-  const childId = currentChild?.child_id || defaultChildId
+  const { currentChild } = useChildStore()
+  const childId = currentChild?.child_id || null
   const [isEditing, setIsEditing] = useState(false)
   const [editForm, setEditForm] = useState<UpdateProfileRequest>({
     display_name: user?.display_name || '',


### PR DESCRIPTION
## Summary
Profile page "Favorite Themes and Interests" was always empty despite the user having stories. Three root causes fixed:

1. **Missing child_id resolution**: Frontend used a random `defaultChildId` from Zustand store that never matched the real child_id in the DB. Added `GET /memory/child-id` endpoint and auto-resolution in `useMemoryApi`.

2. **Orphaned preference data**: Preference writes used bare `child_id` key but reads used `user_id:child_id` composite key. Added fallback-and-migrate in `PreferenceRepository.get_profile` and `get_profile_with_metadata`.

3. **Missing user_id on writes**: Previously fixed in PR #317 — 8 call sites now pass `user_id`.

**Parent Epic**: #42

## Verified via Playwright
- Characters gallery: 小默 (x2), 小松鼠 (x1), 幽灵豹 (x1)
- Themes: 人与自然和谐共处, 幽灵豹的传说, 自然探索, 珍视内心的美好, 观察与记录
- Interests: Forest, Magic
- Data includes themes from BOTH image-to-story AND interactive story

## Test plan
- [x] 29 preference-related tests pass
- [x] TypeScript compiles cleanly
- [x] Playwright: profile shows themes from art stories + interactive stories
- [x] New `/memory/child-id` endpoint returns correct child_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)