### PR TITLE
chore(infra): add Railway and Vercel deployment configs (#315, #316)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,9 @@ DAILY_DROP_RATE_LIMIT_SECONDS=2
 # 应用配置
 ENVIRONMENT=development
 LOG_LEVEL=INFO
+
+# Production / Deployment
+ALLOWED_ORIGINS=https://your-app.vercel.app
+SECRET_KEY=change-me-in-production
+DATA_DIR=./data
+DAILY_GENERATION_QUOTA=3

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,0 +1,1 @@
+web: cd backend && python -m uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/backend/railway.toml
+++ b/backend/railway.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "nixpacks"
+
+[deploy]
+startCommand = "cd backend && python -m uvicorn src.main:app --host 0.0.0.0 --port ${PORT:-8000}"
+healthcheckPath = "/health"
+healthcheckTimeout = 300
+restartPolicyType = "on_failure"
+restartPolicyMaxRetries = 3

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -107,13 +107,20 @@ app = FastAPI(
 # CORS Middleware
 # ============================================================================
 
+_default_origins = "http://localhost:3000,http://localhost:5173"
+_allowed_origins = [
+    origin.strip()
+    for origin in os.getenv("ALLOWED_ORIGINS", _default_origins).split(",")
+    if origin.strip()
+]
+# Keep FRONTEND_URL for backward compatibility
+_frontend_url = os.getenv("FRONTEND_URL", "")
+if _frontend_url and _frontend_url not in _allowed_origins:
+    _allowed_origins.append(_frontend_url)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",  # React frontend
-        "http://localhost:5173",  # Vite frontend
-        os.getenv("FRONTEND_URL", "http://localhost:3000")
-    ],
+    allow_origins=_allowed_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- Add `backend/railway.toml` and `backend/Procfile` for Railway backend deployment
- Add `frontend/vercel.json` with SPA rewrite rules for Vercel frontend deployment
- Update CORS in `backend/src/main.py` to read from `ALLOWED_ORIGINS` env var (comma-separated) instead of hardcoded origins
- Extend `backend/.env.example` with production env vars (`ALLOWED_ORIGINS`, `SECRET_KEY`, `DATA_DIR`, `DAILY_GENERATION_QUOTA`)

Related to #315
Related to #316
**Parent Epic**: #313

## Test plan
- [ ] Verify `backend/railway.toml` is picked up by Railway on deploy
- [ ] Verify `frontend/vercel.json` rewrites work for SPA client-side routing
- [ ] Verify CORS accepts origins from `ALLOWED_ORIGINS` env var
- [ ] Verify backward compatibility with `FRONTEND_URL` env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)