### PR TITLE
feat(auth): Supabase Auth with backward-compatible legacy fallback (#318)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,9 @@ DAILY_DROP_RATE_LIMIT_SECONDS=2
 ENVIRONMENT=development
 LOG_LEVEL=INFO
 
+# Supabase Auth (#318)
+SUPABASE_JWT_SECRET=your-supabase-jwt-secret
+
 # Production / Deployment
 ALLOWED_ORIGINS=https://your-app.vercel.app
 SECRET_KEY=change-me-in-production

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -28,6 +28,9 @@ tavily-python==0.5.0
 # Database
 aiosqlite>=0.19.0
 
+# Auth (Supabase JWT validation)
+PyJWT[crypto]>=2.8.0
+
 # Utilities
 pyyaml==6.0.1
 

--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -11,8 +11,9 @@ import os
 from fastapi import Header, HTTPException, status, Depends
 
 from ..services.user_service import user_service, UserData
-from ..services.database import story_repo, session_repo, db_manager, usage_repo
+from ..services.database import story_repo, session_repo, db_manager, usage_repo, user_repo
 from ..services.database.session_repository import SessionData
+from ..services.supabase_auth import decode_supabase_token
 
 _DEFAULT_DAILY_QUOTA = 3
 
@@ -93,7 +94,17 @@ async def get_current_user(authorization: Optional[str] = Header(None)) -> UserD
             detail="Invalid authentication token format",
         )
 
-    user = await user_service.validate_token(parts[1])
+    token = parts[1]
+
+    # Try Supabase JWT first (if SUPABASE_JWT_SECRET is configured)
+    claims = decode_supabase_token(token)
+    if claims:
+        user = await _get_or_create_supabase_user(claims)
+        if user:
+            return user
+
+    # Fall back to legacy custom token validation
+    user = await user_service.validate_token(token)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -101,6 +112,41 @@ async def get_current_user(authorization: Optional[str] = Header(None)) -> UserD
         )
 
     return user
+
+
+async def _get_or_create_supabase_user(claims) -> Optional[UserData]:
+    """Look up local user by Supabase UID, or auto-create one."""
+    from datetime import datetime
+
+    user = await user_repo.get_by_id(claims.sub)
+    if user:
+        return user
+
+    # Auto-create local user from Supabase claims
+    now = datetime.now().isoformat()
+    username = claims.email.split("@")[0][:50] if claims.email else claims.sub[:50]
+
+    # Ensure unique username
+    existing = await user_repo.get_by_username(username)
+    if existing:
+        username = f"{username}_{claims.sub[:8]}"
+
+    now = datetime.now().isoformat()
+    await db_manager.execute(
+        """
+        INSERT OR IGNORE INTO users (
+            user_id, username, email, password_hash, display_name,
+            is_active, is_verified, role, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            claims.sub, username, claims.email, "supabase_managed",
+            username, 1, 1 if claims.email_confirmed else 0,
+            "child", now, now,
+        ),
+    )
+    await db_manager.commit()
+    return await user_repo.get_by_id(claims.sub)
 
 
 async def get_admin_user(

--- a/backend/src/services/supabase_auth.py
+++ b/backend/src/services/supabase_auth.py
@@ -1,0 +1,71 @@
+"""Supabase JWT token validation.
+
+Validates access tokens issued by Supabase Auth. Extracts the user's
+Supabase UID and email from the JWT claims so the backend can look up
+or auto-create a matching local user row.
+
+Issue: #318 | Parent Epic: #313
+"""
+
+import os
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import jwt
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SupabaseClaims:
+    """Decoded Supabase JWT claims relevant to user identification."""
+    sub: str          # Supabase user ID (UUID)
+    email: str
+    email_confirmed: bool
+
+
+def get_jwt_secret() -> Optional[str]:
+    """Return the Supabase JWT secret from env, or None if not configured."""
+    return os.getenv("SUPABASE_JWT_SECRET")
+
+
+def decode_supabase_token(token: str) -> Optional[SupabaseClaims]:
+    """Decode and validate a Supabase access token.
+
+    Returns SupabaseClaims on success, None if the token is invalid or
+    SUPABASE_JWT_SECRET is not configured (allows graceful fallback to
+    legacy auth).
+    """
+    secret = get_jwt_secret()
+    if not secret:
+        return None
+
+    try:
+        payload = jwt.decode(
+            token,
+            secret,
+            algorithms=["HS256"],
+            audience="authenticated",
+        )
+        sub = payload.get("sub")
+        email = payload.get("email", "")
+        # Supabase puts email confirmation in app_metadata or user_metadata
+        user_meta = payload.get("user_metadata", {})
+        email_confirmed = payload.get("email_confirmed_at") is not None or \
+            user_meta.get("email_verified", False)
+
+        if not sub:
+            return None
+
+        return SupabaseClaims(
+            sub=sub,
+            email=email,
+            email_confirmed=email_confirmed,
+        )
+    except jwt.ExpiredSignatureError:
+        logger.debug("Supabase token expired")
+        return None
+    except jwt.InvalidTokenError as e:
+        logger.debug("Invalid Supabase token: %s", e)
+        return None

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "creative-agent-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.100.1",
         "@tanstack/react-query": "^5.17.0",
         "axios": "^1.6.5",
         "framer-motion": "^11.0.0",
@@ -83,6 +84,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1439,6 +1441,92 @@
         "win32"
       ]
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.100.1.tgz",
+      "integrity": "sha512-c5FB4nrG7cs1mLSzFGuIVl2iR2YO5XkSJ96uF4zubYm8YDn71XOi2emE9sBm/avfGCj61jaRBLOvxEAVnpys0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.100.1.tgz",
+      "integrity": "sha512-mo8QheoV4KR+wSubtyEWhZUxWnCM7YZ23TncccMAlbWAHb8YTDqRGRm9IalWCAswniKyud6buZCk9snRqI86KA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.0.tgz",
+      "integrity": "sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.100.1.tgz",
+      "integrity": "sha512-OIh4mOSo2LdqF2kox76OAPDtcSs+PwKABJOjc6plUV4/LXhFEsI2uwdEEIs7K7fd141qehWEVl/Y+Ts0fNvYsw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.100.1.tgz",
+      "integrity": "sha512-FHuRWPX4qZQ4x+0Q+ZrKaBZnOiVGiwsgiAUJM98pYRib1yeaE/fOM1lZ1ozd+4gA8Udw23OyaD8SxKS5mT5NYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.0",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.100.1.tgz",
+      "integrity": "sha512-x9xpEIoWM4xKiAlwfWTgHPSN6N4Y0aS4FVU4F6ZPbq7Gayw08SrtC6/YH/gOr8CjXQr0HxXYXDop2xGTSjubYA==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.100.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.100.1.tgz",
+      "integrity": "sha512-CAeFm5sfX8sbTzxoxRafhohreIzl9a7R6qHTck3MrgTqm5M5g/u0IHfEKYzI9w/17r8NINl8UZrw2i08wrO7Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.100.1",
+        "@supabase/functions-js": "2.100.1",
+        "@supabase/postgrest-js": "2.100.1",
+        "@supabase/realtime-js": "2.100.1",
+        "@supabase/storage-js": "2.100.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.90.20",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
@@ -1535,7 +1623,6 @@
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.1.0.tgz",
       "integrity": "sha512-t7frlewr6+cbx+9Ohpl0NOTKXZNV9xHRmNOvql47BFJKcEG1CxtxlPEEe+gR9uhVWM4DwhnvTF110mIL4yP9RA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1554,6 +1641,7 @@
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1567,6 +1655,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1614,6 +1711,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -1865,6 +1963,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2087,6 +2186,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2486,6 +2586,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3035,6 +3136,15 @@
       "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
       "license": "MIT"
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3147,6 +3257,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3647,6 +3758,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3853,6 +3965,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3865,6 +3978,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4288,6 +4402,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4353,6 +4468,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4389,7 +4505,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -4455,6 +4570,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -4548,6 +4664,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4579,6 +4696,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.100.1",
     "@tanstack/react-query": "^5.17.0",
     "axios": "^1.6.5",
     "framer-motion": "^11.0.0",

--- a/frontend/src/api/services/authService.ts
+++ b/frontend/src/api/services/authService.ts
@@ -1,8 +1,18 @@
 /**
- * Auth Service - API methods for authentication
+ * Auth Service - authentication via Supabase (primary) or legacy API (fallback).
+ *
+ * When VITE_SUPABASE_URL is set, signUp/signIn/signOut use the Supabase JS
+ * client. The Supabase access token is then passed to the backend as a Bearer
+ * token — the backend validates it via SUPABASE_JWT_SECRET.
+ *
+ * When Supabase is not configured, falls back to the existing custom-token
+ * endpoints (/users/register, /users/login, etc.).
+ *
+ * Issue: #318 | Parent Epic: #313
  */
 
 import apiClient from '../client'
+import supabase, { isSupabaseEnabled } from '@/lib/supabase'
 import type {
   LoginRequest,
   RegisterRequest,
@@ -15,28 +25,90 @@ import type {
   PaginatedSessions,
 } from '@/types/auth'
 
-// API base URL for auth endpoints
 const AUTH_BASE = '/users'
 
 export const authService = {
   /**
-   * Login with username/email and password
+   * Login with email and password.
    */
   async login(data: LoginRequest): Promise<AuthResponse> {
+    if (isSupabaseEnabled()) {
+      const { data: authData, error } = await supabase!.auth.signInWithPassword({
+        email: data.username_or_email,
+        password: data.password,
+      })
+      if (error) throw new Error(error.message)
+      if (!authData.session) throw new Error('No session returned')
+
+      // Sync user to backend (auto-creates local row if needed)
+      const user = await authService._syncUser(authData.session.access_token)
+
+      return {
+        user,
+        token: {
+          access_token: authData.session.access_token,
+          token_type: 'bearer',
+          expires_in: authData.session.expires_in ?? 3600,
+        },
+      }
+    }
+
+    // Legacy flow
     const response = await apiClient.post<AuthResponse>(`${AUTH_BASE}/login`, data)
     return response.data
   },
 
   /**
-   * Register a new user
+   * Register a new user with email + password.
    */
   async register(data: RegisterRequest): Promise<AuthResponse> {
+    if (isSupabaseEnabled()) {
+      const { data: authData, error } = await supabase!.auth.signUp({
+        email: data.email,
+        password: data.password,
+        options: {
+          data: {
+            display_name: data.display_name || data.username,
+            username: data.username,
+          },
+        },
+      })
+      if (error) throw new Error(error.message)
+      if (!authData.session) {
+        // Email confirmation required — Supabase doesn't return a session
+        throw new Error('Please check your email to verify your account before logging in.')
+      }
+
+      const user = await authService._syncUser(authData.session.access_token)
+
+      return {
+        user,
+        token: {
+          access_token: authData.session.access_token,
+          token_type: 'bearer',
+          expires_in: authData.session.expires_in ?? 3600,
+        },
+      }
+    }
+
+    // Legacy flow
     const response = await apiClient.post<AuthResponse>(`${AUTH_BASE}/register`, data)
     return response.data
   },
 
   /**
-   * Get current user profile
+   * Sync Supabase user to backend — calls GET /users/me which auto-creates
+   * the local user row via get_current_user dep.
+   */
+  async _syncUser(accessToken: string): Promise<User> {
+    const response = await apiClient.get<User>(`${AUTH_BASE}/me`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    })
+    return response.data
+  },
+
+  /**
+   * Get current user profile.
    */
   async getCurrentUser(): Promise<User> {
     const response = await apiClient.get<User>(`${AUTH_BASE}/me`)
@@ -44,7 +116,7 @@ export const authService = {
   },
 
   /**
-   * Update current user profile
+   * Update current user profile.
    */
   async updateProfile(data: UpdateProfileRequest): Promise<User> {
     const response = await apiClient.put<User>(`${AUTH_BASE}/me`, data)
@@ -52,9 +124,17 @@ export const authService = {
   },
 
   /**
-   * Change password
+   * Change password.
    */
   async changePassword(data: ChangePasswordRequest): Promise<{ message: string }> {
+    if (isSupabaseEnabled()) {
+      const { error } = await supabase!.auth.updateUser({
+        password: data.new_password,
+      })
+      if (error) throw new Error(error.message)
+      return { message: 'Password updated' }
+    }
+
     const response = await apiClient.post<{ message: string }>(
       `${AUTH_BASE}/me/change-password`,
       data
@@ -63,14 +143,18 @@ export const authService = {
   },
 
   /**
-   * Logout current user
+   * Logout current user.
    */
   async logout(): Promise<void> {
+    if (isSupabaseEnabled()) {
+      await supabase!.auth.signOut()
+      return
+    }
     await apiClient.post(`${AUTH_BASE}/logout`)
   },
 
   /**
-   * Get user by ID
+   * Get user by ID.
    */
   async getUserById(userId: string): Promise<User> {
     const response = await apiClient.get<User>(`${AUTH_BASE}/${userId}`)
@@ -78,7 +162,7 @@ export const authService = {
   },
 
   /**
-   * Get current user stats (story count, session count)
+   * Get current user stats.
    */
   async getUserStats(): Promise<UserWithStats> {
     const response = await apiClient.get<UserWithStats>(`${AUTH_BASE}/me/stats`)
@@ -86,7 +170,7 @@ export const authService = {
   },
 
   /**
-   * Get current user's stories (paginated)
+   * Get current user's stories (paginated).
    */
   async getMyStories(params?: { limit?: number; offset?: number }): Promise<PaginatedStories> {
     const response = await apiClient.get<PaginatedStories>(`${AUTH_BASE}/me/stories`, { params })
@@ -94,7 +178,7 @@ export const authService = {
   },
 
   /**
-   * Get current user's interactive sessions (paginated)
+   * Get current user's interactive sessions (paginated).
    */
   async getMySessions(params?: { status?: string; status_filter?: string; limit?: number; offset?: number }): Promise<PaginatedSessions> {
     const normalizedParams = params

--- a/frontend/src/lib/supabase.ts
+++ b/frontend/src/lib/supabase.ts
@@ -1,0 +1,30 @@
+/**
+ * Supabase client singleton.
+ *
+ * Reads VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY from env.
+ * When env vars are missing (local dev without Supabase), the client
+ * is null and auth falls back to the legacy custom-token flow.
+ *
+ * Issue: #318 | Parent Epic: #313
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string | undefined
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined
+
+let supabase: SupabaseClient | null = null
+
+if (supabaseUrl && supabaseAnonKey) {
+  supabase = createClient(supabaseUrl, supabaseAnonKey)
+}
+
+export default supabase
+
+/**
+ * Returns true when Supabase Auth is configured.
+ * The app uses this to decide between Supabase and legacy auth flows.
+ */
+export function isSupabaseEnabled(): boolean {
+  return supabase !== null
+}

--- a/frontend/src/pages/LoginPage/index.tsx
+++ b/frontend/src/pages/LoginPage/index.tsx
@@ -31,7 +31,7 @@ function LoginPage() {
   // Validation
   const validateForm = (): string | null => {
     if (mode === 'login') {
-      if (!username.trim()) return 'Please enter your username or email'
+      if (!username.trim()) return 'Please enter your email'
       if (!password) return 'Please enter your password'
     } else {
       if (!username.trim()) return 'Please enter a username'
@@ -183,10 +183,10 @@ function LoginPage() {
                 )}
               </AnimatePresence>
 
-              {/* Username field */}
+              {/* Username / Email field */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">
-                  {mode === 'login' ? 'Username or Email' : 'Username'}
+                  {mode === 'login' ? 'Email' : 'Username'}
                 </label>
                 <div className="relative">
                   <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
@@ -196,7 +196,7 @@ function LoginPage() {
                     type="text"
                     value={username}
                     onChange={(e) => setUsername(e.target.value)}
-                    placeholder={mode === 'login' ? 'Enter username or email' : 'Choose a username'}
+                    placeholder={mode === 'login' ? 'Enter your email' : 'Choose a username'}
                     className="input-kid pl-10"
                     autoComplete="username"
                   />

--- a/frontend/src/store/useAuthStore.ts
+++ b/frontend/src/store/useAuthStore.ts
@@ -1,10 +1,17 @@
 /**
- * Auth Store - Manages authentication state with persistence
+ * Auth Store - Manages authentication state with persistence.
+ *
+ * Works with both Supabase Auth and legacy custom tokens.
+ * When Supabase is enabled, listens for token refresh events and
+ * auto-updates the stored token.
+ *
+ * Issue: #318 | Parent Epic: #313
  */
 
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { User } from '@/types/auth'
+import supabase, { isSupabaseEnabled } from '@/lib/supabase'
 
 interface AuthState {
   // State
@@ -76,5 +83,23 @@ const useAuthStore = create<AuthState>()(
     }
   )
 )
+
+// Listen for Supabase auth state changes (token refresh, sign out)
+if (isSupabaseEnabled()) {
+  supabase!.auth.onAuthStateChange((event, session) => {
+    const store = useAuthStore.getState()
+
+    if (event === 'TOKEN_REFRESHED' && session) {
+      // Update the stored token so API calls use the fresh one
+      if (store.isAuthenticated) {
+        useAuthStore.setState({ token: session.access_token })
+      }
+    }
+
+    if (event === 'SIGNED_OUT') {
+      store.logout()
+    }
+  })
+}
 
 export default useAuthStore


### PR DESCRIPTION
## Summary\n\n- **Backend**: `supabase_auth.py` decodes Supabase JWTs via PyJWT; `get_current_user` tries Supabase first, auto-creates local user from claims, falls back to legacy custom tokens when `SUPABASE_JWT_SECRET` is not set\n- **Frontend**: `@supabase/supabase-js` for signUp/signIn/signOut with `onAuthStateChange` token refresh; `isSupabaseEnabled()` flag routes to legacy API when `VITE_SUPABASE_URL` is not set\n- **Login page**: updated label to \"Email\" for login mode\n- **Zero breaking changes**: existing local-dev auth works identically when Supabase env vars are absent\n\nFixes #318\n**Parent Epic**: #313\n\n## Setup (operator tasks)\n\n1. Create a Supabase project at supabase.com\n2. Go to Project Settings > API > JWT Secret\n3. Set env vars:\n   - Backend: `SUPABASE_JWT_SECRET=<jwt-secret>`\n   - Frontend: `VITE_SUPABASE_URL=https://<project>.supabase.co` and `VITE_SUPABASE_ANON_KEY=<anon-key>`\n4. In Supabase dashboard: Authentication > Settings > enable email confirmation\n\n## Test plan\n- [x] TypeScript compiles cleanly\n- [x] 36/36 backend tests pass (no regressions)\n- [x] Without Supabase env vars: legacy auth flow works unchanged\n- [ ] With Supabase env vars: register sends verification email, login returns JWT, protected routes work\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)