### PR TITLE
fix(frontend,backend): newspaper-style news detail, fix profile child_id and add concepts

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -136,9 +136,9 @@ async def get_recommendations(
 async def get_child_id(
     user: UserData = Depends(get_current_user),
 ):
-    """Return the child_id most recently used by this user, derived from story history."""
+    """Return the user's primary child_id — the one with the most stories."""
     row = await story_repo._db.fetchone(
-        "SELECT child_id FROM stories WHERE user_id = ? ORDER BY created_at DESC LIMIT 1",
+        "SELECT child_id FROM stories WHERE user_id = ? GROUP BY child_id ORDER BY COUNT(*) DESC LIMIT 1",
         (user.user_id,),
     )
     return {"child_id": row["child_id"] if row else None}

--- a/frontend/src/pages/NewsDetailPage/index.tsx
+++ b/frontend/src/pages/NewsDetailPage/index.tsx
@@ -1,7 +1,6 @@
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import Card from '@/components/common/Card'
 import Button from '@/components/common/Button'
 import storyService from '@/api/services/storyService'
 
@@ -33,146 +32,160 @@ function NewsDetailPage() {
     ? conversion.category.charAt(0).toUpperCase() + conversion.category.slice(1)
     : 'General'
 
+  // Split content into paragraphs for newspaper-style rendering
+  const paragraphs = (conversion.kid_content || '').split('\n').filter(p => p.trim())
+
   return (
-    <div className="max-w-3xl mx-auto space-y-4">
-      {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-800">{conversion.kid_title}</h1>
-          <div className="flex items-center gap-2 mt-1">
-            <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-accent/10 text-accent">
-              {categoryLabel}
-            </span>
-            <span className="text-sm text-gray-500">
-              {conversion.age_group} age group
-            </span>
-            <span className="text-sm text-gray-400">
-              {new Date(conversion.created_at).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'short',
-                day: 'numeric',
-              })}
-            </span>
-          </div>
+    <div className="news-detail-page max-w-3xl mx-auto space-y-5 pb-8">
+      {/* Newspaper masthead */}
+      <motion.header
+        className="news-detail-header"
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <button
+            onClick={() => navigate(-1)}
+            className="text-sm text-gray-400 hover:text-gray-600 transition-colors"
+            style={{ fontFamily: "'Georgia', 'Noto Serif SC', serif" }}
+          >
+            ← Back
+          </button>
+          <span className="text-xs text-gray-400" style={{ fontFamily: "'Georgia', serif" }}>
+            {new Date(conversion.created_at).toLocaleDateString('en-US', {
+              weekday: 'long',
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </span>
         </div>
-        <Button variant="ghost" size="sm" onClick={() => navigate('/library')}>
-          Back to Library
-        </Button>
-      </div>
+
+        {/* Divider line */}
+        <div className="border-t-2 border-b border-gray-800 py-1 mb-4">
+          <div className="border-b border-gray-800" />
+        </div>
+
+        {/* Headline */}
+        <h1 className="news-detail-headline">
+          {conversion.kid_title}
+        </h1>
+
+        {/* Byline */}
+        <div className="flex items-center gap-3 mt-3">
+          <span className="text-xs font-semibold uppercase tracking-wider px-2 py-0.5 border border-gray-300 text-gray-600">
+            {categoryLabel}
+          </span>
+          <span className="text-xs text-gray-400 italic" style={{ fontFamily: "'Georgia', serif" }}>
+            Adapted for {conversion.age_group} readers
+          </span>
+        </div>
+
+        {/* Thin rule */}
+        <div className="border-b border-gray-200 mt-4" />
+      </motion.header>
 
       {/* Audio player */}
       {conversion.audio_url && (
         <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
+          className="news-audio-bar"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
           transition={{ delay: 0.1 }}
         >
-          <Card>
-            <h2 className="text-base font-bold text-gray-800 mb-2">Listen</h2>
-            <audio controls className="w-full" src={conversion.audio_url} />
-          </Card>
+          <span className="text-sm font-medium text-gray-600">Listen to this article</span>
+          <audio controls className="w-full mt-2" src={conversion.audio_url} />
         </motion.div>
       )}
 
-      {/* Main content */}
-      <motion.div
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
+      {/* Main article body */}
+      <motion.article
+        className="news-article-body"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
         transition={{ delay: 0.15 }}
       >
-        <Card>
-          <div className="prose prose-sm max-w-none text-gray-700 leading-relaxed whitespace-pre-line">
-            {conversion.kid_content}
-          </div>
-        </Card>
-      </motion.div>
+        {paragraphs.map((para, idx) => (
+          <p key={idx} className={idx === 0 ? 'first-news-para' : ''}>
+            {para}
+          </p>
+        ))}
+      </motion.article>
 
-      {/* Why care */}
+      {/* Why care — editorial callout */}
       {conversion.why_care && (
         <motion.div
+          className="news-callout"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2 }}
         >
-          <Card>
-            <h2 className="text-base font-bold text-gray-800 mb-2">Why Should I Care?</h2>
-            <p className="text-sm text-gray-600 leading-relaxed">{conversion.why_care}</p>
-          </Card>
+          <h2>Why Should I Care?</h2>
+          <p>{conversion.why_care}</p>
         </motion.div>
       )}
 
       {/* Key concepts */}
       {conversion.key_concepts && conversion.key_concepts.length > 0 && (
         <motion.div
+          className="news-concepts"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.25 }}
         >
-          <Card>
-            <h2 className="text-base font-bold text-gray-800 mb-2">Key Concepts</h2>
-            <div className="space-y-2">
-              {conversion.key_concepts.map((concept) => (
-                <div key={concept.term} className="text-sm bg-gray-50 rounded-lg p-2">
-                  <span className="font-semibold text-gray-800">
-                    {concept.emoji} {concept.term}:
-                  </span>{' '}
-                  <span className="text-gray-600">{concept.explanation}</span>
+          <h2>Key Concepts</h2>
+          <div className="news-concepts-grid">
+            {conversion.key_concepts.map((concept) => (
+              <div key={concept.term} className="news-concept-card">
+                <span className="news-concept-emoji">{concept.emoji}</span>
+                <div>
+                  <span className="news-concept-term">{concept.term}</span>
+                  {concept.explanation && (
+                    <span className="news-concept-explanation"> — {concept.explanation}</span>
+                  )}
                 </div>
-              ))}
-            </div>
-          </Card>
+              </div>
+            ))}
+          </div>
         </motion.div>
       )}
 
       {/* Interactive questions */}
       {conversion.interactive_questions && conversion.interactive_questions.length > 0 && (
         <motion.div
+          className="news-questions"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.3 }}
         >
-          <Card>
-            <h2 className="text-base font-bold text-gray-800 mb-2">Think About It</h2>
-            <div className="space-y-2">
-              {conversion.interactive_questions.map((q, idx) => (
-                <div
-                  key={idx}
-                  className="text-sm bg-primary/5 border border-primary/15 rounded-lg p-2"
-                >
-                  <p className="text-gray-700">
-                    {q.emoji} {q.question}
-                  </p>
-                  {q.hint && (
-                    <p className="text-gray-400 text-xs mt-1">Hint: {q.hint}</p>
-                  )}
-                </div>
-              ))}
+          <h2>Think About It</h2>
+          {conversion.interactive_questions.map((q, idx) => (
+            <div key={idx} className="news-question-item">
+              <span className="news-question-emoji">{q.emoji}</span>
+              <div>
+                <p className="news-question-text">{q.question}</p>
+                {q.hint && <p className="news-question-hint">Hint: {q.hint}</p>}
+              </div>
             </div>
-          </Card>
+          ))}
         </motion.div>
       )}
 
-      {/* Original URL */}
+      {/* Source */}
       {conversion.original_url && (
-        <motion.div
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.35 }}
-        >
-          <Card>
-            <p className="text-xs text-gray-400">
-              Original source:{' '}
-              <a
-                href={conversion.original_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                {conversion.original_url}
-              </a>
-            </p>
-          </Card>
-        </motion.div>
+        <div className="text-center pt-4 border-t border-gray-200">
+          <p className="text-xs text-gray-400" style={{ fontFamily: "'Georgia', serif" }}>
+            Source:{' '}
+            <a
+              href={conversion.original_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-500 hover:underline"
+            >
+              {conversion.original_url}
+            </a>
+          </p>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/ProfilePage/PreferenceSummary.tsx
+++ b/frontend/src/pages/ProfilePage/PreferenceSummary.tsx
@@ -57,7 +57,8 @@ function PreferenceSummary({ preferences, isLoading }: PreferenceSummaryProps) {
 
   const themes = preferences ? topEntries(preferences.themes, 5) : []
   const interests = preferences ? topEntries(preferences.interests, 5) : []
-  const hasData = themes.length > 0 || interests.length > 0
+  const concepts = preferences ? topEntries(preferences.concepts, 5) : []
+  const hasData = themes.length > 0 || interests.length > 0 || concepts.length > 0
 
   return (
     <Card className="p-6">
@@ -106,6 +107,28 @@ function PreferenceSummary({ preferences, isLoading }: PreferenceSummaryProps) {
                   <motion.span
                     key={entry.label}
                     className={`inline-block rounded-full px-3 py-1 text-sm font-medium ${INTEREST_COLORS[index % INTEREST_COLORS.length]}`}
+                    initial={{ opacity: 0, scale: 0.8 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={{ delay: index * 0.05 }}
+                    whileHover={{ scale: 1.08 }}
+                  >
+                    {entry.label}
+                  </motion.span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {concepts.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-600 mb-2">
+                Things You Learned
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {concepts.map((entry, index) => (
+                  <motion.span
+                    key={entry.label}
+                    className={`inline-block rounded-full px-3 py-1 text-sm font-medium bg-gray-200 text-gray-700`}
                     initial={{ opacity: 0, scale: 0.8 }}
                     animate={{ opacity: 1, scale: 1 }}
                     transition={{ delay: index * 0.05 }}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1007,6 +1007,143 @@
   @apply bg-purple-50 text-purple-700;
 }
 
+/* ===== News Detail — Newspaper Style ===== */
+
+.news-detail-headline {
+  font-family: 'Georgia', 'Noto Serif SC', serif;
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.2;
+  color: #1a1a1a;
+  letter-spacing: -0.02em;
+}
+
+@media (min-width: 768px) {
+  .news-detail-headline {
+    font-size: 2.5rem;
+  }
+}
+
+.news-article-body {
+  font-family: 'Georgia', 'Noto Serif SC', serif;
+  font-size: 1.125rem;
+  line-height: 1.9;
+  color: #333;
+}
+
+.news-article-body p {
+  @apply mb-5;
+  text-indent: 1.5em;
+}
+
+.news-article-body .first-news-para {
+  text-indent: 0;
+  font-size: 1.2rem;
+}
+
+.news-article-body .first-news-para::first-letter {
+  float: left;
+  font-size: 3.5rem;
+  line-height: 1;
+  font-weight: bold;
+  color: #1a1a1a;
+  margin-right: 6px;
+  margin-top: 4px;
+  font-family: 'Georgia', serif;
+}
+
+.news-callout {
+  @apply py-5 px-6;
+  border-left: 4px solid rgba(139, 115, 85, 0.4);
+  background: rgba(248, 240, 228, 0.4);
+  border-radius: 0 8px 8px 0;
+}
+
+.news-callout h2 {
+  font-family: 'Georgia', serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #555;
+  margin-bottom: 0.5rem;
+}
+
+.news-callout p {
+  font-family: 'Georgia', serif;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: #555;
+  font-style: italic;
+}
+
+.news-concepts h2,
+.news-questions h2 {
+  font-family: 'Georgia', serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #444;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid rgba(210, 190, 165, 0.3);
+}
+
+.news-concepts-grid {
+  @apply space-y-2;
+}
+
+.news-concept-card {
+  @apply flex items-start gap-2 py-2 px-3;
+  background: rgba(248, 240, 228, 0.3);
+  border-radius: 6px;
+}
+
+.news-concept-emoji {
+  @apply text-lg flex-shrink-0;
+}
+
+.news-concept-term {
+  font-family: 'Georgia', serif;
+  font-weight: 700;
+  color: #333;
+  font-size: 0.9rem;
+}
+
+.news-concept-explanation {
+  font-family: 'Georgia', serif;
+  color: #666;
+  font-size: 0.85rem;
+}
+
+.news-question-item {
+  @apply flex items-start gap-2 py-2 px-3 mb-2;
+  border-radius: 6px;
+  border: 1px solid rgba(210, 190, 165, 0.25);
+}
+
+.news-question-emoji {
+  @apply text-lg flex-shrink-0;
+}
+
+.news-question-text {
+  font-family: 'Georgia', serif;
+  color: #444;
+  font-size: 0.9rem;
+}
+
+.news-question-hint {
+  font-family: 'Georgia', serif;
+  color: #999;
+  font-size: 0.8rem;
+  font-style: italic;
+  margin-top: 0.25rem;
+}
+
+.news-audio-bar {
+  @apply py-3 px-4;
+  background: rgba(248, 240, 228, 0.4);
+  border-radius: 8px;
+  border: 1px solid rgba(210, 190, 165, 0.2);
+}
+
 /* Action Buttons */
 .action-buttons {
   @apply flex flex-col sm:flex-row gap-3;


### PR DESCRIPTION
## Summary
Three fixes addressing user-reported issues:

1. **News detail page**: Redesigned with newspaper aesthetic — large serif headline, double-rule masthead, drop cap on first paragraph, editorial callout for "Why Should I Care?", proper Key Concepts cards. Text size increased from `prose-sm` to 1.125rem serif.

2. **Profile child_id resolution**: Changed `/memory/child-id` from `ORDER BY created_at DESC` (picks most recent, possibly empty session) to `GROUP BY child_id ORDER BY COUNT(*) DESC` (picks the child_id with most stories).

3. **Preferences display**: Added "Things You Learned" section showing `concepts` (from art-to-story) alongside Themes (from interactive stories) and Interests (from interactive story choices).

**Parent Epic**: #42

## Verified via Playwright
- News detail: newspaper-style with drop cap, serif text, editorial callout
- Characters: 小默 (x2), 小松鼠 (x1), 幽灵豹 (x1) showing
- Themes: 人与自然和谐共处, 幽灵豹的传说, 自然探索... (interactive + art)
- Interests: Forest, Magic (interactive story choices)
- Things You Learned: 责任感, 森林探险, 秘密地图... (art story concepts)

## Test plan
- [x] TypeScript compiles cleanly
- [x] News detail displays with newspaper typography and all sections
- [x] Profile characters gallery populated
- [x] Themes, Interests, and Things You Learned all display

🤖 Generated with [Claude Code](https://claude.com/claude-code)