### PR TITLE
feat(morning-show): SSE streaming, frontend service, on-demand tests (#306, #307, #311)

### DIFF
--- a/backend/src/api/routes/morning_show.py
+++ b/backend/src/api/routes/morning_show.py
@@ -800,12 +800,17 @@ async def generate_morning_show_on_demand_stream(
             return
 
         # Build the full episode (audio + illustrations + persist)
-        response = await _build_episode(build_request, user, source="on_demand")
-        await usage_repo.increment(user.user_id, "morning_show")  # quota tracking (#314)
+        try:
+            response = await _build_episode(build_request, user, source="on_demand")
+            await usage_repo.increment(user.user_id, "morning_show")  # quota tracking (#314)
 
-        # Phase 5: complete
-        yield f"event: result\ndata: {json.dumps(response.model_dump(mode='json'), ensure_ascii=False)}\n\n"
-        yield f"event: complete\ndata: {json.dumps({'phase': 'complete', 'message': 'Morning Show generation complete'}, ensure_ascii=False)}\n\n"
+            # Phase 5: complete
+            yield f"event: result\ndata: {json.dumps(response.model_dump(mode='json'), ensure_ascii=False)}\n\n"
+            yield f"event: complete\ndata: {json.dumps({'phase': 'complete', 'message': 'Morning Show generation complete'}, ensure_ascii=False)}\n\n"
+        except Exception as exc:
+            logger.error("On-demand morning show build failed: %s", exc)
+            yield f"event: error\ndata: {json.dumps({'phase': 'error', 'message': '节目生成失败，请稍后重试 / Episode generation failed, please try again later'}, ensure_ascii=False)}\n\n"
+            return
 
     return StreamingResponse(
         event_generator(),

--- a/backend/tests/api/test_morning_show_on_demand.py
+++ b/backend/tests/api/test_morning_show_on_demand.py
@@ -1,0 +1,271 @@
+"""API tests for Morning Show on-demand generation endpoints (#311).
+
+Tests cover:
+- POST /generate-now — success, unsubscribed category (400), rate limit (429)
+- POST /generate-now/stream — SSE event ordering
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Shared mock data
+# ---------------------------------------------------------------------------
+
+_MOCK_GENERATED = {
+    "kid_title": "Coral Reef Discovery",
+    "kid_content": "Scientists found a new coral reef that helps sea animals.",
+    "why_care": "Coral reefs protect ocean life.",
+    "key_concepts": [],
+    "interactive_questions": [],
+    "dialogue_script": {
+        "lines": [
+            {
+                "role": "curious_kid",
+                "text": "Mimi: What is a coral reef?",
+                "display_name": "Mimi",
+                "timestamp_start": 0.0,
+                "timestamp_end": 4.0,
+            },
+            {
+                "role": "fun_expert",
+                "text": "Duo: It is an underwater garden for fish!",
+                "display_name": "Duo",
+                "timestamp_start": 4.0,
+                "timestamp_end": 8.0,
+            },
+        ],
+        "total_duration": 8.0,
+        "guest_character": "Professor Owl",
+    },
+    "safety_score": 0.92,
+    "used_mock": False,
+    "guest_character": "Professor Owl",
+}
+
+_MOCK_NEWS_TEXT = "Today's news about science:\n- Coral reef found: A new reef protects sea animals"
+
+
+def _mock_stream_events():
+    """Async generator yielding mock SSE events from stream_morning_show_generation."""
+    events = [
+        {"type": "status", "data": {"phase": "generating_script", "message": "Generating..."}},
+        {"type": "result", "data": _MOCK_GENERATED},
+    ]
+
+    async def _gen(**kwargs):
+        for e in events:
+            yield e
+
+    return _gen
+
+
+# ---------------------------------------------------------------------------
+# Patch targets (routes module imports these at top level)
+# ---------------------------------------------------------------------------
+_ROUTE = "backend.src.api.routes.morning_show"
+_CONVERT = f"{_ROUTE}.convert_news_to_morning_show"
+_STREAM = f"{_ROUTE}.stream_morning_show_generation"
+_FETCH = f"{_ROUTE}.fetch_news_text"
+_AUDIO = f"{_ROUTE}.generate_multi_speaker_audio"
+_SUB_REPO = f"{_ROUTE}.subscription_repo"
+_STORY_REPO = f"{_ROUTE}.story_repo"
+_USAGE_REPO = f"{_ROUTE}.usage_repo"
+_GEN_ILLUSTRATIONS = f"{_ROUTE}._generate_illustrations"
+
+
+@pytest.mark.asyncio
+class TestGenerateNowEndpoint:
+    """POST /api/v1/morning-show/generate-now"""
+
+    async def test_returns_valid_episode(self, test_client):
+        """On-demand generation with mocked agent returns a valid MorningShowResponse."""
+        child_id = f"child-od-{uuid.uuid4().hex[:8]}"
+
+        with (
+            patch(_FETCH, new_callable=AsyncMock, return_value=_MOCK_NEWS_TEXT),
+            patch(_CONVERT, new_callable=AsyncMock, return_value=_MOCK_GENERATED),
+            patch(_AUDIO, new_callable=AsyncMock, return_value={"0": "/audio/line0.mp3"}),
+            patch(_GEN_ILLUSTRATIONS, new_callable=AsyncMock, return_value=[]),
+            patch(_SUB_REPO) as mock_sub,
+            patch(_STORY_REPO) as mock_story,
+            patch(_USAGE_REPO) as mock_usage,
+        ):
+            mock_sub.has_active_subscription = AsyncMock(return_value=True)
+            mock_story.count_recent_on_demand = AsyncMock(return_value=0)
+            mock_story.create = AsyncMock(return_value=None)
+            mock_usage.increment = AsyncMock(return_value=None)
+
+            async with test_client as client:
+                response = await client.post(
+                    "/api/v1/morning-show/generate-now",
+                    json={
+                        "child_id": child_id,
+                        "category": "science",
+                        "age_group": "6-8",
+                    },
+                )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert "episode" in data
+            assert "metadata" in data
+            assert data["episode"]["story_type"] == "morning_show"
+            assert data["metadata"]["safety_score"] >= 0.85
+            assert "generation_id" in data["metadata"]
+            assert len(data["episode"]["dialogue_script"]["lines"]) > 0
+
+    async def test_returns_400_for_unsubscribed_category(self, test_client):
+        """If the child has no active subscription for the category, returns 400."""
+        child_id = f"child-od-{uuid.uuid4().hex[:8]}"
+
+        with (
+            patch(_SUB_REPO) as mock_sub,
+        ):
+            mock_sub.has_active_subscription = AsyncMock(return_value=False)
+
+            async with test_client as client:
+                response = await client.post(
+                    "/api/v1/morning-show/generate-now",
+                    json={
+                        "child_id": child_id,
+                        "category": "science",
+                        "age_group": "6-8",
+                    },
+                )
+
+            assert response.status_code == 400
+            assert "Subscribe" in response.json()["detail"] or "订阅" in response.json()["detail"]
+
+    async def test_returns_429_when_rate_limited(self, test_client):
+        """4th request within 1 hour returns 429 with retry_after."""
+        child_id = f"child-od-{uuid.uuid4().hex[:8]}"
+
+        with (
+            patch(_SUB_REPO) as mock_sub,
+            patch(_STORY_REPO) as mock_story,
+        ):
+            mock_sub.has_active_subscription = AsyncMock(return_value=True)
+            mock_story.count_recent_on_demand = AsyncMock(return_value=3)  # already at limit
+            mock_story.get_oldest_recent_on_demand_ts = AsyncMock(return_value=None)
+
+            async with test_client as client:
+                response = await client.post(
+                    "/api/v1/morning-show/generate-now",
+                    json={
+                        "child_id": child_id,
+                        "category": "science",
+                        "age_group": "6-8",
+                    },
+                )
+
+            assert response.status_code == 429
+            data = response.json()
+            assert "retry_after" in data
+            assert isinstance(data["retry_after"], int)
+            assert data["retry_after"] >= 0
+
+
+@pytest.mark.asyncio
+class TestGenerateNowStreamEndpoint:
+    """POST /api/v1/morning-show/generate-now/stream"""
+
+    async def test_stream_returns_sse_events_in_order(self, test_client):
+        """SSE stream must emit status events for each phase, then result, then complete."""
+        child_id = f"child-od-{uuid.uuid4().hex[:8]}"
+
+        with (
+            patch(_FETCH, new_callable=AsyncMock, return_value=_MOCK_NEWS_TEXT),
+            patch(_STREAM, side_effect=_mock_stream_events()),
+            patch(_AUDIO, new_callable=AsyncMock, return_value={"0": "/audio/line0.mp3"}),
+            patch(_GEN_ILLUSTRATIONS, new_callable=AsyncMock, return_value=[]),
+            patch(_CONVERT, new_callable=AsyncMock, return_value=_MOCK_GENERATED),
+            patch(_SUB_REPO) as mock_sub,
+            patch(_STORY_REPO) as mock_story,
+            patch(_USAGE_REPO) as mock_usage,
+        ):
+            mock_sub.has_active_subscription = AsyncMock(return_value=True)
+            mock_story.count_recent_on_demand = AsyncMock(return_value=0)
+            mock_story.create = AsyncMock(return_value=None)
+            mock_usage.increment = AsyncMock(return_value=None)
+
+            async with test_client as client:
+                response = await client.post(
+                    "/api/v1/morning-show/generate-now/stream",
+                    json={
+                        "child_id": child_id,
+                        "category": "science",
+                        "age_group": "6-8",
+                    },
+                )
+
+            assert response.status_code == 200
+            assert response.headers["content-type"].startswith("text/event-stream")
+
+            body = response.text
+            # Verify all expected SSE phases appear
+            assert "event: status" in body
+            assert "fetching_news" in body
+            assert "generating_script" in body
+            assert "generating_audio" in body
+            assert "generating_illustrations" in body
+            assert "event: result" in body
+            assert "event: complete" in body
+
+            # Verify phase ordering: fetching_news before generating_script
+            fetching_pos = body.index("fetching_news")
+            script_pos = body.index("generating_script")
+            audio_pos = body.index("generating_audio")
+            illustrations_pos = body.index("generating_illustrations")
+            complete_pos = body.index("event: complete")
+
+            assert fetching_pos < script_pos < audio_pos < illustrations_pos < complete_pos
+
+    async def test_stream_returns_400_for_unsubscribed_category(self, test_client):
+        """Stream endpoint also checks subscription before starting SSE."""
+        child_id = f"child-od-{uuid.uuid4().hex[:8]}"
+
+        with patch(_SUB_REPO) as mock_sub:
+            mock_sub.has_active_subscription = AsyncMock(return_value=False)
+
+            async with test_client as client:
+                response = await client.post(
+                    "/api/v1/morning-show/generate-now/stream",
+                    json={
+                        "child_id": child_id,
+                        "category": "science",
+                        "age_group": "6-8",
+                    },
+                )
+
+            assert response.status_code == 400
+
+    async def test_stream_returns_429_when_rate_limited(self, test_client):
+        """Stream endpoint also enforces rate limiting before starting SSE."""
+        child_id = f"child-od-{uuid.uuid4().hex[:8]}"
+
+        with (
+            patch(_SUB_REPO) as mock_sub,
+            patch(_STORY_REPO) as mock_story,
+        ):
+            mock_sub.has_active_subscription = AsyncMock(return_value=True)
+            mock_story.count_recent_on_demand = AsyncMock(return_value=3)
+            mock_story.get_oldest_recent_on_demand_ts = AsyncMock(return_value=None)
+
+            async with test_client as client:
+                response = await client.post(
+                    "/api/v1/morning-show/generate-now/stream",
+                    json={
+                        "child_id": child_id,
+                        "category": "science",
+                        "age_group": "6-8",
+                    },
+                )
+
+            assert response.status_code == 429

--- a/backend/tests/contracts/test_on_demand_generation.py
+++ b/backend/tests/contracts/test_on_demand_generation.py
@@ -1,0 +1,237 @@
+"""
+On-Demand Morning Show Generation Contract Tests (#311)
+
+Validates Pydantic model constraints and output shapes for:
+- MorningShowOnDemandRequest required fields
+- MorningShowGenerationMetadata provenance tracking (safety_score, generation_id, is_degraded)
+- MorningShowResponse structure consistency between Daily Drop and on-demand
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend.src.api.models import (
+    AgeGroup,
+    MorningShowGenerationMetadata,
+    MorningShowOnDemandRequest,
+    MorningShowResponse,
+    MorningShowEpisode,
+    DialogueScript,
+    DialogueLine,
+    NewsCategory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_episode(**overrides) -> MorningShowEpisode:
+    """Build a minimal valid MorningShowEpisode for contract assertions."""
+    defaults = dict(
+        episode_id="ep-001",
+        child_id="child-1",
+        age_group=AgeGroup.AGE_6_8,
+        category=NewsCategory.SCIENCE,
+        kid_title="Test Episode",
+        kid_content="Some educational content.",
+        why_care="It helps us learn.",
+        dialogue_script=DialogueScript(
+            lines=[
+                DialogueLine(
+                    role="curious_kid",
+                    text="Why?",
+                    timestamp_start=0.0,
+                    timestamp_end=3.0,
+                ),
+                DialogueLine(
+                    role="fun_expert",
+                    text="Because science!",
+                    timestamp_start=3.0,
+                    timestamp_end=6.0,
+                ),
+            ],
+            total_duration=6.0,
+        ),
+    )
+    defaults.update(overrides)
+    return MorningShowEpisode(**defaults)
+
+
+def _make_metadata(**overrides) -> MorningShowGenerationMetadata:
+    """Build a minimal valid MorningShowGenerationMetadata."""
+    defaults = dict(
+        generation_id="gen-001",
+        safety_score=0.92,
+        used_mock=False,
+        is_degraded=False,
+    )
+    defaults.update(overrides)
+    return MorningShowGenerationMetadata(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# MorningShowOnDemandRequest — required fields
+# ---------------------------------------------------------------------------
+class TestOnDemandRequestContract:
+    """Contract: MorningShowOnDemandRequest must enforce required fields."""
+
+    def test_valid_request(self):
+        """Contract: a request with child_id, category, and age_group must pass."""
+        req = MorningShowOnDemandRequest(
+            child_id="child-abc",
+            category=NewsCategory.SCIENCE,
+            age_group=AgeGroup.AGE_6_8,
+        )
+        assert req.child_id == "child-abc"
+        assert req.category == NewsCategory.SCIENCE
+        assert req.age_group == AgeGroup.AGE_6_8
+
+    def test_missing_child_id_rejected(self):
+        """Contract: child_id is required."""
+        with pytest.raises(ValidationError):
+            MorningShowOnDemandRequest(
+                category=NewsCategory.SCIENCE,
+                age_group=AgeGroup.AGE_6_8,
+            )
+
+    def test_empty_child_id_rejected(self):
+        """Contract: child_id must have min_length=1."""
+        with pytest.raises(ValidationError):
+            MorningShowOnDemandRequest(
+                child_id="",
+                category=NewsCategory.SCIENCE,
+                age_group=AgeGroup.AGE_6_8,
+            )
+
+    def test_missing_age_group_rejected(self):
+        """Contract: age_group is required."""
+        with pytest.raises(ValidationError):
+            MorningShowOnDemandRequest(
+                child_id="child-1",
+                category=NewsCategory.SCIENCE,
+            )
+
+    def test_invalid_age_group_rejected(self):
+        """Contract: age_group must be a valid AgeGroup enum value."""
+        with pytest.raises(ValidationError):
+            MorningShowOnDemandRequest(
+                child_id="child-1",
+                category=NewsCategory.SCIENCE,
+                age_group="13-15",
+            )
+
+    def test_category_defaults_to_general(self):
+        """Contract: category defaults to GENERAL when omitted."""
+        req = MorningShowOnDemandRequest(
+            child_id="child-1",
+            age_group=AgeGroup.AGE_3_5,
+        )
+        assert req.category == NewsCategory.GENERAL
+
+    def test_invalid_category_rejected(self):
+        """Contract: an unknown category must fail validation."""
+        with pytest.raises(ValidationError):
+            MorningShowOnDemandRequest(
+                child_id="child-1",
+                category="cooking",
+                age_group=AgeGroup.AGE_6_8,
+            )
+
+    def test_child_id_max_length(self):
+        """Contract: child_id must be at most 100 characters."""
+        with pytest.raises(ValidationError):
+            MorningShowOnDemandRequest(
+                child_id="x" * 101,
+                category=NewsCategory.SCIENCE,
+                age_group=AgeGroup.AGE_6_8,
+            )
+
+
+# ---------------------------------------------------------------------------
+# MorningShowGenerationMetadata — provenance tracking
+# ---------------------------------------------------------------------------
+class TestOnDemandMetadataContract:
+    """Contract: on-demand output includes provenance fields matching Daily Drop."""
+
+    def test_metadata_has_safety_score(self):
+        """Contract: safety_score must exist and be within [0.0, 1.0]."""
+        meta = _make_metadata(safety_score=0.95)
+        assert hasattr(meta, "safety_score")
+        assert 0.0 <= meta.safety_score <= 1.0
+
+    def test_metadata_has_generation_id(self):
+        """Contract: generation_id must be a non-empty string for traceability."""
+        meta = _make_metadata(generation_id="gen-42")
+        assert meta.generation_id == "gen-42"
+
+    def test_metadata_has_is_degraded(self):
+        """Contract: is_degraded must exist (matches Daily Drop provenance)."""
+        meta = _make_metadata(is_degraded=True, degraded_reason="agent_fallback")
+        assert meta.is_degraded is True
+        assert meta.degraded_reason == "agent_fallback"
+
+    def test_metadata_safety_score_below_zero_rejected(self):
+        """Contract: safety_score < 0 must fail validation."""
+        with pytest.raises(ValidationError):
+            _make_metadata(safety_score=-0.1)
+
+    def test_metadata_safety_score_above_one_rejected(self):
+        """Contract: safety_score > 1 must fail validation."""
+        with pytest.raises(ValidationError):
+            _make_metadata(safety_score=1.5)
+
+    def test_metadata_used_mock_defaults_false(self):
+        """Contract: used_mock defaults to False."""
+        meta = MorningShowGenerationMetadata(
+            generation_id="gen-x",
+            safety_score=0.9,
+        )
+        assert meta.used_mock is False
+
+    def test_metadata_is_degraded_defaults_false(self):
+        """Contract: is_degraded defaults to False."""
+        meta = MorningShowGenerationMetadata(
+            generation_id="gen-x",
+            safety_score=0.9,
+        )
+        assert meta.is_degraded is False
+
+
+# ---------------------------------------------------------------------------
+# MorningShowResponse — same shape for Daily Drop and on-demand
+# ---------------------------------------------------------------------------
+class TestOnDemandResponseContract:
+    """Contract: MorningShowResponse carries episode + metadata consistently."""
+
+    def test_response_contains_episode_and_metadata(self):
+        """Contract: response must have both episode and metadata fields."""
+        resp = MorningShowResponse(
+            episode=_make_episode(),
+            metadata=_make_metadata(),
+        )
+        assert resp.episode.episode_id == "ep-001"
+        assert resp.metadata.generation_id == "gen-001"
+
+    def test_response_safety_score_in_metadata(self):
+        """Contract: safety_score lives in metadata, not directly on the response."""
+        resp = MorningShowResponse(
+            episode=_make_episode(),
+            metadata=_make_metadata(safety_score=0.88),
+        )
+        assert resp.metadata.safety_score == 0.88
+
+    def test_response_provenance_fields_present(self):
+        """Contract: generation_id and is_degraded exist in metadata for tracing."""
+        resp = MorningShowResponse(
+            episode=_make_episode(is_degraded=True, degraded_reason="timeout"),
+            metadata=_make_metadata(is_degraded=True, degraded_reason="timeout"),
+        )
+        assert resp.metadata.generation_id is not None
+        assert resp.metadata.is_degraded is True
+        assert resp.episode.is_degraded is True
+
+    def test_episode_story_type_is_morning_show(self):
+        """Contract: episode.story_type must always be 'morning_show'."""
+        ep = _make_episode()
+        assert ep.story_type == "morning_show"

--- a/backend/tests/unit/test_news_headline_fetcher.py
+++ b/backend/tests/unit/test_news_headline_fetcher.py
@@ -1,0 +1,203 @@
+"""Unit tests for news_headline_fetcher retry logic and backoff timing (#311).
+
+Complements the tests in test_scheduler_no_stub.py with focused coverage of:
+- Retry succeeds after transient failure
+- Retry gives up after max retries
+- Returns None when tool is unavailable
+- Backoff timing increases linearly
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, call
+
+from src.services.news_headline_fetcher import (
+    fetch_news_text,
+    _MAX_HEADLINE_RETRIES,
+    _RETRY_BACKOFF_SECONDS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _tavily_response(headlines: list[dict] | None = None) -> dict:
+    """Build a mock MCP tool response with valid headlines."""
+    data = {"headlines": headlines or [], "topic": "science"}
+    return {"content": [{"type": "text", "text": json.dumps(data)}]}
+
+
+def _tavily_error_response(error: str = "timeout") -> dict:
+    """Build a mock MCP tool response with an error."""
+    data = {"error": error, "headlines": [], "topic": "science"}
+    return {"content": [{"type": "text", "text": json.dumps(data)}]}
+
+
+# ---------------------------------------------------------------------------
+# Tool unavailable
+# ---------------------------------------------------------------------------
+class TestToolUnavailable:
+    """fetch_news_text returns None when the MCP tool is not available."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_tool_is_none(self):
+        """If get_headlines_by_topic is None (import failed), return None immediately."""
+        with patch("src.services.news_headline_fetcher.get_headlines_by_topic", None):
+            result = await fetch_news_text("science")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Retry logic — succeeds after transient failure
+# ---------------------------------------------------------------------------
+class TestRetrySucceedsAfterTransientFailure:
+    """fetch_news_text should succeed when a transient failure is followed by a good response."""
+
+    @pytest.mark.asyncio
+    async def test_succeeds_after_one_exception(self):
+        """One exception then a valid response should return headlines."""
+        good = _tavily_response([{"title": "New species", "description": "A frog was found"}])
+        mock_fn = AsyncMock(side_effect=[Exception("network error"), good])
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await fetch_news_text("nature")
+        assert result is not None
+        assert "New species" in result
+        assert mock_fn.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_succeeds_after_empty_then_good(self):
+        """Empty headlines on first attempt, real headlines on second."""
+        empty = _tavily_response([])
+        good = _tavily_response([{"title": "Solar eclipse", "description": "Amazing event"}])
+        mock_fn = AsyncMock(side_effect=[empty, good])
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await fetch_news_text("space")
+        assert result is not None
+        assert "Solar eclipse" in result
+
+    @pytest.mark.asyncio
+    async def test_succeeds_after_error_response_then_good(self):
+        """Tavily error dict on first attempt, valid response on second."""
+        error = _tavily_error_response("rate limited")
+        good = _tavily_response([{"title": "Robot dog", "description": "Walks on its own"}])
+        mock_fn = AsyncMock(side_effect=[error, good])
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await fetch_news_text("technology")
+        assert result is not None
+        assert "Robot dog" in result
+
+
+# ---------------------------------------------------------------------------
+# Retry logic — gives up after max retries
+# ---------------------------------------------------------------------------
+class TestRetryGivesUpAfterMaxRetries:
+    """fetch_news_text returns None after exhausting all retry attempts."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_after_all_exceptions(self):
+        """When every attempt raises an exception, return None."""
+        mock_fn = AsyncMock(side_effect=Exception("persistent failure"))
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await fetch_news_text("sports")
+        assert result is None
+        assert mock_fn.call_count == _MAX_HEADLINE_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_returns_none_after_all_empty_responses(self):
+        """When every attempt returns empty headlines, return None."""
+        empty = _tavily_response([])
+        mock_fn = AsyncMock(return_value=empty)
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await fetch_news_text("animals")
+        assert result is None
+        assert mock_fn.call_count == _MAX_HEADLINE_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_returns_none_after_all_error_responses(self):
+        """When every attempt returns an error dict, return None."""
+        error = _tavily_error_response("service unavailable")
+        mock_fn = AsyncMock(return_value=error)
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            result = await fetch_news_text("culture")
+        assert result is None
+        assert mock_fn.call_count == _MAX_HEADLINE_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Backoff timing increases linearly
+# ---------------------------------------------------------------------------
+class TestBackoffTimingLinear:
+    """Backoff delay should increase linearly: _RETRY_BACKOFF_SECONDS * attempt."""
+
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_exceptions(self):
+        """Sleep durations should be 2s, 4s (for _RETRY_BACKOFF_SECONDS=2, attempts 1,2)."""
+        mock_fn = AsyncMock(side_effect=Exception("timeout"))
+        mock_sleep = AsyncMock()
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", mock_sleep),
+        ):
+            await fetch_news_text("science")
+
+        # Sleep is called between retries: attempts 1..(N-1) sleep, last attempt does not
+        # because the code only sleeps when attempt < _MAX_HEADLINE_RETRIES
+        expected_sleeps = [
+            call(_RETRY_BACKOFF_SECONDS * attempt)
+            for attempt in range(1, _MAX_HEADLINE_RETRIES)
+        ]
+        assert mock_sleep.call_args_list == expected_sleeps
+
+    @pytest.mark.asyncio
+    async def test_backoff_increases_on_empty_headlines(self):
+        """Sleep durations should increase linearly on empty headline retries."""
+        empty = _tavily_response([])
+        mock_fn = AsyncMock(return_value=empty)
+        mock_sleep = AsyncMock()
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", mock_sleep),
+        ):
+            await fetch_news_text("sports")
+
+        # Empty headlines always sleep (all attempts including last)
+        expected_sleeps = [
+            call(_RETRY_BACKOFF_SECONDS * attempt)
+            for attempt in range(1, _MAX_HEADLINE_RETRIES + 1)
+        ]
+        assert mock_sleep.call_args_list == expected_sleeps
+
+    @pytest.mark.asyncio
+    async def test_no_sleep_on_first_success(self):
+        """When the first attempt succeeds, no sleep should be called."""
+        good = _tavily_response([{"title": "Happy news", "description": "Everything is great"}])
+        mock_fn = AsyncMock(return_value=good)
+        mock_sleep = AsyncMock()
+        with (
+            patch("src.services.news_headline_fetcher.get_headlines_by_topic", mock_fn),
+            patch("src.services.news_headline_fetcher.asyncio.sleep", mock_sleep),
+        ):
+            result = await fetch_news_text("general")
+        assert result is not None
+        mock_sleep.assert_not_called()

--- a/frontend/src/api/services/storyService.ts
+++ b/frontend/src/api/services/storyService.ts
@@ -436,6 +436,43 @@ export const storyService = {
   },
 
   /**
+   * Generate Morning Show episode on-demand (streaming)
+   */
+  async generateMorningShowOnDemandStream(
+    params: MorningShowOnDemandRequest,
+    callbacks: StreamCallbacks,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const response = await fetch(`${API_BASE_URL}/morning-show/generate-now/stream`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getAuthHeaders(),
+      },
+      body: JSON.stringify(params),
+      signal,
+    })
+
+    if (!response.ok) {
+      if (response.status === 429) {
+        const errorData = await response.json()
+        throw new Error(
+          `Rate limited: ${errorData.message || errorData.detail || 'Too many requests'}. Retry after ${errorData.retry_after || 60} seconds.`
+        )
+      }
+      if (response.status === 400) {
+        const errorData = await response.json()
+        throw new Error(
+          errorData.detail || 'Subscription required or invalid request.'
+        )
+      }
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    await consumeSSEStream(response, callbacks)
+  },
+
+  /**
    * Track Morning Show playback event
    */
   async trackMorningShowEvent(


### PR DESCRIPTION
## Summary
- **#306**: Add error event handling to on-demand SSE stream — `_build_episode` failures now yield `event: error` instead of silently killing the stream
- **#307**: Add `generateMorningShowOnDemandStream()` to frontend `storyService.ts` with 429 rate-limit and 400 subscription error handling
- **#311**: Add 35 tests across 3 files: contract tests (safety_score, provenance), API tests (generate-now, rate limiting, SSE event ordering), unit tests (headline fetcher retry logic)

Fixes #306, Fixes #307, Fixes #311
**Parent Epic**: #44

## Changes Applied
| File | What Changed |
|------|-------------|
| `backend/src/api/routes/morning_show.py` | Wrap `_build_episode` in SSE generator with try/except, yield error event on failure |
| `frontend/src/api/services/storyService.ts` | Add `generateMorningShowOnDemandStream()` SSE method |
| `backend/tests/contracts/test_on_demand_generation.py` | 19 contract tests for request/response/metadata shape |
| `backend/tests/api/test_morning_show_on_demand.py` | 6 API tests for endpoint behavior (400, 429, SSE ordering) |
| `backend/tests/unit/test_news_headline_fetcher.py` | 10 unit tests for retry logic and backoff |

## Test plan
- [x] All 35 new tests pass
- [x] Existing morning show tests pass (no regression)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual: trigger on-demand generation via subscriptions page
- [ ] Manual: verify SSE progress events appear in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)