### PR TITLE
feat(library): replace flat creation chart with rich growth dashboard

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -884,6 +884,22 @@ class LibraryStatsResponse(BaseModel):
     periods: List[LibraryStatsPeriod] = Field(..., description="Creation counts by period")
 
 
+class RichStatsPeriod(BaseModel):
+    """A single period with multi-dimensional growth metrics (#356)."""
+    period: str = Field(..., description="Period label (YYYY-Www or YYYY-MM)")
+    creation_count: int = Field(0, description="Total creations")
+    total_words: int = Field(0, description="Sum of word counts from stories")
+    unique_themes: int = Field(0, description="Distinct themes explored")
+    completion_rate: float = Field(0.0, description="Interactive session completion rate (0-1)")
+    story_type_breakdown: Dict[str, int] = Field(default_factory=dict, description="Count per story type")
+
+
+class RichStatsResponse(BaseModel):
+    """Rich growth dashboard stats (#356)."""
+    periods: List[RichStatsPeriod] = Field(..., description="Per-period growth metrics")
+    streak_days: int = Field(0, description="Current consecutive creation days")
+
+
 class PaginatedNewsResponse(BaseModel):
     """Paginated news history response (#69)."""
     items: List[Dict[str, Any]] = Field(..., description="News story items")

--- a/backend/src/api/routes/library.py
+++ b/backend/src/api/routes/library.py
@@ -31,6 +31,8 @@ from ..models import (
     LibraryStatsGroupBy,
     LibraryStatsPeriod,
     LibraryStatsResponse,
+    RichStatsPeriod,
+    RichStatsResponse,
 )
 
 # Content safety threshold — items below this score are hidden (#81)
@@ -381,6 +383,161 @@ async def get_library_stats(
     ]
 
     return LibraryStatsResponse(periods=periods)
+
+
+# ============================================================================
+# GET /api/v1/library/stats-rich — Rich growth dashboard (#356)
+# ============================================================================
+
+
+@router.get(
+    "/stats-rich",
+    response_model=RichStatsResponse,
+    responses={401: {"model": ErrorResponse}},
+    summary="Get rich growth dashboard stats",
+    description="Returns multi-dimensional growth metrics per period: word count, theme diversity, completion rate, content mix, and streak",
+)
+async def get_rich_stats(
+    group_by: LibraryStatsGroupBy = Query(
+        LibraryStatsGroupBy.WEEK, description="Group by week or month"
+    ),
+    user: UserData = Depends(get_current_user),
+):
+    """Rich growth metrics aggregated per time period (#356).
+
+    Uses existing DB data — no schema changes needed.
+    """
+    fmt = "%Y-%m" if group_by == LibraryStatsGroupBy.MONTH else "%Y-W%W"
+
+    # 1) Stories: count, word_count sum, themes, story_type per period
+    stories_query = f"""
+        SELECT
+            strftime('{fmt}', created_at) AS period,
+            COUNT(*) AS cnt,
+            COALESCE(SUM(word_count), 0) AS total_words,
+            GROUP_CONCAT(themes, '||') AS all_themes,
+            GROUP_CONCAT(story_type, '||') AS all_types
+        FROM stories
+        WHERE user_id = ?
+        GROUP BY period
+        ORDER BY period
+    """
+    story_rows = await db_manager.fetchall(stories_query, (user.user_id,))
+
+    # 2) Sessions: count, completed count per period
+    sessions_query = f"""
+        SELECT
+            strftime('{fmt}', created_at) AS period,
+            COUNT(*) AS total_sessions,
+            SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_sessions
+        FROM sessions
+        WHERE user_id = ?
+        GROUP BY period
+        ORDER BY period
+    """
+    session_rows = await db_manager.fetchall(sessions_query, (user.user_id,))
+
+    # Build lookup from sessions
+    session_map: dict = {}
+    for row in session_rows:
+        if row["period"]:
+            session_map[row["period"]] = row
+
+    # Collect all periods
+    all_periods: dict[str, RichStatsPeriod] = {}
+
+    for row in story_rows:
+        p = row["period"]
+        if not p:
+            continue
+
+        # Parse unique themes from concatenated JSON arrays
+        unique_themes: set[str] = set()
+        if row["all_themes"]:
+            for chunk in row["all_themes"].split("||"):
+                chunk = chunk.strip()
+                if not chunk:
+                    continue
+                try:
+                    parsed = json.loads(chunk)
+                    if isinstance(parsed, list):
+                        unique_themes.update(str(t) for t in parsed)
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+        # Parse story type breakdown
+        type_breakdown: dict[str, int] = {}
+        if row["all_types"]:
+            for t in row["all_types"].split("||"):
+                t = t.strip()
+                if t:
+                    type_breakdown[t] = type_breakdown.get(t, 0) + 1
+
+        # Merge with session data
+        sess = session_map.pop(p, None)
+        total_sess = sess["total_sessions"] if sess else 0
+        completed_sess = sess["completed_sessions"] if sess else 0
+        creation_count = row["cnt"] + total_sess
+        completion_rate = (
+            round(completed_sess / total_sess, 2)
+            if total_sess > 0
+            else 0.0
+        )
+        if total_sess > 0:
+            type_breakdown["interactive"] = type_breakdown.get("interactive", 0) + total_sess
+
+        all_periods[p] = RichStatsPeriod(
+            period=p,
+            creation_count=creation_count,
+            total_words=row["total_words"],
+            unique_themes=len(unique_themes),
+            completion_rate=completion_rate,
+            story_type_breakdown=type_breakdown,
+        )
+
+    # Add session-only periods (no stories that period)
+    for p, sess in session_map.items():
+        all_periods[p] = RichStatsPeriod(
+            period=p,
+            creation_count=sess["total_sessions"],
+            total_words=0,
+            unique_themes=0,
+            completion_rate=(
+                round(sess["completed_sessions"] / sess["total_sessions"], 2)
+                if sess["total_sessions"] > 0
+                else 0.0
+            ),
+            story_type_breakdown={"interactive": sess["total_sessions"]},
+        )
+
+    # 3) Streak: consecutive days with any creation (from daily_usage)
+    streak_query = """
+        SELECT DISTINCT usage_date
+        FROM daily_usage
+        WHERE user_id = ? AND count > 0
+        ORDER BY usage_date DESC
+    """
+    usage_rows = await db_manager.fetchall(streak_query, (user.user_id,))
+
+    streak = 0
+    if usage_rows:
+        from datetime import date, timedelta
+
+        today = date.today()
+        expected = today
+        for row in usage_rows:
+            try:
+                d = date.fromisoformat(row["usage_date"])
+            except (ValueError, TypeError):
+                break
+            if d == expected:
+                streak += 1
+                expected = d - timedelta(days=1)
+            elif d < expected:
+                break
+
+    sorted_periods = sorted(all_periods.values(), key=lambda x: x.period)
+    return RichStatsResponse(periods=sorted_periods, streak_days=streak)
 
 
 # ============================================================================

--- a/frontend/src/api/services/libraryService.ts
+++ b/frontend/src/api/services/libraryService.ts
@@ -56,6 +56,20 @@ export interface LibraryStatsResponse {
   periods: LibraryStatsPeriod[]
 }
 
+export interface RichStatsPeriod {
+  period: string
+  creation_count: number
+  total_words: number
+  unique_themes: number
+  completion_rate: number
+  story_type_breakdown: Record<string, number>
+}
+
+export interface RichStatsResponse {
+  periods: RichStatsPeriod[]
+  streak_days: number
+}
+
 // ---- API ----
 
 const LIBRARY_BASE = '/library'
@@ -104,6 +118,16 @@ export const libraryService = {
    */
   async getStats(groupBy: StatsGroupBy = 'week'): Promise<LibraryStatsResponse> {
     const response = await apiClient.get<LibraryStatsResponse>(`${LIBRARY_BASE}/stats`, {
+      params: { group_by: groupBy },
+    })
+    return response.data
+  },
+
+  /**
+   * GET /api/v1/library/stats-rich — Rich growth dashboard metrics (#356)
+   */
+  async getRichStats(groupBy: StatsGroupBy = 'week'): Promise<RichStatsResponse> {
+    const response = await apiClient.get<RichStatsResponse>(`${LIBRARY_BASE}/stats-rich`, {
       params: { group_by: groupBy },
     })
     return response.data

--- a/frontend/src/components/library/GrowthTimeline/index.tsx
+++ b/frontend/src/components/library/GrowthTimeline/index.tsx
@@ -1,8 +1,8 @@
 /**
- * GrowthTimeline — Pure SVG bar chart for creation frequency (#134)
+ * GrowthTimeline — Rich growth dashboard for creative development (#356)
  *
- * Shows creation counts grouped by week or month.
- * No external chart library — lightweight SVG rendering.
+ * Replaces the flat creation-count bar chart with meaningful metrics:
+ * word count trend, theme diversity, completion rate, content mix, and streak.
  */
 
 import { useState } from 'react'
@@ -10,136 +10,148 @@ import { useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import { TrendingUp } from 'lucide-react'
 import { libraryService } from '@/api/services/libraryService'
-import type { StatsGroupBy, LibraryStatsPeriod } from '@/api/services/libraryService'
+import type { StatsGroupBy, RichStatsPeriod } from '@/api/services/libraryService'
 
-// ---- SVG Bar Chart ----
+// ---- Metric Card ----
 
-const CHART_HEIGHT = 180
-const BAR_GAP = 6
-const LABEL_HEIGHT = 32
-const Y_AXIS_WIDTH = 36
-const BAR_WIDTH = 24
-const CELL_WIDTH = BAR_WIDTH + BAR_GAP * 2
-
-function formatPeriodLabel(period: string, groupBy: StatsGroupBy): string {
-  if (groupBy === 'month') {
-    // "2026-03" → "Mar"
-    const [, month] = period.split('-')
-    const date = new Date(2000, parseInt(month, 10) - 1)
-    return date.toLocaleString('en-US', { month: 'short' })
-  }
-  // "2026-W10" → "W10"
-  const match = period.match(/W(\d+)/)
-  return match ? `W${match[1]}` : period
-}
-
-function BarChart({
-  periods,
-  groupBy,
+function MetricCard({
+  icon,
+  label,
+  value,
+  sub,
+  trend,
 }: {
-  periods: LibraryStatsPeriod[]
-  groupBy: StatsGroupBy
+  icon: string
+  label: string
+  value: string | number
+  sub?: string
+  trend?: 'up' | 'down' | 'flat'
 }) {
-  const maxCount = Math.max(...periods.map((p) => p.count), 1)
-  // Round up to a nice tick ceiling (multiples of 2 for small, 5 for larger)
-  const tickStep = maxCount <= 6 ? 2 : 5
-  const tickMax = Math.ceil(maxCount / tickStep) * tickStep || tickStep
-
-  const barAreaWidth = periods.length * CELL_WIDTH
-  const svgWidth = barAreaWidth + Y_AXIS_WIDTH + 16
-  const svgHeight = CHART_HEIGHT + LABEL_HEIGHT + 12
-
-  // Generate evenly spaced ticks
-  const tickCount = Math.min(tickMax / tickStep, 5)
-  const ticks = Array.from({ length: tickCount + 1 }, (_, i) =>
-    Math.round((i * tickMax) / tickCount)
-  )
+  const trendIcon = trend === 'up' ? '↑' : trend === 'down' ? '↓' : ''
+  const trendColor = trend === 'up' ? 'text-emerald-500' : trend === 'down' ? 'text-red-400' : ''
 
   return (
-    <div className="overflow-x-auto -mx-2 px-2">
-      <svg
-        width={svgWidth}
-        height={svgHeight}
-        className="block"
-        role="img"
-        aria-label="Creation frequency chart"
-      >
-        {/* Y-axis ticks + grid lines */}
-        {ticks.map((tick) => {
-          const y = CHART_HEIGHT - (tick / tickMax) * CHART_HEIGHT + 6
-          return (
-            <g key={tick}>
-              <text
-                x={Y_AXIS_WIDTH - 6}
-                y={y}
-                textAnchor="end"
-                className="fill-gray-400"
-                fontSize={11}
-                dominantBaseline="middle"
-              >
-                {tick}
-              </text>
-              <line
-                x1={Y_AXIS_WIDTH}
-                y1={y}
-                x2={svgWidth - 8}
-                y2={y}
-                stroke="#e5e7eb"
-                strokeWidth={1}
-                strokeDasharray={tick === 0 ? undefined : '4 3'}
-              />
-            </g>
-          )
-        })}
+    <motion.div
+      className="bg-white rounded-2xl border border-gray-100 p-4 shadow-sm"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-lg">{icon}</span>
+        <span className="text-xs font-medium text-gray-400 uppercase tracking-wide">{label}</span>
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-2xl font-bold text-gray-800">{value}</span>
+        {trend && <span className={`text-sm font-semibold ${trendColor}`}>{trendIcon}</span>}
+      </div>
+      {sub && <p className="text-xs text-gray-400 mt-0.5">{sub}</p>}
+    </motion.div>
+  )
+}
 
-        {/* Bars */}
-        {periods.map((p, i) => {
-          const x = Y_AXIS_WIDTH + 8 + i * CELL_WIDTH + BAR_GAP
-          const barH = Math.max((p.count / tickMax) * CHART_HEIGHT, p.count > 0 ? 4 : 0)
-          const y = CHART_HEIGHT - barH + 6
+// ---- Word Count Mini Chart ----
 
-          return (
-            <g key={p.period}>
-              <motion.rect
-                x={x}
-                y={y}
-                width={BAR_WIDTH}
-                height={barH}
-                rx={4}
-                className="fill-primary/70 hover:fill-primary transition-colors"
-                initial={{ height: 0, y: CHART_HEIGHT + 6 }}
-                animate={{ height: barH, y }}
-                transition={{ duration: 0.5, delay: i * 0.05 }}
-              />
-              {/* Count label on top of bar */}
-              {p.count > 0 && (
-                <text
-                  x={x + BAR_WIDTH / 2}
-                  y={y - 6}
-                  textAnchor="middle"
-                  className="fill-gray-600"
-                  fontSize={11}
-                  fontWeight={600}
-                >
-                  {p.count}
-                </text>
-              )}
-              {/* X-axis label */}
-              <text
-                x={x + BAR_WIDTH / 2}
-                y={CHART_HEIGHT + 22}
-                textAnchor="middle"
-                className="fill-gray-500"
-                fontSize={10}
-              >
-                {formatPeriodLabel(p.period, groupBy)}
-              </text>
-            </g>
-          )
-        })}
-      </svg>
+function WordTrendChart({ periods }: { periods: RichStatsPeriod[] }) {
+  if (periods.length < 2) return null
+
+  const values = periods.map((p) => p.total_words)
+  const max = Math.max(...values, 1)
+  const width = 240
+  const height = 48
+  const step = width / (values.length - 1)
+
+  const points = values.map((v, i) => `${i * step},${height - (v / max) * height}`).join(' ')
+
+  return (
+    <svg width={width} height={height} className="block mt-2">
+      <polyline
+        fill="none"
+        stroke="url(#wordGrad)"
+        strokeWidth={2.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        points={points}
+      />
+      <defs>
+        <linearGradient id="wordGrad" x1="0" y1="0" x2="1" y2="0">
+          <stop offset="0%" stopColor="#818cf8" />
+          <stop offset="100%" stopColor="#34d399" />
+        </linearGradient>
+      </defs>
+    </svg>
+  )
+}
+
+// ---- Content Mix Bar ----
+
+function ContentMixBar({ breakdown }: { breakdown: Record<string, number> }) {
+  const total = Object.values(breakdown).reduce((s, v) => s + v, 0)
+  if (total === 0) return null
+
+  const colors: Record<string, string> = {
+    image_to_story: 'bg-violet-400',
+    kids_daily: 'bg-sky-400',
+    interactive: 'bg-emerald-400',
+    news_to_kids: 'bg-amber-400',
+    morning_show: 'bg-sky-400',
+  }
+
+  const labels: Record<string, string> = {
+    image_to_story: '🎨 Art',
+    kids_daily: '🎙️ Podcast',
+    interactive: '🎭 Interactive',
+    news_to_kids: '📰 News',
+    morning_show: '🎙️ Podcast',
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex h-3 rounded-full overflow-hidden">
+        {Object.entries(breakdown).map(([type, count]) => (
+          <div
+            key={type}
+            className={`${colors[type] || 'bg-gray-300'} transition-all`}
+            style={{ width: `${(count / total) * 100}%` }}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+        {Object.entries(breakdown).map(([type, count]) => (
+          <span key={type} className="text-[10px] text-gray-400">
+            {labels[type] || type} {count}
+          </span>
+        ))}
+      </div>
     </div>
   )
+}
+
+// ---- Streak Badge ----
+
+function StreakBadge({ days }: { days: number }) {
+  if (days < 1) return null
+  return (
+    <motion.div
+      className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-gradient-to-r from-orange-400 to-amber-400 text-white text-sm font-bold shadow-md"
+      initial={{ scale: 0.8, opacity: 0 }}
+      animate={{ scale: 1, opacity: 1 }}
+      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+    >
+      <span>🔥</span>
+      <span>{days}-day streak!</span>
+    </motion.div>
+  )
+}
+
+// ---- Trend helper ----
+
+function getTrend(periods: RichStatsPeriod[], key: keyof RichStatsPeriod): 'up' | 'down' | 'flat' {
+  if (periods.length < 2) return 'flat'
+  const curr = periods[periods.length - 1][key] as number
+  const prev = periods[periods.length - 2][key] as number
+  if (curr > prev) return 'up'
+  if (curr < prev) return 'down'
+  return 'flat'
 }
 
 // ---- Empty State ----
@@ -151,9 +163,7 @@ function EmptyState() {
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
     >
-      <div className="text-5xl mb-4">
-        <TrendingUp size={48} className="text-gray-300 mx-auto" />
-      </div>
+      <TrendingUp size={48} className="text-gray-300 mx-auto mb-4" />
       <h3 className="text-lg font-semibold text-gray-600 mb-2">
         Your growth story starts here!
       </h3>
@@ -170,12 +180,25 @@ export default function GrowthTimeline() {
   const [groupBy, setGroupBy] = useState<StatsGroupBy>('week')
 
   const { data, isLoading } = useQuery({
-    queryKey: ['library-stats', groupBy],
-    queryFn: () => libraryService.getStats(groupBy),
+    queryKey: ['library-stats-rich', groupBy],
+    queryFn: () => libraryService.getRichStats(groupBy),
   })
 
   const periods = data?.periods ?? []
-  const totalCreations = periods.reduce((sum, p) => sum + p.count, 0)
+  const streak = data?.streak_days ?? 0
+
+  // Aggregate latest period for headline metrics
+  const latest = periods.length > 0 ? periods[periods.length - 1] : null
+  const totalWords = periods.reduce((s, p) => s + p.total_words, 0)
+  const totalCreations = periods.reduce((s, p) => s + p.creation_count, 0)
+
+  // Aggregate content mix across all periods
+  const allMix: Record<string, number> = {}
+  for (const p of periods) {
+    for (const [type, count] of Object.entries(p.story_type_breakdown)) {
+      allMix[type] = (allMix[type] || 0) + count
+    }
+  }
 
   return (
     <motion.div
@@ -183,18 +206,12 @@ export default function GrowthTimeline() {
       animate={{ opacity: 1, y: 0 }}
       className="space-y-4"
     >
-      {/* Header with group-by toggle */}
-      <div className="flex items-center justify-between">
+      {/* Header with toggle + streak */}
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <div className="flex items-center gap-2">
           <TrendingUp size={18} className="text-primary" />
-          <span className="text-sm font-semibold text-gray-700">
-            Growth Timeline
-          </span>
-          {totalCreations > 0 && (
-            <span className="text-xs text-gray-400">
-              ({totalCreations} total)
-            </span>
-          )}
+          <span className="text-sm font-semibold text-gray-700">Growth Dashboard</span>
+          <StreakBadge days={streak} />
         </div>
         <div className="flex bg-gray-100 rounded-lg p-0.5">
           {(['week', 'month'] as StatsGroupBy[]).map((option) => (
@@ -213,18 +230,68 @@ export default function GrowthTimeline() {
         </div>
       </div>
 
-      {/* Chart area */}
-      <div className="bg-white rounded-2xl border border-gray-200/80 p-4 shadow-sm">
-        {isLoading ? (
-          <div className="flex items-center justify-center py-16">
-            <div className="w-6 h-6 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+      {/* Content */}
+      {isLoading ? (
+        <div className="flex items-center justify-center py-16">
+          <div className="w-6 h-6 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
+        </div>
+      ) : periods.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="space-y-4">
+          {/* Metric cards grid */}
+          <div className="grid grid-cols-2 gap-3">
+            <MetricCard
+              icon="✍️"
+              label="Total Words"
+              value={totalWords.toLocaleString()}
+              sub={latest ? `${latest.total_words.toLocaleString()} this ${groupBy}` : undefined}
+              trend={getTrend(periods, 'total_words')}
+            />
+            <MetricCard
+              icon="🎨"
+              label="Themes Explored"
+              value={latest?.unique_themes ?? 0}
+              sub={`this ${groupBy}`}
+              trend={getTrend(periods, 'unique_themes')}
+            />
+            <MetricCard
+              icon="🎭"
+              label="Completion"
+              value={latest ? `${Math.round(latest.completion_rate * 100)}%` : '—'}
+              sub="interactive stories"
+              trend={getTrend(periods, 'completion_rate')}
+            />
+            <MetricCard
+              icon="📚"
+              label="Creations"
+              value={totalCreations}
+              sub={latest ? `${latest.creation_count} this ${groupBy}` : undefined}
+              trend={getTrend(periods, 'creation_count')}
+            />
           </div>
-        ) : periods.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <BarChart periods={periods} groupBy={groupBy} />
-        )}
-      </div>
+
+          {/* Word count trend */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4 shadow-sm">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-1">
+              Word Count Trend
+            </p>
+            <WordTrendChart periods={periods} />
+            <div className="flex justify-between text-[10px] text-gray-300 mt-1">
+              <span>{periods[0]?.period}</span>
+              <span>{periods[periods.length - 1]?.period}</span>
+            </div>
+          </div>
+
+          {/* Content mix */}
+          <div className="bg-white rounded-2xl border border-gray-100 p-4 shadow-sm">
+            <p className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2">
+              Content Mix
+            </p>
+            <ContentMixBar breakdown={allMix} />
+          </div>
+        </div>
+      )}
     </motion.div>
   )
 }


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/library/stats-rich` backend endpoint — returns per-period: word count, unique themes, completion rate, content mix breakdown, and creation streak
- All computed from existing DB data (stories + sessions + daily_usage) — **no schema changes**
- Redesign `GrowthTimeline` frontend component with:
  - 4 metric cards (Total Words, Themes Explored, Completion Rate, Creations) with trend arrows
  - Word count sparkline chart
  - Content mix stacked bar (art/podcast/interactive)
  - Streak badge (🔥 7-day streak!)
- Old `GET /api/v1/library/stats` endpoint unchanged (backward compatible)

Fixes #356
Related to #49 (Epic: My Library)

## Test plan
- [ ] Open Library → Growth Timeline → see metric cards with real data
- [ ] Toggle Weekly/Monthly → data refreshes correctly
- [ ] Word count trend shows sparkline with actual trajectory
- [ ] Content mix bar shows breakdown of story types
- [ ] Streak badge shows when user has consecutive creation days
- [ ] Empty state still works for new users with no data
- [ ] Old `/stats` endpoint still returns same data as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)