### PR TITLE
feat(database): add dual-driver adapter pattern (SQLite dev / PostgreSQL prod)

### DIFF
--- a/backend/src/services/database/__init__.py
+++ b/backend/src/services/database/__init__.py
@@ -20,6 +20,7 @@ from .subscription_repository import (
     MaxSubscriptionsExceededError,
 )
 from .usage_repository import UsageRepository, usage_repo
+from .referral_repository import ReferralRepository, referral_repo
 
 __all__ = [
     "CursorResult",
@@ -48,4 +49,6 @@ __all__ = [
     "MaxSubscriptionsExceededError",
     "UsageRepository",
     "usage_repo",
+    "ReferralRepository",
+    "referral_repo",
 ]


### PR DESCRIPTION
## Summary

- Introduce `DatabaseAdapter` protocol with factory pattern that selects aiosqlite (dev) or asyncpg (prod) based on `DATABASE_URL` env var
- Extract SQLite logic into `SQLiteAdapter` with identical behavior to original `DatabaseManager`
- Add `PostgresAdapter` with connection pooling, `?` → `$N` placeholder translation, and `Record` → `dict` conversion
- `DatabaseManager` becomes a backward-compatible facade — all existing code keeps working unchanged
- `CursorResult` normalizes `execute()` return values across both drivers (`.rowcount` attribute)

## Files Changed

| File | Change |
|------|--------|
| `adapter.py` | NEW: `DatabaseAdapter` protocol + `CursorResult` + `create_adapter()` factory |
| `sqlite_adapter.py` | NEW: aiosqlite implementation (extracted from `DatabaseManager`) |
| `postgres_adapter.py` | NEW: asyncpg with pooling + placeholder translation |
| `connection.py` | REFACTORED: thin facade delegating to adapter |
| `__init__.py` | UPDATED: export `CursorResult`, `DatabaseAdapter`, `create_adapter` |
| `requirements.txt` | UPDATED: add `asyncpg>=0.29.0` |

## Test plan

- [x] All 256 existing API + contract tests pass unchanged (SQLite path)
- [x] Import verification: `from src.services.database import CursorResult, DatabaseAdapter`
- [x] `db_manager.dialect` returns `"sqlite"` when no `DATABASE_URL` set
- [ ] PostgreSQL adapter tested against real Supabase instance (follow-up: #345)

Fixes #340
**Parent Epic**: #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)