### PR TITLE
feat(referral): accept referral code during registration

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -682,6 +682,11 @@ class UserRegisterRequest(BaseModel):
         max_length=100,
         description="显示名称"
     )
+    referral_code: Optional[str] = Field(
+        None,
+        max_length=8,
+        description="Referral code from share link (optional)"
+    )
 
     @field_validator('email')
     @classmethod

--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -81,7 +81,8 @@ async def register(request: UserRegisterRequest):
         username=request.username,
         email=request.email,
         password=request.password,
-        display_name=request.display_name
+        display_name=request.display_name,
+        referral_code=request.referral_code
     )
 
     if not result.success:

--- a/backend/src/services/database/user_repository.py
+++ b/backend/src/services/database/user_repository.py
@@ -153,6 +153,14 @@ class UserRepository:
         )
         return self._row_to_user(row) if row else None
 
+    async def get_by_referral_code(self, referral_code: str) -> Optional[UserData]:
+        """Get a user by their referral code."""
+        row = await self._db.fetchone(
+            "SELECT * FROM users WHERE referral_code = ?",
+            (referral_code,)
+        )
+        return self._row_to_user(row) if row else None
+
     async def get_by_email(self, email: str) -> Optional[UserData]:
         """
         Get a user by email (case-insensitive).

--- a/backend/src/services/user_service.py
+++ b/backend/src/services/user_service.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 from typing import Optional, Tuple
 from dataclasses import dataclass
 
-from .database import user_repo, db_manager, UserData
+from .database import user_repo, referral_repo, db_manager, UserData
 
 
 @dataclass
@@ -170,7 +170,8 @@ class UserService:
         username: str,
         email: str,
         password: str,
-        display_name: Optional[str] = None
+        display_name: Optional[str] = None,
+        referral_code: Optional[str] = None
     ) -> AuthResult:
         """
         User registration
@@ -180,6 +181,7 @@ class UserService:
             email: Email address
             password: Password
             display_name: Display name
+            referral_code: Referral code from share link (optional)
 
         Returns:
             AuthResult: Registration result
@@ -204,14 +206,35 @@ class UserService:
         if await self._repo.check_email_exists(email):
             return AuthResult(success=False, error="Email already registered")
 
+        # Look up referrer by code (silently ignore invalid codes)
+        referred_by = None
+        referrer_user_id = None
+        if referral_code:
+            referrer = await self._repo.get_by_referral_code(referral_code)
+            if referrer:
+                referred_by = referral_code
+                referrer_user_id = referrer.user_id
+
         # Create user
         password_hash, _ = self._hash_password(password)
         user = await self._repo.create_user(
             username=username,
             email=email,
             password_hash=password_hash,
-            display_name=display_name
+            display_name=display_name,
+            referred_by=referred_by
         )
+
+        # Create referral record if valid referrer found
+        if referrer_user_id:
+            try:
+                await referral_repo.create_referral(
+                    referrer_user_id=referrer_user_id,
+                    referred_user_id=user.user_id,
+                    referral_code=referral_code
+                )
+            except Exception:
+                pass  # Silently ignore (e.g. duplicate referral)
 
         # Generate token
         token = await self._generate_token(user.user_id)

--- a/backend/tests/api/test_registration_referral.py
+++ b/backend/tests/api/test_registration_referral.py
@@ -1,0 +1,124 @@
+"""
+Registration Referral Tests (#349)
+
+Tests that registration accepts an optional referral_code parameter
+and creates referral records when the code is valid.
+"""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserRepository
+from backend.src.services.database.referral_repository import ReferralRepository
+from backend.src.services.user_service import UserService
+
+
+@pytest_asyncio.fixture
+async def service():
+    """UserService with in-memory database."""
+    db = DatabaseManager(":memory:")
+    await db.connect()
+    await init_schema(db)
+
+    user_repo = UserRepository()
+    user_repo._db = db
+
+    ref_repo = ReferralRepository()
+    ref_repo._db = db
+
+    svc = UserService()
+    svc._repo = user_repo
+    svc._db = db
+
+    # Patch the module-level referral_repo used inside register().
+    # Note: `backend.src.services.user_service` resolves to the UserService
+    # singleton due to __init__.py re-export, so we use sys.modules instead.
+    import sys
+    _us_mod = sys.modules["backend.src.services.user_service"]
+    _original_ref_repo = _us_mod.referral_repo
+    _us_mod.referral_repo = ref_repo
+
+    yield {"svc": svc, "user_repo": user_repo, "ref_repo": ref_repo, "db": db}
+
+    _us_mod.referral_repo = _original_ref_repo
+    await db.disconnect()
+
+
+@pytest_asyncio.fixture
+async def referrer(service):
+    """Create a referrer user and return their data."""
+    result = await service["svc"].register(
+        username="referrer", email="referrer@test.com", password="password123"
+    )
+    return result.user
+
+
+class TestRegistrationWithReferralCode:
+    """Registration accepts optional referral_code."""
+
+    @pytest.mark.asyncio
+    async def test_register_without_referral_code(self, service):
+        result = await service["svc"].register(
+            username="noreferral", email="noreferral@test.com",
+            password="password123"
+        )
+        assert result.success is True
+        assert result.user.referred_by is None
+
+    @pytest.mark.asyncio
+    async def test_register_with_valid_referral_code(self, service, referrer):
+        result = await service["svc"].register(
+            username="referred1", email="referred1@test.com",
+            password="password123",
+            referral_code=referrer.referral_code
+        )
+        assert result.success is True
+        assert result.user.referred_by == referrer.referral_code
+
+    @pytest.mark.asyncio
+    async def test_valid_referral_creates_referral_record(self, service, referrer):
+        result = await service["svc"].register(
+            username="referred2", email="referred2@test.com",
+            password="password123",
+            referral_code=referrer.referral_code
+        )
+        ref = await service["ref_repo"].get_referral_by_referred_user(result.user.user_id)
+        assert ref is not None
+        assert ref["referrer_user_id"] == referrer.user_id
+        assert ref["referral_code"] == referrer.referral_code
+        assert ref["is_qualified"] == 0
+
+    @pytest.mark.asyncio
+    async def test_register_with_invalid_referral_code(self, service):
+        result = await service["svc"].register(
+            username="badreferral", email="badreferral@test.com",
+            password="password123",
+            referral_code="INVALID1"
+        )
+        assert result.success is True
+        assert result.user.referred_by is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_referral_no_record_created(self, service):
+        result = await service["svc"].register(
+            username="badreferral2", email="badreferral2@test.com",
+            password="password123",
+            referral_code="XXXXXXXX"
+        )
+        ref = await service["ref_repo"].get_referral_by_referred_user(result.user.user_id)
+        assert ref is None
+
+    @pytest.mark.asyncio
+    async def test_referral_count_increments(self, service, referrer):
+        for i in range(3):
+            await service["svc"].register(
+                username=f"ref_count_{i}", email=f"ref_count_{i}@test.com",
+                password="password123",
+                referral_code=referrer.referral_code
+            )
+        count = await service["ref_repo"].get_referral_count(referrer.user_id)
+        assert count == 3


### PR DESCRIPTION
## Summary

- Registration API accepts optional `referral_code` in request body
- Valid codes create a referral record and set `referred_by` on the new user
- Invalid/missing codes are silently ignored — registration always succeeds
- New `get_by_referral_code()` method on UserRepository

Fixes #349
**Parent Epic**: #346

## Test plan

- [x] 6 tests in `test_registration_referral.py`: no code, valid code, invalid code, record creation, count increment

🤖 Generated with [Claude Code](https://claude.com/claude-code)