### PR TITLE
feat(referral): add referral status API, auto-upgrade, and tier quota

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -22,6 +22,7 @@ from ..services.supabase_auth import decode_supabase_token
 from ..services.user_service import UserData, user_service
 
 _DEFAULT_DAILY_QUOTA = 6
+_TIER_QUOTA = {"free": 3, "plus": 9}
 
 
 def _is_development_env() -> bool:
@@ -29,12 +30,19 @@ def _is_development_env() -> bool:
     return env in {"development", "dev", "local"}
 
 
-def _get_daily_quota() -> int:
-    try:
-        quota = int(os.getenv("DAILY_GENERATION_QUOTA", _DEFAULT_DAILY_QUOTA))
-        return quota if quota > 0 else _DEFAULT_DAILY_QUOTA
-    except (ValueError, TypeError):
-        return _DEFAULT_DAILY_QUOTA
+def _get_daily_quota(membership_tier: str = "free") -> int:
+    """Return daily quota based on membership tier.
+
+    Priority: env var override > tier-based default > global default.
+    """
+    env_quota = os.getenv("DAILY_GENERATION_QUOTA")
+    if env_quota:
+        try:
+            quota = int(env_quota)
+            return quota if quota > 0 else _DEFAULT_DAILY_QUOTA
+        except (ValueError, TypeError):
+            pass
+    return _TIER_QUOTA.get(membership_tier, _DEFAULT_DAILY_QUOTA)
 
 
 def _is_pytest_runtime() -> bool:
@@ -213,7 +221,8 @@ async def check_generation_quota(
     if _allow_test_auth_bypass() or _is_development_env():
         return user
 
-    quota = _get_daily_quota()
+    tier = getattr(user, 'membership_tier', 'free') or 'free'
+    quota = _get_daily_quota(tier)
     used = await usage_repo.get_usage_today(user.user_id)
     if used >= quota:
         resets_at = (await usage_repo.get_quota_status(user.user_id, quota))[

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -738,6 +738,16 @@ class UserResponse(BaseModel):
     last_login_at: Optional[datetime] = Field(None, description="最后登录时间")
 
 
+class ReferralStatusResponse(BaseModel):
+    """Referral progress and membership tier status (PRD §3.9.4)"""
+    referral_code: str = Field(..., description="User's unique referral code")
+    share_url: str = Field(..., description="Shareable referral link")
+    qualified_count: int = Field(0, description="Verified referrals count")
+    total_count: int = Field(0, description="Total referrals count")
+    upgrade_threshold: int = Field(10, description="Qualified referrals needed for Plus")
+    membership_tier: str = Field("free", description="Current membership tier")
+
+
 class UserWithStatsResponse(UserResponse):
     """User info with content statistics"""
     story_count: int = Field(0, description="Total stories created")

--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -14,6 +14,7 @@ from ..models import (
     UserResponse,
     PublicUserResponse,
     UserWithStatsResponse,
+    ReferralStatusResponse,
     TokenResponse,
     AuthResponse,
     ChangePasswordRequest,
@@ -22,6 +23,7 @@ from ..models import (
 )
 from ..deps import get_current_user
 from ...services.user_service import user_service, UserData
+from ...services.database import referral_repo
 
 
 router = APIRouter(
@@ -143,6 +145,28 @@ async def login(request: UserLoginRequest):
             token_type=result.token.token_type,
             expires_in=result.token.expires_in
         )
+    )
+
+
+@router.get(
+    "/me/referrals",
+    response_model=ReferralStatusResponse,
+    summary="Get referral status",
+    description="Returns referral progress, share link, and membership tier"
+)
+async def get_referral_status(user: UserData = Depends(get_current_user)):
+    """Get the current user's referral status and membership tier."""
+    import os
+    base_url = os.getenv("FRONTEND_URL", "https://app.example.com")
+    qualified = await referral_repo.get_referral_count(user.user_id, qualified_only=True)
+    total = await referral_repo.get_referral_count(user.user_id)
+    return ReferralStatusResponse(
+        referral_code=user.referral_code,
+        share_url=f"{base_url}/login?ref={user.referral_code}",
+        qualified_count=qualified,
+        total_count=total,
+        upgrade_threshold=10,
+        membership_tier=user.membership_tier,
     )
 
 

--- a/backend/src/services/database/user_repository.py
+++ b/backend/src/services/database/user_repository.py
@@ -177,6 +177,16 @@ class UserRepository:
         )
         return self._row_to_user(row) if row else None
 
+    async def update_membership_tier(self, user_id: str, tier: str) -> bool:
+        """Update a user's membership tier."""
+        now = datetime.now().isoformat()
+        cursor = await self._db.execute(
+            "UPDATE users SET membership_tier = ?, updated_at = ? WHERE user_id = ?",
+            (tier, now, user_id)
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
     async def update_user(
         self,
         user_id: str,

--- a/backend/src/services/user_service.py
+++ b/backend/src/services/user_service.py
@@ -245,6 +245,33 @@ class UserService:
             token=token
         )
 
+    async def qualify_and_maybe_upgrade(self, referred_user_id: str) -> bool:
+        """Qualify a referral and auto-upgrade the referrer if threshold reached.
+
+        Called when a referred user verifies their email.
+
+        Returns:
+            True if the referrer was upgraded to Plus tier.
+        """
+        qualified = await referral_repo.qualify_referral(referred_user_id)
+        if not qualified:
+            return False
+
+        ref = await referral_repo.get_referral_by_referred_user(referred_user_id)
+        if not ref:
+            return False
+
+        referrer_id = ref["referrer_user_id"]
+        referrer = await self._repo.get_by_id(referrer_id)
+        if not referrer or referrer.membership_tier == "plus":
+            return False
+
+        if await referral_repo.check_upgrade_eligible(referrer_id):
+            await self._repo.update_membership_tier(referrer_id, "plus")
+            return True
+
+        return False
+
     async def login(
         self,
         username_or_email: str,

--- a/backend/tests/api/test_referral_status.py
+++ b/backend/tests/api/test_referral_status.py
@@ -1,0 +1,151 @@
+"""
+Referral Status API and Auto-Upgrade Tests (#350)
+
+Tests for:
+- GET /me/referrals endpoint
+- Auto-upgrade logic when threshold reached
+- Tier-based quota enforcement
+"""
+
+import os
+import sys
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserRepository
+from backend.src.services.database.referral_repository import ReferralRepository
+from backend.src.services.user_service import UserService
+from backend.src.api.deps import _get_daily_quota
+
+
+@pytest_asyncio.fixture
+async def env():
+    """Full test environment with in-memory DB."""
+    db = DatabaseManager(":memory:")
+    await db.connect()
+    await init_schema(db)
+
+    user_repo = UserRepository()
+    user_repo._db = db
+
+    ref_repo = ReferralRepository()
+    ref_repo._db = db
+
+    svc = UserService()
+    svc._repo = user_repo
+    svc._db = db
+
+    # Patch module-level referral_repo
+    _mod = sys.modules["backend.src.services.user_service"]
+    _orig = _mod.referral_repo
+    _mod.referral_repo = ref_repo
+
+    yield {
+        "svc": svc,
+        "user_repo": user_repo,
+        "ref_repo": ref_repo,
+        "db": db,
+    }
+
+    _mod.referral_repo = _orig
+    await db.disconnect()
+
+
+class TestAutoUpgrade:
+    """qualify_and_maybe_upgrade promotes referrer at threshold."""
+
+    @pytest.mark.asyncio
+    async def test_qualify_upgrades_at_threshold(self, env):
+        svc, user_repo, ref_repo = env["svc"], env["user_repo"], env["ref_repo"]
+
+        referrer = await svc.register(
+            username="upgrader", email="upgrader@test.com", password="password123"
+        )
+        referrer_user = referrer.user
+
+        # Create 10 referrals and qualify 9 (below threshold)
+        referred_ids = []
+        for i in range(10):
+            r = await svc.register(
+                username=f"ref_{i}", email=f"ref_{i}@test.com",
+                password="password123",
+                referral_code=referrer_user.referral_code,
+            )
+            referred_ids.append(r.user.user_id)
+
+        for uid in referred_ids[:9]:
+            await svc.qualify_and_maybe_upgrade(uid)
+
+        # Referrer should still be free
+        user = await user_repo.get_by_id(referrer_user.user_id)
+        assert user.membership_tier == "free"
+
+        # Qualify the 10th — should trigger upgrade
+        upgraded = await svc.qualify_and_maybe_upgrade(referred_ids[9])
+        assert upgraded is True
+
+        user = await user_repo.get_by_id(referrer_user.user_id)
+        assert user.membership_tier == "plus"
+
+    @pytest.mark.asyncio
+    async def test_already_plus_not_affected(self, env):
+        svc, user_repo, ref_repo = env["svc"], env["user_repo"], env["ref_repo"]
+
+        referrer = await svc.register(
+            username="already_plus", email="already_plus@test.com",
+            password="password123"
+        )
+        await user_repo.update_membership_tier(referrer.user.user_id, "plus")
+
+        r = await svc.register(
+            username="extra_ref", email="extra_ref@test.com",
+            password="password123",
+            referral_code=referrer.user.referral_code,
+        )
+        result = await svc.qualify_and_maybe_upgrade(r.user.user_id)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_qualify_nonexistent_returns_false(self, env):
+        result = await env["svc"].qualify_and_maybe_upgrade("nonexistent-id")
+        assert result is False
+
+
+class TestTierBasedQuota:
+    """_get_daily_quota returns tier-appropriate limits."""
+
+    def test_free_tier_quota(self):
+        # Clear env override if set
+        orig = os.environ.pop("DAILY_GENERATION_QUOTA", None)
+        try:
+            assert _get_daily_quota("free") == 3
+        finally:
+            if orig is not None:
+                os.environ["DAILY_GENERATION_QUOTA"] = orig
+
+    def test_plus_tier_quota(self):
+        orig = os.environ.pop("DAILY_GENERATION_QUOTA", None)
+        try:
+            assert _get_daily_quota("plus") == 9
+        finally:
+            if orig is not None:
+                os.environ["DAILY_GENERATION_QUOTA"] = orig
+
+    def test_env_override_takes_precedence(self):
+        os.environ["DAILY_GENERATION_QUOTA"] = "20"
+        try:
+            assert _get_daily_quota("free") == 20
+            assert _get_daily_quota("plus") == 20
+        finally:
+            del os.environ["DAILY_GENERATION_QUOTA"]
+
+    def test_unknown_tier_returns_default(self):
+        orig = os.environ.pop("DAILY_GENERATION_QUOTA", None)
+        try:
+            assert _get_daily_quota("unknown") == 6
+        finally:
+            if orig is not None:
+                os.environ["DAILY_GENERATION_QUOTA"] = orig


### PR DESCRIPTION
## Summary

- `GET /api/v1/users/me/referrals` — returns referral code, share URL, counts, tier
- `qualify_and_maybe_upgrade()` — auto-promotes referrer to Plus at 10 qualified referrals
- `_get_daily_quota()` now reads `membership_tier` (free=3, plus=9; env var overrides)
- `update_membership_tier()` on UserRepository

Fixes #350
**Parent Epic**: #346

## Test plan

- [x] 7 tests: threshold upgrade, already-plus guard, nonexistent referral, tier quota (free/plus/env/unknown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)