### PR TITLE
fix(memory): deterministic character injection for story continuity and podcast guest (#364)

### DIFF
--- a/backend/src/agents/interactive_story_agent.py
+++ b/backend/src/agents/interactive_story_agent.py
@@ -242,6 +242,7 @@ def _build_opening_prompt(
     preference_context: str = "",
     story_memory_section: str = "",
     dedup_nudge: str = "",
+    character_memory_section: str = "",
 ) -> str:
     """
     Build the full prompt for interactive story opening generation.
@@ -274,6 +275,10 @@ def _build_opening_prompt(
     # Inject cross-story memory (#165)
     if story_memory_section:
         prompt += f"\n{story_memory_section}\n"
+
+    # Inject deterministic character memory (#365)
+    if character_memory_section:
+        prompt += f"\n{character_memory_section}\n"
 
     # Inject dedup variation nudge (#290)
     if dedup_nudge:
@@ -326,6 +331,7 @@ def _build_next_segment_prompt(
     config: Dict[str, Any],
     choice_history_context: str = "",
     opening_hook: str = "",
+    continuity_anchors: str = "",
 ) -> str:
     """Build prompt for generating the next story segment."""
     return f"""你是一位专业的儿童故事作家，正在继续一个互动故事。
@@ -347,6 +353,9 @@ def _build_next_segment_prompt(
 **开场关键线索（结局必须回扣）**：
 {opening_hook if opening_hook else "（无）"}
 
+**结局连续性锚点（结局必须引用至少 2 个）**：
+{continuity_anchors if continuity_anchors else "（无，可从上文事件与选择中提炼）"}
+
 **用户的选择**：
 选择ID: {choice_id}
 选择内容: {chosen_option or "继续故事"}
@@ -362,7 +371,7 @@ def _build_next_segment_prompt(
 1. 根据用户的选择自然延续故事
 2. 保持故事的连贯性和吸引力
 3. {
-        "这是结局段落，请给出一个温馨、积极、完整的结局：必须明确回应开场线索，并回扣至少两个关键选择，让结尾和前文形成闭环"
+        "这是结局段落，请给出一个温馨、积极、完整的结局：必须明确回应开场线索，并且原样引用上面“结局连续性锚点”中至少2个词组，不得引入全新主线任务，让结尾和前文形成闭环"
         if is_final_segment
         else "继续发展情节，提供 2-3 个新选项"
     }
@@ -524,16 +533,213 @@ def _extract_opening_hook(segments: List[Dict[str, Any]]) -> str:
     return hook[:36]
 
 
+def _extract_choice_history_steps(choice_history_context: str) -> List[str]:
+    """Extract selected choice texts from numbered history lines."""
+    history_lines = [
+        line.strip()
+        for line in str(choice_history_context or "").splitlines()
+        if line.strip() and line.strip()[0].isdigit()
+    ]
+    steps: List[str] = []
+    for line in history_lines:
+        if ". " in line:
+            steps.append(line.split(". ", 1)[1].strip())
+        else:
+            steps.append(line.strip())
+    return [step for step in steps if step]
+
+
+def _extract_salient_fragment(text: str, max_len: int = 14) -> str:
+    """Extract a concise phrase from a segment as a continuity anchor."""
+    content = str(text or "").strip()
+    if not content:
+        return ""
+    parts = [p.strip() for p in re.split(r"[，。！？!?；;：:]", content) if p.strip()]
+    for part in parts:
+        if 4 <= len(part) <= max_len:
+            return part
+    if parts:
+        part = parts[0]
+        return part[:max_len] if len(part) > max_len else part
+    return content[:max_len]
+
+
+def _extract_keywords(text: str, limit: int = 6) -> List[str]:
+    """Extract compact keywords from Chinese/English text."""
+    content = str(text or "")
+    if not content:
+        return []
+
+    stop_words = {
+        "我们",
+        "你们",
+        "他们",
+        "大家",
+        "小伙伴",
+        "小伙伴们",
+        "故事",
+        "冒险",
+        "最后",
+        "终于",
+        "然后",
+        "因为",
+        "所以",
+        "开始",
+        "继续",
+        "一起",
+        "这个",
+        "那个",
+        "这样",
+        "那里",
+        "这里",
+        "温暖",
+        "结局",
+        "成长",
+    }
+    en_stop_words = {
+        "the",
+        "and",
+        "with",
+        "that",
+        "this",
+        "from",
+        "then",
+        "they",
+        "them",
+        "story",
+        "ending",
+    }
+
+    tokens = re.findall(r"[\u4e00-\u9fff]{2,8}|[A-Za-z][A-Za-z0-9_-]{2,}", content)
+    keywords: List[str] = []
+    for token in tokens:
+        cleaned = token.strip()
+        if not cleaned:
+            continue
+        if cleaned in stop_words:
+            continue
+        if cleaned.lower() in en_stop_words:
+            continue
+        if cleaned not in keywords:
+            keywords.append(cleaned)
+        if len(keywords) >= limit:
+            break
+    return keywords
+
+
+def _build_continuity_anchors(
+    segments: List[Dict[str, Any]],
+    opening_hook: str,
+    chosen_option: Optional[str],
+    choice_history_context: str,
+    max_items: int = 6,
+) -> List[str]:
+    """Collect stable anchors from prior story so ending can stay on-topic."""
+    anchors: List[str] = []
+
+    def add_anchor(candidate: str) -> None:
+        item = str(candidate or "").strip()
+        if not item:
+            return
+        item = item[:20]
+        if item not in anchors:
+            anchors.append(item)
+
+    add_anchor(opening_hook)
+    add_anchor(chosen_option or "")
+
+    history_steps = _extract_choice_history_steps(choice_history_context)
+    for step in history_steps[-3:]:
+        add_anchor(step)
+
+    for seg in segments[-3:]:
+        add_anchor(_extract_salient_fragment(seg.get("text", "")))
+
+    keyword_sources: List[str] = []
+    if opening_hook:
+        keyword_sources.append(opening_hook)
+    if chosen_option:
+        keyword_sources.append(chosen_option)
+    keyword_sources.extend(history_steps[-3:])
+    for seg in segments[-2:]:
+        keyword_sources.append(str(seg.get("text", "")))
+
+    for source in keyword_sources:
+        for kw in _extract_keywords(source, limit=3):
+            add_anchor(kw)
+            if len(anchors) >= max_items:
+                return anchors[:max_items]
+
+    return anchors[:max_items]
+
+
+def _count_anchor_hits(text: str, anchors: List[str]) -> int:
+    """Count how many anchors appear in generated ending text."""
+    content = str(text or "")
+    return sum(1 for anchor in anchors if anchor and anchor in content)
+
+
+def _rewrite_ending_with_anchors(
+    opening_hook: str,
+    chosen_option: Optional[str],
+    choice_history_context: str,
+    continuity_anchors: List[str],
+) -> str:
+    """Rewrite ending into a coherent close that references earlier context."""
+    anchors = [a for a in continuity_anchors if a][:3]
+    history_steps = _extract_choice_history_steps(choice_history_context)
+
+    hook_clause = (
+        f"从故事一开始“{opening_hook}”的悬念，到现在终于有了清楚的答案。"
+        if opening_hook
+        else "这趟旅程终于把前面埋下的问题都解决了。"
+    )
+    option_clause = (
+        f"当大家做出“{chosen_option}”这个关键选择后，"
+        if chosen_option
+        else "在最后一次关键决定后，"
+    )
+
+    if anchors:
+        anchor_clause = f"围绕{'、'.join(anchors)}，大家把一路上的挑战一步步化解。"
+    else:
+        anchor_clause = "大家把一路上的挑战一步步化解，并让故事线索完整收束。"
+
+    history_clause = ""
+    if history_steps:
+        recent = "、".join(history_steps[-2:])
+        history_clause = f"回看之前的选择（{recent}），每一步都把故事推向了同一个方向。"
+
+    return (
+        f"{hook_clause}{option_clause}{anchor_clause}"
+        f"{history_clause}最后，伙伴们带着新的勇气与合作精神回到日常生活，故事圆满结束。"
+    )
+
+
 def _ensure_ending_coherence(
     ending_text: str,
     opening_hook: str,
     chosen_option: Optional[str],
     choice_history_context: str,
+    continuity_anchors: Optional[List[str]] = None,
 ) -> str:
     """Ensure final segment explicitly connects to opening and recent choices."""
     text = str(ending_text or "").strip()
     if not text:
         text = "这次冒险终于迎来了温暖的结局。"
+
+    anchors = [a.strip() for a in (continuity_anchors or []) if str(a).strip()]
+    required_hits = 2 if len(anchors) >= 2 else len(anchors)
+    anchor_hits = _count_anchor_hits(text, anchors)
+
+    # If ending drifts away from prior context, rewrite to force alignment.
+    if required_hits and anchor_hits < required_hits:
+        text = _rewrite_ending_with_anchors(
+            opening_hook=opening_hook,
+            chosen_option=chosen_option,
+            choice_history_context=choice_history_context,
+            continuity_anchors=anchors,
+        )
 
     additions: List[str] = []
     if opening_hook and opening_hook not in text:
@@ -551,19 +757,9 @@ def _ensure_ending_coherence(
     if not any(k in text for k in ["最后", "终于", "结局", "回到", "学会", "从此"]):
         additions.append("最后，大家带着新的勇气与智慧回到日常生活，故事也圆满结束。")
 
-    history_lines = [
-        line.strip()
-        for line in choice_history_context.splitlines()
-        if line.strip() and line.strip()[0].isdigit()
-    ]
-    if history_lines:
-        last_steps = []
-        for line in history_lines[-2:]:
-            if ". " in line:
-                last_steps.append(line.split(". ", 1)[1])
-            else:
-                last_steps.append(line)
-        summary = "；".join(last_steps)
+    history_steps = _extract_choice_history_steps(choice_history_context)
+    if history_steps:
+        summary = "；".join(history_steps[-2:])
         if summary and summary not in text:
             additions.append(f"一路上的关键选择（{summary}）在这一刻都得到了回应。")
 
@@ -1100,6 +1296,12 @@ async def generate_next_segment_stream(
 
     choice_history_context = _build_choice_history_context(segments, choice_history)
     opening_hook = _extract_opening_hook(segments)
+    continuity_anchors = _build_continuity_anchors(
+        segments=segments,
+        opening_hook=opening_hook,
+        chosen_option=chosen_option,
+        choice_history_context=choice_history_context,
+    )
 
     prompt = _build_next_segment_prompt(
         story_title=story_title,
@@ -1115,6 +1317,7 @@ async def generate_next_segment_stream(
         config=config,
         choice_history_context=choice_history_context,
         opening_hook=opening_hook,
+        continuity_anchors="、".join(continuity_anchors),
     )
 
     # Determine if we should generate audio based on age_group audio_mode
@@ -1272,6 +1475,7 @@ async def generate_next_segment_stream(
                 opening_hook=opening_hook,
                 chosen_option=chosen_option,
                 choice_history_context=choice_history_context,
+                continuity_anchors=continuity_anchors,
             )
 
     if is_final_segment and "educational_summary" not in result_data:
@@ -1352,6 +1556,12 @@ async def generate_next_segment(
 
     choice_history_context = _build_choice_history_context(segments, choice_history)
     opening_hook = _extract_opening_hook(segments)
+    continuity_anchors = _build_continuity_anchors(
+        segments=segments,
+        opening_hook=opening_hook,
+        chosen_option=chosen_option,
+        choice_history_context=choice_history_context,
+    )
 
     prompt = _build_next_segment_prompt(
         story_title=story_title,
@@ -1367,6 +1577,7 @@ async def generate_next_segment(
         config=config,
         choice_history_context=choice_history_context,
         opening_hook=opening_hook,
+        continuity_anchors="、".join(continuity_anchors),
     )
 
     # Determine if we should generate audio based on age_group audio_mode
@@ -1459,6 +1670,7 @@ async def generate_next_segment(
                 opening_hook=opening_hook,
                 chosen_option=chosen_option,
                 choice_history_context=choice_history_context,
+                continuity_anchors=continuity_anchors,
             )
 
     # Add audio path to result if available

--- a/backend/src/agents/kids_daily_agent.py
+++ b/backend/src/agents/kids_daily_agent.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ValidationError
 
 from ..api.models import DialogueLine, DialogueScript
 from ..mcp_servers import safety_server, tts_server, vector_server
+from ..services.database import character_repo
 from ..utils.model_config import get_claude_agent_model
 
 try:
@@ -908,7 +909,17 @@ async def generate_kids_daily_dialogue(
 
     source_text = _clean_source_text(news_text, news_url)
     topic = _headline_from_text(source_text)
+
+    # Resolve guest from recurring characters first (#365)
     guest_name = _default_guest(child_id)
+    if child_id:
+        try:
+            characters = await character_repo.get_characters("", child_id)
+            if characters:
+                guest_name = characters[0].get("name", guest_name)
+        except Exception:
+            pass  # Fall back to default guest
+
     used_mock = _should_use_mock()
     degraded_reason: Optional[str] = None
 

--- a/backend/src/services/story_memory.py
+++ b/backend/src/services/story_memory.py
@@ -10,7 +10,7 @@ Parent Epic: #42
 import json
 from typing import List, Dict, Any
 
-from .database import story_repo
+from .database import story_repo, character_repo
 
 
 async def get_story_memory_prompt(child_id: str, limit: int = 3, *, user_id: str = "") -> str:
@@ -28,35 +28,71 @@ async def get_story_memory_prompt(child_id: str, limit: int = 3, *, user_id: str
         stories = await story_repo.list_by_user_and_child(user_id, child_id, limit=limit)
     else:
         stories = await story_repo.list_by_child(child_id, limit=limit)
-    if not stories:
+    # Fetch recurring characters deterministically (#365)
+    characters: List[Dict[str, Any]] = []
+    try:
+        characters = await character_repo.get_characters(user_id, child_id)
+    except Exception:
+        pass  # Non-critical — degrade gracefully
+
+    if not stories and not characters:
         return ""
 
-    lines = []
-    for i, story in enumerate(stories, 1):
-        text = story.get("story_text", "")
-        # Build a brief summary: first 80 chars + themes
-        preview = text[:80].replace("\n", " ").strip()
-        if len(text) > 80:
-            preview += "..."
-        themes_raw = story.get("themes", "[]")
-        if isinstance(themes_raw, str):
-            try:
-                themes = json.loads(themes_raw)
-            except json.JSONDecodeError:
-                themes = []
-        else:
-            themes = themes_raw if isinstance(themes_raw, list) else []
-        themes_str = ", ".join(themes[:3]) if themes else ""
-        line = f"{i}. {preview}"
-        if themes_str:
-            line += f" (themes: {themes_str})"
-        lines.append(line)
+    sections: List[str] = []
 
-    story_list = "\n".join(lines)
+    # Story previews section
+    if stories:
+        lines = []
+        for i, story in enumerate(stories, 1):
+            text = story.get("story_text", "")
+            # Build a brief summary: first 80 chars + themes
+            preview = text[:80].replace("\n", " ").strip()
+            if len(text) > 80:
+                preview += "..."
+            themes_raw = story.get("themes", "[]")
+            if isinstance(themes_raw, str):
+                try:
+                    themes = json.loads(themes_raw)
+                except json.JSONDecodeError:
+                    themes = []
+            else:
+                themes = themes_raw if isinstance(themes_raw, list) else []
+            themes_str = ", ".join(themes[:3]) if themes else ""
+            line = f"{i}. {preview}"
+            if themes_str:
+                line += f" (themes: {themes_str})"
+            lines.append(line)
 
-    return f"""
-**Story Memory**:
-This child has told stories before. Here are their recent stories:
-{story_list}
-Please naturally reference or continue these stories when appropriate (e.g., "Remember when Lightning Dog went to the moon?"), but do not repeat the same plot. Create something fresh that builds on their creative world.
-"""
+        story_list = "\n".join(lines)
+        sections.append(
+            f"**Story Memory**:\n"
+            f"This child has told stories before. Here are their recent stories:\n"
+            f"{story_list}\n"
+            f"Please naturally reference or continue these stories when appropriate "
+            f'(e.g., "Remember when Lightning Dog went to the moon?"), '
+            f"but do not repeat the same plot. Create something fresh that builds on their creative world."
+        )
+
+    # Character memory section — deterministic injection (#365)
+    if characters:
+        char_lines = []
+        for ch in characters[:5]:  # Top 5 by appearance
+            name = ch.get("name", "")
+            count = ch.get("appearance_count", 1)
+            traits = ch.get("traits", [])
+            desc = ch.get("description", "")
+            parts = [f"- **{name}** (appeared {count} times)"]
+            if traits:
+                parts[0] += f": {', '.join(traits[:3])}"
+            if desc:
+                parts.append(f"  {desc}")
+            char_lines.append("\n".join(parts))
+
+        sections.append(
+            "**Recurring Characters**:\n"
+            "These characters have appeared in this child's previous stories. "
+            "Use them naturally in new stories to maintain continuity:\n"
+            + "\n".join(char_lines)
+        )
+
+    return "\n\n" + "\n\n".join(sections) + "\n"

--- a/backend/tests/contracts/test_character_continuity_contract.py
+++ b/backend/tests/contracts/test_character_continuity_contract.py
@@ -1,0 +1,245 @@
+"""
+Character Continuity Contract Tests (#365)
+
+Verifies that:
+1. get_story_memory_prompt includes character names from character_repository
+2. kids_daily_agent uses recurring characters as podcast guest
+3. interactive_story_agent prompt includes deterministic character section
+
+Parent Epic: #42 | Issue: #365
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Story memory prompt must include character names
+# ---------------------------------------------------------------------------
+
+
+class TestStoryMemoryIncludesCharacters:
+    """get_story_memory_prompt must inject known characters deterministically."""
+
+    @pytest.fixture()
+    def get_story_memory_prompt(self):
+        from backend.src.services.story_memory import get_story_memory_prompt
+        return get_story_memory_prompt
+
+    @pytest.mark.asyncio
+    async def test_includes_character_names_when_available(self, get_story_memory_prompt):
+        """Character names from character_repo must appear in the memory prompt."""
+        stories = [
+            {
+                "story_text": "Lightning Dog flew to the moon.",
+                "themes": json.dumps(["space"]),
+            },
+        ]
+        characters = [
+            {
+                "name": "Lightning Dog",
+                "description": "A brave puppy who can fly",
+                "traits": ["brave", "loyal"],
+                "appearance_count": 3,
+            },
+            {
+                "name": "Star Cat",
+                "description": "A curious cat from the stars",
+                "traits": ["curious"],
+                "appearance_count": 1,
+            },
+        ]
+        with (
+            patch("backend.src.services.story_memory.story_repo") as mock_story,
+            patch("backend.src.services.story_memory.character_repo") as mock_char,
+        ):
+            mock_story.list_by_child = AsyncMock(return_value=stories)
+            mock_char.get_characters = AsyncMock(return_value=characters)
+            result = await get_story_memory_prompt("child-abc")
+
+        assert "Lightning Dog" in result
+        assert "Star Cat" in result
+        assert "brave" in result or "loyal" in result
+
+    @pytest.mark.asyncio
+    async def test_no_character_section_when_no_characters(self, get_story_memory_prompt):
+        """When no characters exist, prompt should still work (stories only)."""
+        stories = [
+            {
+                "story_text": "A fish swam in the ocean.",
+                "themes": json.dumps(["ocean"]),
+            },
+        ]
+        with (
+            patch("backend.src.services.story_memory.story_repo") as mock_story,
+            patch("backend.src.services.story_memory.character_repo") as mock_char,
+        ):
+            mock_story.list_by_child = AsyncMock(return_value=stories)
+            mock_char.get_characters = AsyncMock(return_value=[])
+            result = await get_story_memory_prompt("child-empty")
+
+        assert "Story Memory" in result
+        # No character section when there are no characters
+        assert "Recurring Characters" not in result
+
+    @pytest.mark.asyncio
+    async def test_characters_shown_even_without_stories(self, get_story_memory_prompt):
+        """If there are characters but no stories, still include character section."""
+        characters = [
+            {
+                "name": "Rainbow Bird",
+                "description": "A colorful bird",
+                "traits": ["cheerful"],
+                "appearance_count": 2,
+            },
+        ]
+        with (
+            patch("backend.src.services.story_memory.story_repo") as mock_story,
+            patch("backend.src.services.story_memory.character_repo") as mock_char,
+        ):
+            mock_story.list_by_child = AsyncMock(return_value=[])
+            mock_char.get_characters = AsyncMock(return_value=characters)
+            result = await get_story_memory_prompt("child-chars-only")
+
+        assert "Rainbow Bird" in result
+
+    @pytest.mark.asyncio
+    async def test_user_scoped_character_fetch(self, get_story_memory_prompt):
+        """When user_id is provided, character_repo.get_characters uses it."""
+        with (
+            patch("backend.src.services.story_memory.story_repo") as mock_story,
+            patch("backend.src.services.story_memory.character_repo") as mock_char,
+        ):
+            mock_story.list_by_user_and_child = AsyncMock(return_value=[])
+            mock_char.get_characters = AsyncMock(return_value=[])
+            await get_story_memory_prompt("child-1", user_id="user-42")
+
+        mock_char.get_characters.assert_called_once_with("user-42", "child-1")
+
+
+# ---------------------------------------------------------------------------
+# 2. Kids daily agent must prefer recurring character as guest
+# ---------------------------------------------------------------------------
+
+
+class TestKidsDailyGuestFromCharacters:
+    """Podcast guest should come from child's recurring characters."""
+
+    @pytest.mark.asyncio
+    async def test_guest_uses_recurring_character_in_mock(self):
+        """In mock mode, guest_character should be top recurring character."""
+        from backend.src.agents.kids_daily_agent import generate_kids_daily_dialogue
+
+        characters = [
+            {
+                "name": "Lightning Dog",
+                "description": "A brave puppy",
+                "traits": ["brave"],
+                "appearance_count": 5,
+            },
+        ]
+        with patch(
+            "backend.src.agents.kids_daily_agent.character_repo"
+        ) as mock_char:
+            mock_char.get_characters = AsyncMock(return_value=characters)
+            result = await generate_kids_daily_dialogue(
+                news_text="Scientists found a new planet.",
+                age_group="6-8",
+                child_id="child-with-chars",
+            )
+
+        assert result["guest_character"] == "Lightning Dog"
+
+    @pytest.mark.asyncio
+    async def test_guest_falls_back_to_default_without_characters(self):
+        """Without recurring characters, fall back to default guest."""
+        from backend.src.agents.kids_daily_agent import (
+            generate_kids_daily_dialogue,
+            _DEFAULT_GUESTS,
+        )
+
+        with patch(
+            "backend.src.agents.kids_daily_agent.character_repo"
+        ) as mock_char:
+            mock_char.get_characters = AsyncMock(return_value=[])
+            result = await generate_kids_daily_dialogue(
+                news_text="New robot helps kids learn.",
+                age_group="6-8",
+                child_id="child-no-chars",
+            )
+
+        assert result["guest_character"] in _DEFAULT_GUESTS
+
+    @pytest.mark.asyncio
+    async def test_guest_falls_back_without_child_id(self):
+        """Without child_id, default guest is used (no character lookup)."""
+        from backend.src.agents.kids_daily_agent import (
+            generate_kids_daily_dialogue,
+            _DEFAULT_GUESTS,
+        )
+
+        result = await generate_kids_daily_dialogue(
+            news_text="Fun science facts.",
+            age_group="6-8",
+        )
+
+        assert result["guest_character"] in _DEFAULT_GUESTS
+
+
+# ---------------------------------------------------------------------------
+# 3. Interactive story prompt includes deterministic character section
+# ---------------------------------------------------------------------------
+
+
+class TestInteractiveStoryCharacterInjection:
+    """_build_opening_prompt must accept and inject character memory."""
+
+    def test_prompt_includes_character_memory_section(self):
+        from backend.src.agents.interactive_story_agent import _build_opening_prompt
+
+        char_section = (
+            "\n**Recurring Characters**:\n"
+            "- Lightning Dog (appeared 3 times): brave, loyal\n"
+        )
+        prompt = _build_opening_prompt(
+            child_id="child-1",
+            age_group="6-8",
+            interests_str="space, dogs",
+            theme_str="adventure",
+            config={
+                "word_count": "100-150",
+                "sentence_length": "medium",
+                "complexity": "moderate",
+                "vocab_level": "grade 2-3",
+                "theme_depth": "moderate",
+                "choices_style": "action-based",
+            },
+            story_memory_section="**Story Memory**:\n1. Lightning Dog flew...",
+            character_memory_section=char_section,
+        )
+        assert "Recurring Characters" in prompt
+        assert "Lightning Dog" in prompt
+        assert "appeared 3 times" in prompt
+
+    def test_prompt_ok_without_character_memory(self):
+        from backend.src.agents.interactive_story_agent import _build_opening_prompt
+
+        prompt = _build_opening_prompt(
+            child_id="child-1",
+            age_group="6-8",
+            interests_str="space",
+            theme_str="adventure",
+            config={
+                "word_count": "100-150",
+                "sentence_length": "medium",
+                "complexity": "moderate",
+                "vocab_level": "grade 2-3",
+                "theme_depth": "moderate",
+                "choices_style": "action-based",
+            },
+            story_memory_section="",
+            character_memory_section="",
+        )
+        assert "Recurring Characters" not in prompt

--- a/backend/tests/contracts/test_interactive_memory_contract.py
+++ b/backend/tests/contracts/test_interactive_memory_contract.py
@@ -5,21 +5,23 @@ Tests for preference-aware generation (#72) and character continuity (#73).
 Validates prompt construction helpers and allowed-tools contracts.
 """
 
-import pytest
 from unittest.mock import AsyncMock, patch
 
-from backend.src.agents.interactive_story_agent import (
-    _fetch_preference_context,
-    _build_opening_prompt,
-    _build_next_segment_prompt,
-    _append_tts_instructions,
-    AGE_CONFIG,
-)
+import pytest
 
+from backend.src.agents.interactive_story_agent import (
+    AGE_CONFIG,
+    _append_tts_instructions,
+    _build_next_segment_prompt,
+    _build_opening_prompt,
+    _ensure_ending_coherence,
+    _fetch_preference_context,
+)
 
 # ============================================================================
 # Preference Context Builder
 # ============================================================================
+
 
 class TestPreferenceContextBuilder:
     """Contract: _fetch_preference_context returns formatted string or empty."""
@@ -101,6 +103,7 @@ class TestPreferenceContextBuilder:
 # Opening Prompt Contract
 # ============================================================================
 
+
 class TestOpeningPromptContract:
     """Contract: _build_opening_prompt includes required sections."""
 
@@ -150,6 +153,7 @@ class TestOpeningPromptContract:
 # ============================================================================
 # Next Segment Prompt Contract
 # ============================================================================
+
 
 class TestNextSegmentPromptContract:
     """Contract: _build_next_segment_prompt does NOT include memory features."""
@@ -210,10 +214,52 @@ class TestNextSegmentPromptContract:
         assert "educational_summary" in prompt
         assert "是" in prompt  # 是否为结局: 是
 
+    def test_ending_includes_continuity_anchor_constraints(self):
+        """Final prompt includes anchor-based continuity constraints."""
+        config = AGE_CONFIG["6-8"]
+        prompt = _build_next_segment_prompt(
+            story_title="风铃塔探险",
+            age_group="6-8",
+            interests=["解谜"],
+            theme="合作冒险",
+            segment_count=3,
+            total_segments=4,
+            is_final_segment=True,
+            story_context="段落 2: 大家在风铃塔前发现了缺失的钥匙齿轮。",
+            choice_id="choice_2_a",
+            chosen_option="先修好坏掉的星图钥匙",
+            config=config,
+            continuity_anchors="风铃塔、星图钥匙、萤火桥",
+        )
+        assert "结局连续性锚点" in prompt
+        assert "风铃塔、星图钥匙、萤火桥" in prompt
+        assert "至少2个词组" in prompt
+
+
+class TestEndingCoherenceRepair:
+    """Contract: ending repair keeps final paragraph aligned with context."""
+
+    def test_rewrites_drifted_ending_with_story_anchors(self):
+        repaired = _ensure_ending_coherence(
+            ending_text="他们突然去了外太空，开了一家冰淇淋店。",
+            opening_hook="风铃塔的门一到黄昏就会发光",
+            chosen_option="先修好坏掉的星图钥匙",
+            choice_history_context=(
+                "1. 跟着萤火虫去风铃塔\n2. 先修好坏掉的星图钥匙\n3. 和河狸一起搭桥过河"
+            ),
+            continuity_anchors=["风铃塔", "星图钥匙", "搭桥过河"],
+        )
+
+        assert "风铃塔" in repaired
+        assert "星图钥匙" in repaired
+        assert "搭桥过河" in repaired
+        assert "冰淇淋店" not in repaired
+
 
 # ============================================================================
 # Allowed Tools Contract
 # ============================================================================
+
 
 class TestAllowedToolsContract:
     """Contract: opening includes memory tools, next-segment does not."""
@@ -238,6 +284,7 @@ class TestAllowedToolsContract:
 # ============================================================================
 # TTS Instructions Helper
 # ============================================================================
+
 
 class TestTTSInstructionsContract:
     """Contract: _append_tts_instructions appends correct block."""


### PR DESCRIPTION
## Summary

- **story_memory.py**: Fetches recurring characters from `character_repository` and includes them (name, traits, appearance count) directly in the memory prompt — no longer relies on agent calling vector search
- **kids_daily_agent.py**: Pre-fetches top recurring character as podcast guest name before falling back to Professor Owl / Captain Comet
- **interactive_story_agent.py**: Adds `character_memory_section` parameter to `_build_opening_prompt` for explicit character injection; includes ending coherence improvements with continuity anchors

Fixes #364
**Parent Epic**: #42

## Root Cause

Character continuity was 100% probabilistic — it relied on the Claude Agent SDK agent *choosing* to call `mcp__vector-search__search_similar_drawings` at runtime. When the agent skipped the tool call, all character context was lost. The story memory prompt only included story text previews and themes, but **no character names**.

## Test plan

- [x] 9 new contract tests in `test_character_continuity_contract.py` — all pass
- [x] 7 existing story memory contract tests — all pass (no regression)
- [x] 6 existing kids daily character name tests — all pass
- [x] 6 existing kids daily API tests — all pass  
- [x] 17 existing interactive memory contract tests — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)