### PR TITLE
feat(database): add pgvector VectorRepository for production vector search

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,10 @@ elevenlabs>=1.0.0
 # Vector Database (Local)
 chromadb==1.4.1
 
+# Vector Database (Production — pgvector)
+sentence-transformers>=2.2.0
+pgvector>=0.2.0
+
 # Image Processing
 pillow==10.2.0
 

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -77,25 +77,33 @@ async def delete_preferences(
         user.user_id, child_id
     )
 
-    # Delete ChromaDB vectors for this child
+    # Delete vector data for this child (#342 — pgvector or ChromaDB)
     deleted_vectors = 0
     try:
-        import anyio
+        from ...services.database.connection import db_manager as _db_mgr
 
-        from ...mcp_servers.vector_search_server import get_or_create_collection
+        if _db_mgr.is_connected and _db_mgr.dialect == "postgresql":
+            # --- pgvector path (production) ---
+            from ...services.database.vector_repository import vector_repo
 
-        collection = await anyio.to_thread.run_sync(get_or_create_collection)
-        # Get all document IDs for this child
-        results = await anyio.to_thread.run_sync(
-            lambda: collection.get(where={"child_id": child_id})
-        )
-        if results and results.get("ids"):
-            doc_ids = results["ids"]
-            deleted_vectors = len(doc_ids)
-            await anyio.to_thread.run_sync(lambda: collection.delete(ids=doc_ids))
+            deleted_vectors = await vector_repo.delete_by_child(child_id)
+        else:
+            # --- ChromaDB path (local dev) ---
+            import anyio
+
+            from ...mcp_servers.vector_search_server import get_or_create_collection
+
+            collection = await anyio.to_thread.run_sync(get_or_create_collection)
+            results = await anyio.to_thread.run_sync(
+                lambda: collection.get(where={"child_id": child_id})
+            )
+            if results and results.get("ids"):
+                doc_ids = results["ids"]
+                deleted_vectors = len(doc_ids)
+                await anyio.to_thread.run_sync(lambda: collection.delete(ids=doc_ids))
     except Exception:
         logger.warning(
-            "Failed to delete ChromaDB vectors for child %s", child_id, exc_info=True
+            "Failed to delete vectors for child %s", child_id, exc_info=True
         )
 
     return {

--- a/backend/src/mcp_servers/vector_search_server.py
+++ b/backend/src/mcp_servers/vector_search_server.py
@@ -27,6 +27,18 @@ except Exception:  # pragma: no cover - import fallback for test env
     def create_sdk_mcp_server(**kwargs):
         return kwargs
 
+# pgvector repository for production (#342)
+from ..services.database.connection import db_manager
+from ..services.database.vector_repository import VectorRepository, vector_repo
+
+
+def _use_pgvector() -> bool:
+    """Return True when the database backend is PostgreSQL (pgvector available)."""
+    try:
+        return db_manager.is_connected and db_manager.dialect == "postgresql"
+    except Exception:
+        return False
+
 
 # 初始化 ChromaDB 客户端
 def get_chroma_client():
@@ -89,6 +101,25 @@ async def search_similar_drawings(args: Dict[str, Any]) -> Dict[str, Any]:
     top_k = args.get("top_k", 5)
 
     try:
+        # --- pgvector path (production) ---
+        if _use_pgvector():
+            similar_drawings = await vector_repo.search_similar_drawings(
+                query_text=drawing_description,
+                child_id=child_id,
+                top_k=top_k,
+            )
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({
+                        "similar_drawings": similar_drawings,
+                        "total_found": len(similar_drawings),
+                        "query": {"child_id": child_id, "top_k": top_k}
+                    }, ensure_ascii=False, indent=2)
+                }]
+            }
+
+        # --- ChromaDB path (local dev) ---
         # 获取集合（offload blocking ChromaDB call to thread）
         collection = await anyio.to_thread.run_sync(get_or_create_collection)
 
@@ -213,9 +244,6 @@ async def store_drawing_embedding(args: Dict[str, Any]) -> Dict[str, Any]:
             drawing_analysis = {}
 
     try:
-        # 获取集合（offload blocking ChromaDB call to thread）
-        collection = await anyio.to_thread.run_sync(get_or_create_collection)
-
         # 生成唯一 ID
         timestamp = datetime.now().isoformat()
         doc_id = hashlib.md5(
@@ -238,6 +266,29 @@ async def store_drawing_embedding(args: Dict[str, Any]) -> Dict[str, Any]:
                 ensure_ascii=False
             )
         }
+
+        # --- pgvector path (production) ---
+        if _use_pgvector():
+            await vector_repo.add_drawing(
+                doc_id=doc_id,
+                child_id=child_id,
+                document_text=drawing_description,
+                metadata=metadata,
+            )
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({
+                        "success": True,
+                        "document_id": doc_id,
+                        "message": "画作已成功存储到向量数据库 (pgvector)"
+                    }, ensure_ascii=False, indent=2)
+                }]
+            }
+
+        # --- ChromaDB path (local dev) ---
+        # 获取集合（offload blocking ChromaDB call to thread）
+        collection = await anyio.to_thread.run_sync(get_or_create_collection)
 
         # 存储到 ChromaDB
         # ChromaDB 会自动将文本转换为向量
@@ -294,8 +345,6 @@ async def store_story_embedding(args: Dict[str, Any]) -> Dict[str, Any]:
         }
 
     try:
-        collection = await anyio.to_thread.run_sync(get_or_create_story_collection)
-
         doc_id = story_id or hashlib.md5(f"{child_id}_{datetime.now().isoformat()}".encode()).hexdigest()
 
         metadata = {
@@ -305,6 +354,24 @@ async def store_story_embedding(args: Dict[str, Any]) -> Dict[str, Any]:
             "age_group": args.get("age_group", ""),
             "created_at": datetime.now().isoformat(),
         }
+
+        # --- pgvector path (production) ---
+        if _use_pgvector():
+            await vector_repo.add_story_embedding(
+                doc_id=doc_id,
+                child_id=child_id,
+                document_text=story_text[:2000],
+                metadata=metadata,
+            )
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({"success": True, "document_id": doc_id}, ensure_ascii=False)
+                }]
+            }
+
+        # --- ChromaDB path (local dev) ---
+        collection = await anyio.to_thread.run_sync(get_or_create_story_collection)
 
         await anyio.to_thread.run_sync(lambda: collection.upsert(
             ids=[doc_id],
@@ -350,6 +417,25 @@ async def search_similar_stories(args: Dict[str, Any]) -> Dict[str, Any]:
         }
 
     try:
+        # --- pgvector path (production) ---
+        if _use_pgvector():
+            similar_stories = await vector_repo.search_similar_stories(
+                query_text=story_description,
+                child_id=child_id,
+                top_k=top_k,
+            )
+            return {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({
+                        "similar_stories": similar_stories,
+                        "total_found": len(similar_stories),
+                        "query": {"child_id": child_id, "top_k": top_k}
+                    }, ensure_ascii=False, indent=2)
+                }]
+            }
+
+        # --- ChromaDB path (local dev) ---
         collection = await anyio.to_thread.run_sync(get_or_create_story_collection)
 
         results = await anyio.to_thread.run_sync(lambda: collection.query(

--- a/backend/src/services/database/__init__.py
+++ b/backend/src/services/database/__init__.py
@@ -21,6 +21,7 @@ from .subscription_repository import (
 )
 from .usage_repository import UsageRepository, usage_repo
 from .referral_repository import ReferralRepository, referral_repo
+from .vector_repository import VectorRepository, vector_repo
 
 __all__ = [
     "CursorResult",
@@ -51,4 +52,6 @@ __all__ = [
     "usage_repo",
     "ReferralRepository",
     "referral_repo",
+    "VectorRepository",
+    "vector_repo",
 ]

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -417,6 +417,10 @@ async def init_schema(db: "DatabaseManager") -> None:
     from .schema_favorites import init_favorites_schema
     await init_favorites_schema(db)
 
+    # Initialize pgvector schema (#342) — only on PostgreSQL
+    from .schema_vectors import init_vector_schema
+    await init_vector_schema(db)
+
     print("Database schema initialized")
 
 

--- a/backend/src/services/database/schema_vectors.py
+++ b/backend/src/services/database/schema_vectors.py
@@ -1,0 +1,122 @@
+"""
+Vector Embedding Schema (pgvector)
+
+DDL for drawing_embeddings and story_embeddings tables with vector(384) columns.
+Only initialized when dialect is 'postgresql' since SQLite does not support
+the pgvector extension.
+
+Issue: #342
+"""
+
+from typing import TYPE_CHECKING
+
+from .sql_compat import translate_ddl
+
+if TYPE_CHECKING:
+    from .connection import DatabaseManager
+
+
+# ============================================================================
+# Drawing Embeddings Table
+# ============================================================================
+
+DRAWING_EMBEDDINGS_TABLE = """
+CREATE TABLE IF NOT EXISTS drawing_embeddings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    doc_id TEXT UNIQUE NOT NULL,
+    child_id TEXT NOT NULL,
+    document_text TEXT NOT NULL,
+    embedding vector(384) NOT NULL,
+    metadata_json TEXT,
+    created_at TEXT NOT NULL
+);
+"""
+
+DRAWING_EMBEDDINGS_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_drawing_embeddings_child_id ON drawing_embeddings(child_id);
+"""
+
+# IVFFlat index for cosine similarity search (PostgreSQL only, raw SQL)
+DRAWING_EMBEDDINGS_VECTOR_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_drawing_embeddings_vector
+ON drawing_embeddings USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+"""
+
+# ============================================================================
+# Story Embeddings Table
+# ============================================================================
+
+STORY_EMBEDDINGS_PG_TABLE = """
+CREATE TABLE IF NOT EXISTS story_embeddings_pg (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    doc_id TEXT UNIQUE NOT NULL,
+    child_id TEXT NOT NULL,
+    document_text TEXT NOT NULL,
+    embedding vector(384) NOT NULL,
+    metadata_json TEXT,
+    created_at TEXT NOT NULL
+);
+"""
+
+STORY_EMBEDDINGS_PG_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_story_embeddings_pg_child_id ON story_embeddings_pg(child_id);
+"""
+
+STORY_EMBEDDINGS_PG_VECTOR_INDEX = """
+CREATE INDEX IF NOT EXISTS idx_story_embeddings_pg_vector
+ON story_embeddings_pg USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+"""
+
+
+# ============================================================================
+# Schema Initialization
+# ============================================================================
+
+async def init_vector_schema(db: "DatabaseManager") -> None:
+    """Initialize pgvector tables and indexes.
+
+    Only called when dialect == 'postgresql'. SQLite environments use
+    ChromaDB directly and skip this schema entirely.
+    """
+    if db.dialect != "postgresql":
+        return
+
+    # Enable the pgvector extension
+    try:
+        await db.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    except Exception:
+        pass  # Extension may already exist or require superuser
+
+    d = db.dialect
+
+    # Drawing embeddings
+    await db.execute(translate_ddl(DRAWING_EMBEDDINGS_TABLE, d))
+    for stmt in DRAWING_EMBEDDINGS_INDEXES.strip().split(";"):
+        if stmt.strip():
+            try:
+                await db.execute(stmt)
+            except Exception:
+                pass
+
+    # IVFFlat index (skip if not enough rows yet -- Postgres requires rows for IVFFlat)
+    try:
+        await db.execute(DRAWING_EMBEDDINGS_VECTOR_INDEX)
+    except Exception:
+        pass  # IVFFlat needs data; will be created later or manually
+
+    # Story embeddings
+    await db.execute(translate_ddl(STORY_EMBEDDINGS_PG_TABLE, d))
+    for stmt in STORY_EMBEDDINGS_PG_INDEXES.strip().split(";"):
+        if stmt.strip():
+            try:
+                await db.execute(stmt)
+            except Exception:
+                pass
+
+    try:
+        await db.execute(STORY_EMBEDDINGS_PG_VECTOR_INDEX)
+    except Exception:
+        pass
+
+    await db.commit()
+    print("Vector schema initialized (pgvector)")

--- a/backend/src/services/database/vector_repository.py
+++ b/backend/src/services/database/vector_repository.py
@@ -1,0 +1,257 @@
+"""
+Vector Repository — pgvector-backed similarity search for production.
+
+Uses sentence-transformers (all-MiniLM-L6-v2, 384 dims) for embedding
+generation and PostgreSQL pgvector for storage and cosine similarity search.
+
+In dev/test environments where sentence-transformers is not installed,
+the class can still be imported safely (methods will raise at runtime).
+
+Issue: #342 | Parent Epic: #42
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from .connection import db_manager
+
+logger = logging.getLogger(__name__)
+
+# Lazy import — sentence-transformers is heavy and only needed in production
+try:
+    from sentence_transformers import SentenceTransformer
+except Exception:  # pragma: no cover
+    SentenceTransformer = None  # type: ignore[assignment, misc]
+
+
+class VectorRepository:
+    """pgvector-backed vector storage and similarity search.
+
+    Embedding model is loaded lazily on first use to avoid import-time
+    overhead. Uses the same all-MiniLM-L6-v2 model that ChromaDB uses
+    internally, producing 384-dimensional vectors.
+    """
+
+    MODEL_NAME = "all-MiniLM-L6-v2"
+    DIMENSIONS = 384
+
+    def __init__(self):
+        self._db = db_manager
+        self._model = None
+
+    # ------------------------------------------------------------------
+    # Embedding helpers
+    # ------------------------------------------------------------------
+
+    def _get_model(self):
+        """Lazy-load the sentence-transformer model."""
+        if self._model is None:
+            if SentenceTransformer is None:
+                raise RuntimeError(
+                    "sentence-transformers is not installed. "
+                    "Install it with: pip install sentence-transformers"
+                )
+            self._model = SentenceTransformer(self.MODEL_NAME)
+        return self._model
+
+    def _embed(self, text: str) -> List[float]:
+        """Generate embedding vector for a text string."""
+        model = self._get_model()
+        vector = model.encode(text, normalize_embeddings=True)
+        return vector.tolist()
+
+    @staticmethod
+    def _vector_literal(vec: List[float]) -> str:
+        """Format a vector as a pgvector literal string: '[0.1,0.2,...]'."""
+        return "[" + ",".join(str(v) for v in vec) + "]"
+
+    # ------------------------------------------------------------------
+    # Drawing embeddings
+    # ------------------------------------------------------------------
+
+    async def add_drawing(
+        self,
+        doc_id: str,
+        child_id: str,
+        document_text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Store a drawing description with its embedding vector."""
+        embedding = self._embed(document_text)
+        vec_literal = self._vector_literal(embedding)
+        metadata_json = json.dumps(metadata or {}, ensure_ascii=False)
+        now = datetime.now().isoformat()
+
+        await self._db.execute(
+            """
+            INSERT INTO drawing_embeddings (doc_id, child_id, document_text, embedding, metadata_json, created_at)
+            VALUES (?, ?, ?, ?::vector, ?, ?)
+            ON CONFLICT (doc_id) DO UPDATE SET
+                document_text = EXCLUDED.document_text,
+                embedding = EXCLUDED.embedding,
+                metadata_json = EXCLUDED.metadata_json
+            """,
+            (doc_id, child_id, document_text, vec_literal, metadata_json, now),
+        )
+        await self._db.commit()
+
+    async def search_similar_drawings(
+        self,
+        query_text: str,
+        child_id: str,
+        top_k: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Find the most similar drawings for a child using cosine distance."""
+        embedding = self._embed(query_text)
+        vec_literal = self._vector_literal(embedding)
+
+        rows = await self._db.fetchall(
+            """
+            SELECT doc_id, child_id, document_text, metadata_json,
+                   embedding <=> ?::vector AS distance
+            FROM drawing_embeddings
+            WHERE child_id = ?
+            ORDER BY distance ASC
+            LIMIT ?
+            """,
+            (vec_literal, child_id, top_k),
+        )
+
+        results = []
+        for row in rows:
+            distance = row.get("distance", 0.0)
+            similarity = 1.0 / (1.0 + distance)
+            meta = {}
+            if row.get("metadata_json"):
+                try:
+                    meta = json.loads(row["metadata_json"])
+                except json.JSONDecodeError:
+                    pass
+            results.append({
+                "id": row["doc_id"],
+                "similarity_score": round(similarity, 4),
+                "distance": round(distance, 4),
+                "drawing_data": meta,
+                "description": row.get("document_text", ""),
+            })
+        return results
+
+    async def get_drawings_by_child(self, child_id: str) -> List[Dict[str, Any]]:
+        """Return all drawing embeddings for a child (no similarity search)."""
+        rows = await self._db.fetchall(
+            "SELECT doc_id, child_id, document_text, metadata_json, created_at "
+            "FROM drawing_embeddings WHERE child_id = ?",
+            (child_id,),
+        )
+        results = []
+        for row in rows:
+            meta = {}
+            if row.get("metadata_json"):
+                try:
+                    meta = json.loads(row["metadata_json"])
+                except json.JSONDecodeError:
+                    pass
+            results.append({
+                "id": row["doc_id"],
+                "child_id": row["child_id"],
+                "document_text": row.get("document_text", ""),
+                "metadata": meta,
+                "created_at": row.get("created_at", ""),
+            })
+        return results
+
+    # ------------------------------------------------------------------
+    # Story embeddings
+    # ------------------------------------------------------------------
+
+    async def add_story_embedding(
+        self,
+        doc_id: str,
+        child_id: str,
+        document_text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Store a story text with its embedding vector for deduplication."""
+        embedding = self._embed(document_text)
+        vec_literal = self._vector_literal(embedding)
+        metadata_json = json.dumps(metadata or {}, ensure_ascii=False)
+        now = datetime.now().isoformat()
+
+        await self._db.execute(
+            """
+            INSERT INTO story_embeddings_pg (doc_id, child_id, document_text, embedding, metadata_json, created_at)
+            VALUES (?, ?, ?, ?::vector, ?, ?)
+            ON CONFLICT (doc_id) DO UPDATE SET
+                document_text = EXCLUDED.document_text,
+                embedding = EXCLUDED.embedding,
+                metadata_json = EXCLUDED.metadata_json
+            """,
+            (doc_id, child_id, document_text, vec_literal, metadata_json, now),
+        )
+        await self._db.commit()
+
+    async def search_similar_stories(
+        self,
+        query_text: str,
+        child_id: str,
+        top_k: int = 5,
+    ) -> List[Dict[str, Any]]:
+        """Find semantically similar stories for a child."""
+        embedding = self._embed(query_text)
+        vec_literal = self._vector_literal(embedding)
+
+        rows = await self._db.fetchall(
+            """
+            SELECT doc_id, child_id, document_text, metadata_json,
+                   embedding <=> ?::vector AS distance
+            FROM story_embeddings_pg
+            WHERE child_id = ?
+            ORDER BY distance ASC
+            LIMIT ?
+            """,
+            (vec_literal, child_id, top_k),
+        )
+
+        results = []
+        for row in rows:
+            distance = row.get("distance", 0.0)
+            similarity = 1.0 / (1.0 + distance)
+            meta = {}
+            if row.get("metadata_json"):
+                try:
+                    meta = json.loads(row["metadata_json"])
+                except json.JSONDecodeError:
+                    pass
+            text = row.get("document_text", "")
+            preview = (text[:200] + "...") if len(text) > 200 else text
+            results.append({
+                "story_id": row["doc_id"],
+                "similarity_score": round(similarity, 4),
+                "story_text_preview": preview,
+                "metadata": meta,
+            })
+        return results
+
+    # ------------------------------------------------------------------
+    # Deletion
+    # ------------------------------------------------------------------
+
+    async def delete_by_child(self, child_id: str) -> int:
+        """Delete all vector data for a child. Returns total rows deleted."""
+        r1 = await self._db.execute(
+            "DELETE FROM drawing_embeddings WHERE child_id = ?",
+            (child_id,),
+        )
+        r2 = await self._db.execute(
+            "DELETE FROM story_embeddings_pg WHERE child_id = ?",
+            (child_id,),
+        )
+        await self._db.commit()
+        deleted = (r1.rowcount if r1 else 0) + (r2.rowcount if r2 else 0)
+        return deleted
+
+
+# Module-level singleton (follows the same pattern as other repositories)
+vector_repo = VectorRepository()


### PR DESCRIPTION
## Summary

- Add `VectorRepository` class with 6 methods for pgvector-based vector search in production
- Add `schema_vectors.py` with DDL for `drawing_embeddings` and `story_embeddings_pg` tables using `vector(384)` columns
- Refactor `vector_search_server.py` to dual-path: pgvector for PostgreSQL, ChromaDB for SQLite
- Update `memory.py` for dialect-aware vector deletion
- Uses `sentence-transformers` with `all-MiniLM-L6-v2` (same model as ChromaDB) for embedding parity

## Test plan

- [x] 26 existing tests pass (memory + image_to_story)
- [x] Import verification: `VectorRepository` imports cleanly
- [x] ChromaDB dev path unchanged
- [ ] pgvector validation against real Supabase instance (follow-up: #345)

Fixes #342
**Parent Epic**: #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)