### PR TITLE
feat(frontend): add useDailyTaskStore for daily star collection

### DIFF
--- a/frontend/src/store/useDailyTaskStore.ts
+++ b/frontend/src/store/useDailyTaskStore.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+interface DailyTaskState {
+  // Persisted state
+  claimHistory: string[]  // ISO date strings: ["2026-04-08", "2026-04-09"]
+  totalStars: number
+
+  // Actions
+  canClaimToday: () => boolean
+  claimStar: () => void
+  getWeekProgress: () => { claimed: number; target: number }
+  getStreak: () => number
+}
+
+function getToday(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+/**
+ * Returns the Monday of the week containing the given date string.
+ * Week runs Mon–Sun.
+ */
+function getWeekStart(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00')
+  const day = date.getDay()
+  // JS getDay(): 0=Sun, 1=Mon...6=Sat → offset to Monday
+  const offset = day === 0 ? 6 : day - 1
+  date.setDate(date.getDate() - offset)
+  return date.toISOString().slice(0, 10)
+}
+
+const useDailyTaskStore = create<DailyTaskState>()(
+  persist(
+    (set, get) => ({
+      claimHistory: [],
+      totalStars: 0,
+
+      canClaimToday: () => {
+        const today = getToday()
+        return !get().claimHistory.includes(today)
+      },
+
+      claimStar: () => {
+        const today = getToday()
+        const { claimHistory, totalStars } = get()
+        if (claimHistory.includes(today)) return // idempotent
+        set({
+          claimHistory: [...claimHistory, today],
+          totalStars: totalStars + 1,
+        })
+      },
+
+      getWeekProgress: () => {
+        const today = getToday()
+        const weekStart = getWeekStart(today)
+        const claimed = get().claimHistory.filter(
+          (date) => date >= weekStart && date <= today
+        ).length
+        return { claimed, target: 7 }
+      },
+
+      getStreak: () => {
+        const { claimHistory } = get()
+        if (claimHistory.length === 0) return 0
+
+        const sorted = [...claimHistory].sort().reverse()
+        const today = getToday()
+
+        // Streak must include today or yesterday to be active
+        const yesterday = new Date()
+        yesterday.setDate(yesterday.getDate() - 1)
+        const yesterdayStr = yesterday.toISOString().slice(0, 10)
+
+        if (sorted[0] !== today && sorted[0] !== yesterdayStr) return 0
+
+        let streak = 1
+        for (let i = 1; i < sorted.length; i++) {
+          const prev = new Date(sorted[i - 1] + 'T00:00:00')
+          const curr = new Date(sorted[i] + 'T00:00:00')
+          const diffDays = (prev.getTime() - curr.getTime()) / (1000 * 60 * 60 * 24)
+          if (diffDays === 1) {
+            streak++
+          } else {
+            break
+          }
+        }
+        return streak
+      },
+    }),
+    {
+      name: 'daily-task-storage',
+      partialize: (state) => ({
+        claimHistory: state.claimHistory,
+        totalStars: state.totalStars,
+      }),
+    }
+  )
+)
+
+export default useDailyTaskStore


### PR DESCRIPTION
## Summary

- Create `useDailyTaskStore` Zustand store with `persist` middleware (key: `daily-task-storage`)
- Implements daily claim with idempotency guard, weekly progress (Mon–Sun), and streak calculation
- Follows existing store patterns (`useChildStore`, `useAuthStore`)

Fixes #372
**Parent Epic**: #371

## Test plan

- [ ] Import store in a component and verify `canClaimToday()` returns `true` on first load
- [ ] Call `claimStar()` and verify `canClaimToday()` returns `false`
- [ ] Refresh page — verify state persists from localStorage
- [ ] Verify `getWeekProgress()` returns correct `{claimed, target: 7}`
- [ ] Verify `getStreak()` counts consecutive days correctly
- [ ] Unit tests tracked in #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)