### PR TITLE
Move star jar to profile page, fly stars to nav avatar

### DIFF
--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -6,13 +6,25 @@ import GenerationStatusBar from '@/components/layout/GenerationStatusBar'
 import useGenerationNavigator from '@/hooks/useGenerationNavigator'
 import AvatarDisplay from '@/components/common/AvatarDisplay'
 import useAuthStore from '@/store/useAuthStore'
+import useDailyTaskStore from '@/store/useDailyTaskStore'
 import { authService } from '@/api/services/authService'
 import { performFullLogout } from '@/utils/logout'
+import { NavRefProvider, useNavRef } from '@/contexts/NavRefContext'
 
 function PageContainer() {
+  return (
+    <NavRefProvider>
+      <PageContainerInner />
+    </NavRefProvider>
+  )
+}
+
+function PageContainerInner() {
   const location = useLocation()
   const navigate = useNavigate()
   const { isAuthenticated, user } = useAuthStore()
+  const { setProfileAvatarEl } = useNavRef()
+  const totalStars = useDailyTaskStore((s) => s.totalStars)
 
   useGenerationNavigator()
 
@@ -59,15 +71,22 @@ function PageContainer() {
               {isAuthenticated ? (
                 <div className="flex items-center gap-3 ml-2 pl-4 border-l border-gray-200">
                   <Link to="/profile">
-                    <motion.div
-                      className="flex items-center gap-2 text-gray-600"
-                      whileHover={{ scale: 1.02 }}
-                    >
-                      <AvatarDisplay avatarUrl={user?.avatar_url} size="sm" />
-                      <span className="text-sm font-medium hidden sm:inline">
-                        {user?.display_name || user?.username}
-                      </span>
-                    </motion.div>
+                    <div ref={setProfileAvatarEl} className="relative">
+                      <motion.div
+                        className="flex items-center gap-2 text-gray-600"
+                        whileHover={{ scale: 1.02 }}
+                      >
+                        <AvatarDisplay avatarUrl={user?.avatar_url} size="sm" />
+                        {totalStars > 0 && (
+                          <span className="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] flex items-center justify-center text-[10px] font-bold text-white bg-gradient-to-r from-yellow-400 to-orange-400 rounded-full shadow-sm px-1 leading-none">
+                            {totalStars > 99 ? '99+' : totalStars}
+                          </span>
+                        )}
+                        <span className="text-sm font-medium hidden sm:inline">
+                          {user?.display_name || user?.username}
+                        </span>
+                      </motion.div>
+                    </div>
                   </Link>
                   <motion.button
                     onClick={handleLogout}

--- a/frontend/src/contexts/NavRefContext.tsx
+++ b/frontend/src/contexts/NavRefContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useRef, useCallback, type RefObject } from 'react'
+
+interface NavRefContextValue {
+  profileAvatarRef: RefObject<HTMLDivElement | null>
+  setProfileAvatarEl: (el: HTMLDivElement | null) => void
+}
+
+const NavRefContext = createContext<NavRefContextValue | null>(null)
+
+export function NavRefProvider({ children }: { children: React.ReactNode }) {
+  const profileAvatarRef = useRef<HTMLDivElement | null>(null)
+  const setProfileAvatarEl = useCallback((el: HTMLDivElement | null) => {
+    profileAvatarRef.current = el
+  }, [])
+  return (
+    <NavRefContext.Provider value={{ profileAvatarRef, setProfileAvatarEl }}>
+      {children}
+    </NavRefContext.Provider>
+  )
+}
+
+export function useNavRef() {
+  const ctx = useContext(NavRefContext)
+  if (!ctx) throw new Error('useNavRef must be used within NavRefProvider')
+  return ctx
+}

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -12,10 +12,10 @@ import useAuthStore from '@/store/useAuthStore'
 import useDailyTaskStore from '@/store/useDailyTaskStore'
 import { libraryService, type LibraryItem } from '@/api/services/libraryService'
 import { StoryCard } from '@/components/story/StoryDisplay'
-import StarPiggyBank, { type StarPiggyBankHandle } from '@/components/daily/StarPiggyBank'
 import InspirationDaily from '@/components/daily/InspirationDaily'
 import TearAnimation from '@/components/daily/TearAnimation'
 import StarFlyAnimation from '@/components/daily/StarFlyAnimation'
+import { useNavRef } from '@/contexts/NavRefContext'
 
 const TIPS = [
   { icon: '🎨', tip: 'The more colorful and detailed your artwork, the more magical your story! Try drawing your favorite animals, characters, or imaginary worlds~' },
@@ -88,9 +88,8 @@ function HomePage() {
   const canClaim = useDailyTaskStore((s) => s.canClaimToday())
   const claimStar = useDailyTaskStore((s) => s.claimStar)
   const lastClaimTimestamp = useDailyTaskStore((s) => s.lastClaimTimestamp)
-  const piggyBankRef = useRef<StarPiggyBankHandle>(null)
+  const { profileAvatarRef } = useNavRef()
   const newspaperRef = useRef<HTMLDivElement>(null)
-  const piggyBankElRef = useRef<HTMLDivElement>(null)
   const [starFlying, setStarFlying] = useState(false)
 
   // Hide newspaper 5 minutes after claiming today
@@ -128,7 +127,6 @@ function HomePage() {
   const handleStarArrived = useCallback(() => {
     setStarFlying(false)
     claimStar()
-    piggyBankRef.current?.onStarReceived()
   }, [claimStar])
 
   // Fetch latest 3 items from unified library API (all content types)
@@ -166,16 +164,11 @@ function HomePage() {
 
   return (
     <div className="space-y-8 perspective-1500">
-      {/* Star Piggy Bank — top right */}
-      <div className="flex justify-end" ref={piggyBankElRef}>
-        <StarPiggyBank ref={piggyBankRef} />
-      </div>
-
-      {/* Star fly animation overlay */}
+      {/* Star fly animation — flies from newspaper to profile avatar in nav */}
       <StarFlyAnimation
         active={starFlying}
         fromRef={newspaperRef}
-        toRef={piggyBankElRef}
+        toRef={profileAvatarRef}
         onComplete={handleStarArrived}
       />
 

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -7,9 +7,11 @@ import Card from "@/components/common/Card";
 import TiltCard from "@/components/depth/TiltCard";
 import useAuthStore from "@/store/useAuthStore";
 import useChildStore from "@/store/useChildStore";
+import useDailyTaskStore from "@/store/useDailyTaskStore";
 import { authService } from "@/api/services/authService";
 import type { UpdateProfileRequest, ReferralStatus } from "@/types/auth";
 import AvatarDisplay from "@/components/common/AvatarDisplay";
+import StarPiggyBank from "@/components/daily/StarPiggyBank";
 import CharacterGallery from "./CharacterGallery";
 import PreferenceSummary from "./PreferenceSummary";
 import { useMemoryApi } from "@/hooks/useMemoryApi";
@@ -37,6 +39,50 @@ const ANIMAL_EMOJIS = [
   "🐬",
   "🐙",
 ];
+
+function StarBoard() {
+  const totalStars = useDailyTaskStore((s) => s.totalStars);
+  const streak = useDailyTaskStore((s) => s.getStreak());
+
+  return (
+    <Card className="overflow-hidden">
+      <div className="bg-gradient-to-r from-amber-400 via-yellow-400 to-orange-400 px-5 py-4">
+        <div className="flex items-center gap-3">
+          <div className="text-3xl">🫙</div>
+          <div>
+            <h2 className="text-base font-bold text-white flex items-center gap-2">
+              My Star Collection
+              {streak >= 2 && (
+                <span className="px-2 py-0.5 text-[10px] font-bold rounded-full bg-white/25 text-white backdrop-blur-sm border border-white/30">
+                  🔥 {streak} day streak
+                </span>
+              )}
+            </h2>
+            <p className="text-xs text-white/80 mt-0.5">
+              Tear the daily newspaper to collect stars!
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-5 space-y-4">
+        {/* Total stars */}
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-500">Total Stars</span>
+          <span className="text-2xl font-bold text-amber-500">{totalStars}</span>
+        </div>
+
+        {/* Weekly progress with piggy bank */}
+        <div>
+          <p className="text-xs font-medium text-gray-500 mb-3">This Week</p>
+          <div className="flex justify-center">
+            <StarPiggyBank />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
 
 function ProfilePage() {
   const navigate = useNavigate();
@@ -325,6 +371,15 @@ function ProfilePage() {
           </div>
         </TiltCard>
       </motion.div>
+
+      {/* Star Collection Board */}
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.12 }}
+      >
+        <StarBoard />
+      </motion.section>
 
       {/* Referral Section */}
       <motion.section


### PR DESCRIPTION
## Summary
- Moved StarPiggyBank from HomePage to ProfilePage as a "My Star Collection" board with total stars, weekly progress, and streak display
- Created `NavRefContext` to share the profile avatar ref across components
- Star fly animation now targets the profile avatar in the top nav bar after newspaper tear
- Added a star count badge on the profile avatar (gradient gold, shows total stars)

Fixes #393, Fixes #394
**Parent Epic**: #40

## Test plan
- [ ] Tear newspaper on HomePage — star should fly to profile avatar in top nav
- [ ] Star count badge appears on profile avatar after claiming
- [ ] Navigate to Profile page — "My Star Collection" section shows between stats and referral
- [ ] Weekly progress (star slots) and streak visible on Profile
- [ ] Reduced-motion: star claim happens instantly without animation
- [ ] `npx tsc --noEmit` passes
- [ ] All 16 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)