### PR TITLE
Fix: referral code dropped on Supabase registration

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -12,6 +12,7 @@ from fastapi import Depends, Header, HTTPException, status
 
 from ..services.database import (
     db_manager,
+    referral_repo,
     session_repo,
     story_repo,
     usage_repo,
@@ -184,6 +185,32 @@ async def _get_or_create_supabase_user(claims) -> Optional[UserData]:
         ),
     )
     await db_manager.commit()
+
+    # Handle referral if a referral_code was passed during registration (#424)
+    if getattr(claims, "referral_code", None):
+        try:
+            referrer = await user_repo.get_by_referral_code(claims.referral_code)
+            if referrer and referrer.user_id != claims.sub:
+                await referral_repo.create_referral(
+                    referrer_user_id=referrer.user_id,
+                    referred_user_id=claims.sub,
+                    referral_code=claims.referral_code,
+                )
+                # Update referred_by on the new user
+                await db_manager.execute(
+                    "UPDATE users SET referred_by = ? WHERE user_id = ?",
+                    (claims.referral_code, claims.sub),
+                )
+                await db_manager.commit()
+
+                # Qualify immediately if email is confirmed (#425)
+                if claims.email_confirmed:
+                    await referral_repo.qualify_referral(claims.sub)
+                    from ..services.user_service import user_service
+                    await user_service.qualify_and_maybe_upgrade(referrer.user_id)
+        except Exception:
+            pass  # Referral is non-critical — don't block user creation
+
     return await user_repo.get_by_id(claims.sub)
 
 

--- a/backend/src/services/supabase_auth.py
+++ b/backend/src/services/supabase_auth.py
@@ -31,6 +31,7 @@ class SupabaseClaims:
     sub: str          # Supabase user ID (UUID)
     email: str
     email_confirmed: bool
+    referral_code: Optional[str] = None  # From signUp metadata (#424)
 
 
 def get_jwt_secret() -> Optional[str]:
@@ -151,8 +152,11 @@ def _extract_claims(payload: dict) -> Optional[SupabaseClaims]:
     email_confirmed = payload.get("email_confirmed_at") is not None or \
         user_meta.get("email_verified", False)
 
+    referral_code = user_meta.get("referral_code")
+
     return SupabaseClaims(
         sub=sub,
         email=email,
         email_confirmed=email_confirmed,
+        referral_code=referral_code,
     )

--- a/frontend/src/api/services/authService.ts
+++ b/frontend/src/api/services/authService.ts
@@ -74,6 +74,7 @@ export const authService = {
           data: {
             display_name: data.display_name || data.username,
             username: data.username,
+            ...(data.referral_code ? { referral_code: data.referral_code } : {}),
           },
         },
       })


### PR DESCRIPTION
## Summary
- Pass `referral_code` in Supabase signUp metadata so it survives the auth flow
- Backend reads referral_code from JWT claims and creates referral record during auto-create
- Qualifies referral immediately if email is already confirmed; triggers auto-upgrade at 10

Fixes #424, Fixes #425
**Parent Epic**: #346

## Changes
| File | Change |
|------|--------|
| `authService.ts` | Add `referral_code` to `signUp` `options.data` |
| `supabase_auth.py` | Add `referral_code` field to `SupabaseClaims`, extract from `user_metadata` |
| `deps.py` | Import `referral_repo`, create referral record + qualify in `_get_or_create_supabase_user` |

## Test plan
- [x] 33/33 referral tests pass (contracts, API, registration)
- [x] TypeScript compiles cleanly
- [x] Python syntax validates
- [ ] Manual: register with `?ref=CODE`, verify referral record created in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)