### PR TITLE
feat(schema): add user_agents table + users onboarding columns (#438)

### DIFF
--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -282,6 +282,30 @@ CREATE INDEX IF NOT EXISTS idx_referrals_referrer ON referrals(referrer_user_id)
 CREATE INDEX IF NOT EXISTS idx_referrals_code ON referrals(referral_code);
 """
 
+# ============================================================================
+# User Agents Table (#438) — foundation for Epic #436 (My Agent persona)
+# ============================================================================
+
+USER_AGENTS_TABLE = """
+CREATE TABLE IF NOT EXISTS user_agents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL UNIQUE,
+    user_id TEXT NOT NULL,
+    child_id TEXT NOT NULL,
+    agent_name TEXT NOT NULL,
+    agent_avatar_id TEXT NOT NULL,
+    agent_title TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    UNIQUE(user_id, child_id),
+    FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+"""
+
+USER_AGENTS_INDEXES = """
+CREATE INDEX IF NOT EXISTS idx_user_agents_user ON user_agents(user_id);
+"""
+
 
 # ============================================================================
 # Schema Initialization
@@ -393,6 +417,8 @@ async def init_schema(db: "DatabaseManager") -> None:
     await _migrate_add_styled_image_url(db)
     await _migrate_add_referral_columns(db)
     await _migrate_add_story_length_mode(db)
+    await _migrate_add_onboarding_columns(db)
+    await _migrate_create_user_agents_table(db)
 
     # Now create all indexes (including user_id indexes) after migration
     for stmt in STORIES_INDEXES.strip().split(";"):
@@ -627,6 +653,52 @@ async def _migrate_add_story_length_mode(db: "DatabaseManager") -> None:
         )
         await db.commit()
         print("Sessions story_length_mode migration completed")
+
+
+async def _migrate_add_onboarding_columns(db: "DatabaseManager") -> None:
+    """Migration: Add onboarding columns to users table (#438).
+
+    Adds nullable columns that capture onboarding state and parent identity:
+    - nickname: friendly name shown in UI
+    - onboarded_at: timestamp the user finished onboarding
+    - parent_consent_at: timestamp the parent granted consent
+    - default_child_id: the active child profile to bind agent persona to
+
+    All columns are NULLABLE to keep this migration non-destructive — existing
+    rows are unaffected and stay valid.
+    """
+    columns = [
+        ("nickname", "ALTER TABLE users ADD COLUMN nickname TEXT"),
+        ("onboarded_at", "ALTER TABLE users ADD COLUMN onboarded_at TEXT"),
+        ("parent_consent_at", "ALTER TABLE users ADD COLUMN parent_consent_at TEXT"),
+        ("default_child_id", "ALTER TABLE users ADD COLUMN default_child_id TEXT"),
+    ]
+    added = False
+    for column_name, ddl in columns:
+        if not await column_exists(db, "users", column_name):
+            if not added:
+                print("Migrating users table: adding onboarding columns (#438)...")
+                added = True
+            await db.execute(ddl)
+    if added:
+        await db.commit()
+        print("Users onboarding migration completed")
+
+
+async def _migrate_create_user_agents_table(db: "DatabaseManager") -> None:
+    """Migration: Create user_agents table + indexes (#438).
+
+    Foundation for Epic #436 (My Agent — personalized buddy persona). Uses
+    CREATE TABLE IF NOT EXISTS so the migration is idempotent across reruns.
+    """
+    await db.execute(translate_ddl(USER_AGENTS_TABLE, db.dialect))
+    for stmt in USER_AGENTS_INDEXES.strip().split(";"):
+        if stmt.strip():
+            try:
+                await db.execute(stmt)
+            except Exception:
+                pass
+    await db.commit()
 
 
 # ============================================================================

--- a/backend/src/services/database/user_repository.py
+++ b/backend/src/services/database/user_repository.py
@@ -33,6 +33,11 @@ class UserData:
     created_at: str = ""
     updated_at: str = ""
     last_login_at: Optional[str] = None
+    # Onboarding fields (#438)
+    nickname: Optional[str] = None
+    onboarded_at: Optional[str] = None
+    parent_consent_at: Optional[str] = None
+    default_child_id: Optional[str] = None
 
 
 @dataclass
@@ -262,6 +267,60 @@ class UserRepository:
         cursor = await self._db.execute(
             "UPDATE users SET last_login_at = ?, updated_at = ? WHERE user_id = ?",
             (now, now, user_id)
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    async def update_onboarding_fields(
+        self,
+        user_id: str,
+        *,
+        nickname: Optional[str] = None,
+        onboarded_at: Optional[str] = None,
+        parent_consent_at: Optional[str] = None,
+        default_child_id: Optional[str] = None,
+    ) -> bool:
+        """
+        Partial update of onboarding fields on the users row (#438).
+
+        Only non-None arguments are written. Returns True if at least one row
+        was updated. Returns False if no fields were supplied (no-op) or the
+        user_id did not match any row.
+
+        Args:
+            user_id: User ID to update.
+            nickname: Friendly name shown in UI.
+            onboarded_at: ISO timestamp when onboarding finished.
+            parent_consent_at: ISO timestamp when parent granted consent.
+            default_child_id: Active child profile bound to the agent persona.
+        """
+        updates: List[str] = []
+        params: List[Any] = []
+
+        if nickname is not None:
+            updates.append("nickname = ?")
+            params.append(nickname)
+        if onboarded_at is not None:
+            updates.append("onboarded_at = ?")
+            params.append(onboarded_at)
+        if parent_consent_at is not None:
+            updates.append("parent_consent_at = ?")
+            params.append(parent_consent_at)
+        if default_child_id is not None:
+            updates.append("default_child_id = ?")
+            params.append(default_child_id)
+
+        if not updates:
+            return False
+
+        now = datetime.now().isoformat()
+        updates.append("updated_at = ?")
+        params.append(now)
+        params.append(user_id)
+
+        cursor = await self._db.execute(
+            f"UPDATE users SET {', '.join(updates)} WHERE user_id = ?",
+            tuple(params),
         )
         await self._db.commit()
         return cursor.rowcount > 0
@@ -514,7 +573,11 @@ class UserRepository:
             referred_by=row.get('referred_by'),
             created_at=row['created_at'],
             updated_at=row['updated_at'],
-            last_login_at=row.get('last_login_at')
+            last_login_at=row.get('last_login_at'),
+            nickname=row.get('nickname'),
+            onboarded_at=row.get('onboarded_at'),
+            parent_consent_at=row.get('parent_consent_at'),
+            default_child_id=row.get('default_child_id'),
         )
 
     def _story_row_to_dict(self, row: dict) -> Dict[str, Any]:

--- a/backend/tests/contracts/test_user_agents_repository_contract.py
+++ b/backend/tests/contracts/test_user_agents_repository_contract.py
@@ -1,0 +1,246 @@
+"""
+User Agents Schema Contract Tests
+
+Locks the schema contract for the user_agents table introduced in issue #438.
+This is the foundation table for Epic #436 (My Agent — personalized buddy
+persona). The full repository class lands in #439; here we only cover the
+schema-level invariants the repository will rely on:
+
+  - Table is created by init_schema.
+  - agent_id is UNIQUE.
+  - (user_id, child_id) is UNIQUE — at most one agent per child.
+  - ON DELETE CASCADE removes user_agents when the parent user is deleted.
+
+Parent Epic: #436
+Issue: #438
+"""
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserRepository
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def db():
+    """Fresh in-memory database with full schema applied."""
+    manager = DatabaseManager(":memory:")
+    await manager.connect()
+    await init_schema(manager)
+    yield manager
+    await manager.disconnect()
+
+
+@pytest_asyncio.fixture
+async def user_repo(db):
+    """UserRepository bound to test database."""
+    repo = UserRepository()
+    repo._db = db
+    return repo
+
+
+@pytest_asyncio.fixture
+async def parent_user(user_repo):
+    """A real user row to satisfy the FK on user_agents.user_id."""
+    return await user_repo.create_user(
+        username="parent1",
+        email="parent1@test.com",
+        password_hash="h",
+    )
+
+
+async def _insert_user_agent(
+    db: DatabaseManager,
+    *,
+    agent_id: str,
+    user_id: str,
+    child_id: str,
+    agent_name: str = "Bobo",
+    agent_avatar_id: str = "avatar-fox",
+    agent_title: str = "Brave Buddy",
+    created_at: str = "2026-01-01T00:00:00",
+    updated_at: str = "2026-01-01T00:00:00",
+) -> None:
+    await db.execute(
+        """
+        INSERT INTO user_agents (
+            agent_id, user_id, child_id, agent_name,
+            agent_avatar_id, agent_title, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            agent_id,
+            user_id,
+            child_id,
+            agent_name,
+            agent_avatar_id,
+            agent_title,
+            created_at,
+            updated_at,
+        ),
+    )
+    await db.commit()
+
+
+# ============================================================================
+# Contract: table exists with required columns
+# ============================================================================
+
+
+class TestUserAgentsTableShape:
+    """user_agents table is created with the expected columns."""
+
+    @pytest.mark.asyncio
+    async def test_table_exists(self, db):
+        rows = await db.fetchall("PRAGMA table_info(user_agents)")
+        assert len(rows) > 0, "user_agents table not created"
+
+    @pytest.mark.asyncio
+    async def test_required_columns(self, db):
+        rows = await db.fetchall("PRAGMA table_info(user_agents)")
+        cols = {row["name"] for row in rows}
+        for required in (
+            "id",
+            "agent_id",
+            "user_id",
+            "child_id",
+            "agent_name",
+            "agent_avatar_id",
+            "agent_title",
+            "created_at",
+            "updated_at",
+        ):
+            assert required in cols, f"missing column {required}"
+
+
+# ============================================================================
+# Contract: insert + select roundtrip
+# ============================================================================
+
+
+class TestInsertSelectRoundtrip:
+    """A row inserted by SQL can be selected back with the same values."""
+
+    @pytest.mark.asyncio
+    async def test_roundtrip(self, db, parent_user):
+        await _insert_user_agent(
+            db,
+            agent_id="agent-uuid-1",
+            user_id=parent_user.user_id,
+            child_id="child-1",
+            agent_name="Bobo",
+            agent_avatar_id="avatar-fox",
+            agent_title="Brave Buddy",
+        )
+        row = await db.fetchone(
+            "SELECT agent_id, user_id, child_id, agent_name, agent_avatar_id, "
+            "agent_title FROM user_agents WHERE agent_id = ?",
+            ("agent-uuid-1",),
+        )
+        assert row is not None
+        assert row["agent_id"] == "agent-uuid-1"
+        assert row["user_id"] == parent_user.user_id
+        assert row["child_id"] == "child-1"
+        assert row["agent_name"] == "Bobo"
+        assert row["agent_avatar_id"] == "avatar-fox"
+        assert row["agent_title"] == "Brave Buddy"
+
+
+# ============================================================================
+# Contract: UNIQUE constraints
+# ============================================================================
+
+
+class TestUniqueConstraints:
+    """Both agent_id and (user_id, child_id) are UNIQUE."""
+
+    @pytest.mark.asyncio
+    async def test_unique_user_id_child_id(self, db, parent_user):
+        await _insert_user_agent(
+            db,
+            agent_id="agent-uuid-a",
+            user_id=parent_user.user_id,
+            child_id="child-x",
+        )
+        with pytest.raises(Exception):
+            await _insert_user_agent(
+                db,
+                agent_id="agent-uuid-b",
+                user_id=parent_user.user_id,
+                child_id="child-x",
+            )
+
+    @pytest.mark.asyncio
+    async def test_unique_agent_id(self, db, parent_user):
+        await _insert_user_agent(
+            db,
+            agent_id="agent-uuid-shared",
+            user_id=parent_user.user_id,
+            child_id="child-1",
+        )
+        with pytest.raises(Exception):
+            await _insert_user_agent(
+                db,
+                agent_id="agent-uuid-shared",
+                user_id=parent_user.user_id,
+                child_id="child-2",
+            )
+
+
+# ============================================================================
+# Contract: ON DELETE CASCADE
+# ============================================================================
+
+
+class TestCascadeOnUserDelete:
+    """Deleting the parent user cascades to user_agents rows."""
+
+    @pytest.mark.asyncio
+    async def test_cascade_delete(self, db, parent_user):
+        await _insert_user_agent(
+            db,
+            agent_id="agent-cascade-1",
+            user_id=parent_user.user_id,
+            child_id="child-cascade",
+        )
+        # Sanity: row exists.
+        before = await db.fetchone(
+            "SELECT 1 FROM user_agents WHERE agent_id = ?",
+            ("agent-cascade-1",),
+        )
+        assert before is not None
+
+        await db.execute(
+            "DELETE FROM users WHERE user_id = ?", (parent_user.user_id,)
+        )
+        await db.commit()
+
+        after = await db.fetchone(
+            "SELECT 1 FROM user_agents WHERE agent_id = ?",
+            ("agent-cascade-1",),
+        )
+        assert after is None, "ON DELETE CASCADE did not remove the user_agents row"
+
+
+# ============================================================================
+# Contract: index on user_id
+# ============================================================================
+
+
+class TestUserIdIndex:
+    """idx_user_agents_user index is created for fast lookup-by-user."""
+
+    @pytest.mark.asyncio
+    async def test_index_exists(self, db):
+        rows = await db.fetchall(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='user_agents'"
+        )
+        names = {row["name"] for row in rows}
+        assert "idx_user_agents_user" in names

--- a/backend/tests/contracts/test_users_onboarding_columns_contract.py
+++ b/backend/tests/contracts/test_users_onboarding_columns_contract.py
@@ -1,0 +1,171 @@
+"""
+Users Onboarding Columns Schema Contract Tests
+
+Locks the schema contract for the four nullable onboarding columns added to
+the users table by issue #438:
+  - nickname
+  - onboarded_at
+  - parent_consent_at
+  - default_child_id
+
+Parent Epic: #436 (My Agent — personalized buddy persona)
+Issue: #438
+"""
+
+from typing import Dict, List
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+
+
+REQUIRED_ONBOARDING_COLUMNS = (
+    "nickname",
+    "onboarded_at",
+    "parent_consent_at",
+    "default_child_id",
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def db():
+    """Fresh in-memory database with full schema applied."""
+    manager = DatabaseManager(":memory:")
+    await manager.connect()
+    await init_schema(manager)
+    yield manager
+    await manager.disconnect()
+
+
+async def _users_columns(db: DatabaseManager) -> List[Dict]:
+    return await db.fetchall("PRAGMA table_info(users)")
+
+
+# ============================================================================
+# Contract: columns exist
+# ============================================================================
+
+
+class TestOnboardingColumnsExist:
+    """All four onboarding columns are present on the users table."""
+
+    @pytest.mark.asyncio
+    async def test_nickname_column_exists(self, db):
+        cols = {row["name"] for row in await _users_columns(db)}
+        assert "nickname" in cols
+
+    @pytest.mark.asyncio
+    async def test_onboarded_at_column_exists(self, db):
+        cols = {row["name"] for row in await _users_columns(db)}
+        assert "onboarded_at" in cols
+
+    @pytest.mark.asyncio
+    async def test_parent_consent_at_column_exists(self, db):
+        cols = {row["name"] for row in await _users_columns(db)}
+        assert "parent_consent_at" in cols
+
+    @pytest.mark.asyncio
+    async def test_default_child_id_column_exists(self, db):
+        cols = {row["name"] for row in await _users_columns(db)}
+        assert "default_child_id" in cols
+
+
+# ============================================================================
+# Contract: columns are nullable
+# ============================================================================
+
+
+class TestOnboardingColumnsNullable:
+    """All four onboarding columns must be NULLABLE — non-destructive migration."""
+
+    @pytest.mark.asyncio
+    async def test_all_onboarding_columns_nullable(self, db):
+        rows = await _users_columns(db)
+        # PRAGMA table_info: column "notnull" is 1 if NOT NULL, 0 if nullable.
+        info = {row["name"]: row for row in rows}
+        for name in REQUIRED_ONBOARDING_COLUMNS:
+            assert name in info, f"missing column {name}"
+            assert info[name]["notnull"] == 0, (
+                f"column {name} must be NULLABLE so existing rows stay valid"
+            )
+
+
+# ============================================================================
+# Contract: idempotent migrations
+# ============================================================================
+
+
+class TestSchemaIdempotency:
+    """init_schema can run multiple times without error or duplicate columns."""
+
+    @pytest.mark.asyncio
+    async def test_init_schema_runs_twice_without_error(self, db):
+        # Fixture already ran init_schema once; run it again.
+        await init_schema(db)
+        cols = {row["name"] for row in await _users_columns(db)}
+        for name in REQUIRED_ONBOARDING_COLUMNS:
+            assert name in cols
+
+    @pytest.mark.asyncio
+    async def test_init_schema_three_runs_no_duplicates(self, db):
+        await init_schema(db)
+        await init_schema(db)
+        rows = await _users_columns(db)
+        names = [row["name"] for row in rows]
+        for col in REQUIRED_ONBOARDING_COLUMNS:
+            assert names.count(col) == 1, f"column {col} duplicated after rerun"
+
+
+# ============================================================================
+# Contract: existing data preserved
+# ============================================================================
+
+
+class TestNonDestructive:
+    """Inserting a user without onboarding fields stays valid post-migration."""
+
+    @pytest.mark.asyncio
+    async def test_user_insert_without_onboarding_fields(self, db):
+        await db.execute(
+            """
+            INSERT INTO users (
+                user_id, username, email, password_hash,
+                display_name, is_active, is_verified, role,
+                membership_tier, referral_code, referred_by,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "u-onb-1",
+                "onbuser",
+                "onb@test.com",
+                "h",
+                "Onb",
+                1,
+                0,
+                "child",
+                "free",
+                "code1234",
+                None,
+                "2026-01-01T00:00:00",
+                "2026-01-01T00:00:00",
+            ),
+        )
+        await db.commit()
+        row = await db.fetchone(
+            "SELECT nickname, onboarded_at, parent_consent_at, default_child_id "
+            "FROM users WHERE user_id = ?",
+            ("u-onb-1",),
+        )
+        assert row is not None
+        assert row["nickname"] is None
+        assert row["onboarded_at"] is None
+        assert row["parent_consent_at"] is None
+        assert row["default_child_id"] is None


### PR DESCRIPTION
Fixes #438

Parent epic: #436 (My Agent — personalized buddy persona)

## Summary

Schema foundation for the My Agent feature. Strictly additive and non-destructive.

- New `user_agents` table keyed by surrogate `agent_id` (UUID), with `UNIQUE(user_id, child_id)` (one agent per child profile) and `ON DELETE CASCADE` from `users`.
- Four new nullable columns on `users`: `nickname`, `onboarded_at`, `parent_consent_at`, `default_child_id`.
- Migrations are idempotent (`CREATE TABLE IF NOT EXISTS`, `column_exists` guards) so reruns are safe.
- DDL passes through `translate_ddl` for both SQLite and PostgreSQL — `INTEGER PRIMARY KEY AUTOINCREMENT` becomes `SERIAL PRIMARY KEY`. No new SQLite-only syntax.

## Repository changes

- `UserData` dataclass extended with the four new optional fields.
- `_row_to_user` reads them back.
- New `UserRepository.update_onboarding_fields(user_id, *, nickname=None, onboarded_at=None, parent_consent_at=None, default_child_id=None)` — partial UPDATE of only the fields supplied.

## Tests

Two new contract test modules under `backend/tests/contracts/`:

- `test_users_onboarding_columns_contract.py` — column presence, nullability, idempotency (run twice, run three times), non-destructive insert without onboarding fields. (8 tests)
- `test_user_agents_repository_contract.py` — table shape, insert/select roundtrip, `UNIQUE(user_id, child_id)`, `UNIQUE(agent_id)`, `ON DELETE CASCADE`, `idx_user_agents_user` index. (7 tests)

Result: 15/15 new tests pass. Full `tests/contracts/` suite shows 423 passed, 13 pre-existing failures (chromadb / safety prompt — unrelated to this PR; reproduced on `main`).

## Out of scope

- No new endpoints (those land in #439).
- No frontend changes.
- No `UserAgentsRepository` class yet — only schema + base `UserRepository` extension.

## Test plan

- [x] `cd backend && python -m pytest tests/contracts/test_users_onboarding_columns_contract.py tests/contracts/test_user_agents_repository_contract.py -v`
- [x] Full contract suite — confirmed no new regressions.
- [x] `translate_ddl(USER_AGENTS_TABLE, "postgresql")` produces valid Postgres SQL (`SERIAL PRIMARY KEY`, ON DELETE CASCADE preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)