### PR TITLE
feat(agent): agent repository + safety-checked PUT /me/agent (#439)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -804,6 +804,32 @@ class UserResponse(BaseModel):
     referral_code: str = Field(default="", description="User's unique referral code")
     created_at: datetime = Field(..., description="Registered at")
     last_login_at: Optional[datetime] = Field(None, description="Last login time")
+    # Onboarding + agent fields (#439, depends on #438 schema)
+    has_agent: bool = Field(default=False, description="Whether the user has a configured agent persona")
+    onboarded_at: Optional[datetime] = Field(None, description="When onboarding finished")
+    nickname: Optional[str] = Field(None, description="Friendly name shown in UI")
+    default_child_id: Optional[str] = Field(None, description="Active child profile bound to the agent")
+    parent_consent_at: Optional[datetime] = Field(None, description="When parent granted consent")
+
+
+class AgentResponse(BaseModel):
+    """Agent persona info (PRD §3.11.3)."""
+    agent_id: str = Field(..., description="Stable surrogate ID of the agent persona")
+    user_id: str = Field(..., description="Owner user ID")
+    child_id: str = Field(..., description="Child profile this agent is bound to")
+    agent_name: str = Field(..., description="Agent display name")
+    agent_avatar_id: str = Field(..., description="Avatar identifier (e.g. 'emoji:🦊')")
+    agent_title: str = Field(..., description="Agent title (curated or free-text)")
+    created_at: datetime = Field(..., description="When the agent was first created")
+    updated_at: datetime = Field(..., description="When the agent was last updated")
+
+
+class UpsertAgentRequest(BaseModel):
+    """PUT /me/agent body — create-or-update an agent persona."""
+    agent_name: str = Field(..., min_length=1, max_length=32, description="Agent display name")
+    agent_avatar_id: str = Field(..., min_length=1, description="Avatar identifier from the whitelist")
+    agent_title: str = Field(..., min_length=1, max_length=32, description="Agent title")
+    child_id: str = Field(..., min_length=1, description="Child profile this agent is bound to")
 
 
 class ReferralStatusResponse(BaseModel):

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -1,0 +1,218 @@
+"""
+Agent API Routes (#439)
+
+Endpoints to fetch and upsert the personalized agent persona for the
+current user. Part of Epic #436 (My Agent — personalized buddy persona).
+
+Validation pipeline for PUT /me/agent:
+  1. Pydantic length checks (agent_name, agent_title <= 32, child_id present).
+  2. agent_avatar_id must be in the AVATAR_IDS whitelist.
+  3. agent_title: curated entries skip the safety check (already approved);
+     free-text entries go through check_content_safety.
+  4. agent_name always goes through check_content_safety.
+  5. If the safety MCP raises or returns an error envelope, fail closed
+     with HTTP 503 SAFETY_UNAVAILABLE — never let unchecked content
+     through.
+"""
+
+import json
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from ..deps import get_current_user
+from ..models import AgentResponse, UpsertAgentRequest
+from ...mcp_servers import check_content_safety
+from ...services.agent_constants import (
+    AVATAR_IDS,
+    CURATED_TITLES_SET,
+    MAX_AGENT_NAME_LENGTH,
+    MAX_AGENT_TITLE_LENGTH,
+)
+from ...services.database import agent_repo
+from ...services.user_service import UserData
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/me/agent", tags=["My Agent"])
+
+
+# Default age the safety check evaluates agent text against. Agent persona
+# text is shown to all child age groups, so we use the youngest tier
+# (3-5 -> 4) to apply the strictest filter.
+_AGENT_SAFETY_TARGET_AGE = 4
+_SAFETY_THRESHOLD = 0.85
+
+
+class _SafetyUnavailableError(RuntimeError):
+    """Raised when the safety MCP cannot be reached. Triggers fail-closed."""
+
+
+async def _run_safety_check(text: str) -> float:
+    """
+    Run check_content_safety against agent text.
+
+    Returns the safety score (0.0..1.0). Raises _SafetyUnavailableError if
+    the MCP server is unreachable or returned an error envelope so the
+    caller can fail closed (HTTP 503) — we never silently let unchecked
+    text through.
+    """
+    try:
+        result = await check_content_safety({
+            "content_text": text,
+            "content_type": "agent_persona",
+            "target_age": _AGENT_SAFETY_TARGET_AGE,
+        })
+    except Exception as exc:  # noqa: BLE001 — fail closed on any error
+        logger.warning(
+            "Safety MCP unavailable for agent text, failing closed",
+            exc_info=True,
+        )
+        raise _SafetyUnavailableError(str(exc)) from exc
+
+    try:
+        data = json.loads(result["content"][0]["text"])
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        logger.warning("Safety MCP returned malformed payload, failing closed")
+        raise _SafetyUnavailableError("malformed safety payload") from exc
+
+    if "error" in data:
+        logger.warning(
+            "Safety MCP returned error envelope, failing closed: %s",
+            data["error"],
+        )
+        raise _SafetyUnavailableError(str(data["error"]))
+
+    score = data.get("safety_score")
+    if score is None:
+        # Missing score field -> cannot verify safety -> fail closed.
+        raise _SafetyUnavailableError("safety_score missing from response")
+
+    return float(score)
+
+
+def _to_response(agent) -> AgentResponse:
+    """Convert AgentData to AgentResponse (parses ISO timestamps)."""
+    return AgentResponse(
+        agent_id=agent.agent_id,
+        user_id=agent.user_id,
+        child_id=agent.child_id,
+        agent_name=agent.agent_name,
+        agent_avatar_id=agent.agent_avatar_id,
+        agent_title=agent.agent_title,
+        created_at=datetime.fromisoformat(agent.created_at),
+        updated_at=datetime.fromisoformat(agent.updated_at),
+    )
+
+
+@router.get(
+    "",
+    response_model=AgentResponse,
+    summary="Get current user's agent persona",
+    description="Return the agent bound to (current_user, child_id).",
+)
+async def get_my_agent(
+    child_id: str = Query(..., min_length=1, description="Child profile ID"),
+    user: UserData = Depends(get_current_user),
+):
+    """Look up the agent for (user_id, child_id). 404 if no row exists."""
+    agent = await agent_repo.get_agent(user.user_id, child_id)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "AGENT_NOT_FOUND"},
+        )
+    return _to_response(agent)
+
+
+@router.put(
+    "",
+    response_model=AgentResponse,
+    summary="Create or update current user's agent persona",
+    description=(
+        "Upsert the agent persona bound to (current_user, child_id). "
+        "Validates avatar against the whitelist and runs the safety check on "
+        "the agent name (and on titles outside the curated list)."
+    ),
+)
+async def upsert_my_agent(
+    request: UpsertAgentRequest,
+    user: UserData = Depends(get_current_user),
+):
+    """
+    Upsert flow:
+      1. Whitelist avatar (cheap deterministic check).
+      2. Safety-check agent_name and free-text agent_title.
+      3. Upsert to user_agents.
+      4. Return AgentResponse.
+    """
+    # 1. Avatar whitelist
+    if request.agent_avatar_id not in AVATAR_IDS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_AVATAR"},
+        )
+
+    # 2a. Title validation: skip safety check if curated.
+    title = request.agent_title
+    if title not in CURATED_TITLES_SET:
+        # Free-text path. Pydantic already enforced 1..MAX_AGENT_TITLE_LENGTH,
+        # but we keep this guard explicit so the contract is local to this
+        # route even if the model changes.
+        if not (1 <= len(title) <= MAX_AGENT_TITLE_LENGTH):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"code": "INVALID_AGENT_TITLE"},
+            )
+        try:
+            title_score = await _run_safety_check(title)
+        except _SafetyUnavailableError:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail={"code": "SAFETY_UNAVAILABLE"},
+            )
+        if title_score < _SAFETY_THRESHOLD:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "UNSAFE_AGENT_TITLE",
+                    "reason": "Title did not pass content safety check",
+                    "score": title_score,
+                },
+            )
+
+    # 2b. Name always goes through safety check.
+    if not (1 <= len(request.agent_name) <= MAX_AGENT_NAME_LENGTH):
+        # Belt-and-suspenders — Pydantic already enforces this.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_AGENT_NAME"},
+        )
+    try:
+        name_score = await _run_safety_check(request.agent_name)
+    except _SafetyUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "SAFETY_UNAVAILABLE"},
+        )
+    if name_score < _SAFETY_THRESHOLD:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={
+                "code": "UNSAFE_AGENT_NAME",
+                "reason": "Name did not pass content safety check",
+                "score": name_score,
+            },
+        )
+
+    # 3. Persist via repository (insert or update on (user_id, child_id)).
+    agent = await agent_repo.upsert_agent(
+        user_id=user.user_id,
+        child_id=request.child_id,
+        agent_name=request.agent_name,
+        agent_avatar_id=request.agent_avatar_id,
+        agent_title=request.agent_title,
+    )
+
+    return _to_response(agent)

--- a/backend/src/api/routes/users.py
+++ b/backend/src/api/routes/users.py
@@ -96,8 +96,14 @@ def _user_to_public_response(user: UserData) -> PublicUserResponse:
     )
 
 
-def _user_to_response(user: UserData) -> UserResponse:
-    """Convert UserData to UserResponse"""
+def _user_to_response(user: UserData, *, has_agent: bool = False) -> UserResponse:
+    """Convert UserData to UserResponse.
+
+    The optional ``has_agent`` flag is computed by the caller because it
+    requires an extra DB lookup against ``user_agents``; we keep the helper
+    sync so register/login/update flows stay simple, and only the read
+    paths that care (``GET /me``) pay for the lookup.
+    """
     return UserResponse(
         user_id=user.user_id,
         username=user.username,
@@ -112,6 +118,15 @@ def _user_to_response(user: UserData) -> UserResponse:
         created_at=datetime.fromisoformat(user.created_at),
         last_login_at=datetime.fromisoformat(user.last_login_at)
         if user.last_login_at
+        else None,
+        has_agent=has_agent,
+        onboarded_at=datetime.fromisoformat(user.onboarded_at)
+        if getattr(user, 'onboarded_at', None)
+        else None,
+        nickname=getattr(user, 'nickname', None),
+        default_child_id=getattr(user, 'default_child_id', None),
+        parent_consent_at=datetime.fromisoformat(user.parent_consent_at)
+        if getattr(user, 'parent_consent_at', None)
         else None,
     )
 
@@ -251,8 +266,20 @@ async def logout(authorization: Optional[str] = Header(None)):
     description="Get information about the currently logged-in user",
 )
 async def get_me(user: UserData = Depends(get_current_user)):
-    """Get current user info"""
-    return _user_to_response(user)
+    """Get current user info.
+
+    Looks up whether the user has a configured agent persona for their
+    ``default_child_id`` (PRD §3.11) so the frontend can decide whether
+    to route into onboarding or the main app. The lookup is per-request;
+    we'll denormalize later if profiling shows it matters.
+    """
+    has_agent = False
+    if user.default_child_id:
+        from ...services.database import agent_repo
+
+        agent = await agent_repo.get_agent(user.user_id, user.default_child_id)
+        has_agent = agent is not None
+    return _user_to_response(user, has_agent=has_agent)
 
 
 @router.put(

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -340,6 +340,7 @@ if os.getenv("STORAGE_BACKEND", "local").lower() != "supabase":
 
 from .api.routes import (
     admin_artifacts,
+    agents,
     artifacts,
     audio,
     image_to_story,
@@ -361,6 +362,7 @@ app.include_router(audio.router)
 app.include_router(video.router)
 app.include_router(voice.router)
 app.include_router(users.router)
+app.include_router(agents.router)
 app.include_router(kids_daily.router)
 app.include_router(inspiration_daily.router)
 app.include_router(subscriptions.router)

--- a/backend/src/services/agent_constants.py
+++ b/backend/src/services/agent_constants.py
@@ -37,5 +37,30 @@ AVATAR_IDS: frozenset[str] = frozenset(f"emoji:{e}" for e in ANIMAL_EMOJIS)
 MAX_AGENT_NAME_LENGTH: int = 32
 MAX_AGENT_TITLE_LENGTH: int = 32
 
-# Curated title list is added in #439.
-CURATED_TITLES: tuple[str, ...] = ()
+# Curated title list (#439) — derived from PRD §3.11.3.
+# Pre-approved titles bypass the runtime safety check because they have
+# already been reviewed by the product team.
+CURATED_TITLES: tuple[str, ...] = (
+    "Story Wizard",
+    "Brave Lion",
+    "Galaxy Explorer",
+    "Dragon Friend",
+    "Magic Painter",
+    "Forest Guardian",
+    "Ocean Adventurer",
+    "Star Dreamer",
+    "Dance Captain",
+    "Inventor",
+    "Riddle Master",
+    "Cloud Surfer",
+    "Tiny Hero",
+    "Silly Scientist",
+    "Music Maker",
+    "Treasure Hunter",
+    "Kindness Knight",
+    "Robot Buddy",
+    "Time Traveler",
+    "Sunshine Maker",
+)
+
+CURATED_TITLES_SET: frozenset[str] = frozenset(CURATED_TITLES)

--- a/backend/src/services/database/__init__.py
+++ b/backend/src/services/database/__init__.py
@@ -22,6 +22,7 @@ from .subscription_repository import (
 from .usage_repository import UsageRepository, usage_repo
 from .referral_repository import ReferralRepository, referral_repo
 from .vector_repository import VectorRepository, vector_repo
+from .agent_repository import AgentRepository, AgentData, agent_repo
 
 __all__ = [
     "CursorResult",
@@ -54,4 +55,7 @@ __all__ = [
     "referral_repo",
     "VectorRepository",
     "vector_repo",
+    "AgentRepository",
+    "AgentData",
+    "agent_repo",
 ]

--- a/backend/src/services/database/agent_repository.py
+++ b/backend/src/services/database/agent_repository.py
@@ -1,0 +1,159 @@
+"""
+Agent Repository (#439)
+
+CRUD operations for the user_agents table — the personalized buddy persona
+each (user, child) pair has bound to them. Foundation for Epic #436.
+
+Design notes:
+- (user_id, child_id) is the natural key; agent_id is a stable surrogate
+  used by future hub posts (#447).
+- upsert_agent preserves agent_id across updates so external references
+  remain valid; only created_at is preserved on update, updated_at always
+  refreshes.
+- All timestamps are ISO 8601 (UTC-naive isoformat), matching the
+  convention used by user_repository and referral_repository.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from uuid import uuid4
+
+from .connection import db_manager
+
+
+@dataclass
+class AgentData:
+    """User agent persona row."""
+    agent_id: str
+    user_id: str
+    child_id: str
+    agent_name: str
+    agent_avatar_id: str
+    agent_title: str
+    created_at: str
+    updated_at: str
+
+
+class AgentRepository:
+    """Repository for user_agents records."""
+
+    def __init__(self, db=None):
+        self._db = db if db is not None else db_manager
+
+    async def get_agent(
+        self, user_id: str, child_id: str
+    ) -> Optional[AgentData]:
+        """Look up the agent persona for a (user, child) pair."""
+        row = await self._db.fetchone(
+            """
+            SELECT agent_id, user_id, child_id, agent_name,
+                   agent_avatar_id, agent_title, created_at, updated_at
+            FROM user_agents
+            WHERE user_id = ? AND child_id = ?
+            """,
+            (user_id, child_id),
+        )
+        return self._row_to_agent(row) if row else None
+
+    async def get_by_agent_id(self, agent_id: str) -> Optional[AgentData]:
+        """Look up an agent by its surrogate agent_id (for #447 hub posts)."""
+        row = await self._db.fetchone(
+            """
+            SELECT agent_id, user_id, child_id, agent_name,
+                   agent_avatar_id, agent_title, created_at, updated_at
+            FROM user_agents
+            WHERE agent_id = ?
+            """,
+            (agent_id,),
+        )
+        return self._row_to_agent(row) if row else None
+
+    async def upsert_agent(
+        self,
+        user_id: str,
+        child_id: str,
+        agent_name: str,
+        agent_avatar_id: str,
+        agent_title: str,
+    ) -> AgentData:
+        """
+        Insert a new agent or update the existing one for (user_id, child_id).
+
+        On insert: generates agent_id = f"agt_{uuid4().hex[:12]}" and sets
+        both created_at and updated_at to now.
+        On update: preserves agent_id and created_at; refreshes updated_at.
+        """
+        existing = await self.get_agent(user_id, child_id)
+        now = datetime.now().isoformat()
+
+        if existing is None:
+            agent_id = f"agt_{uuid4().hex[:12]}"
+            await self._db.execute(
+                """
+                INSERT INTO user_agents (
+                    agent_id, user_id, child_id,
+                    agent_name, agent_avatar_id, agent_title,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    agent_id,
+                    user_id,
+                    child_id,
+                    agent_name,
+                    agent_avatar_id,
+                    agent_title,
+                    now,
+                    now,
+                ),
+            )
+            await self._db.commit()
+            return AgentData(
+                agent_id=agent_id,
+                user_id=user_id,
+                child_id=child_id,
+                agent_name=agent_name,
+                agent_avatar_id=agent_avatar_id,
+                agent_title=agent_title,
+                created_at=now,
+                updated_at=now,
+            )
+
+        await self._db.execute(
+            """
+            UPDATE user_agents
+            SET agent_name = ?, agent_avatar_id = ?, agent_title = ?,
+                updated_at = ?
+            WHERE user_id = ? AND child_id = ?
+            """,
+            (agent_name, agent_avatar_id, agent_title, now, user_id, child_id),
+        )
+        await self._db.commit()
+        return AgentData(
+            agent_id=existing.agent_id,
+            user_id=user_id,
+            child_id=child_id,
+            agent_name=agent_name,
+            agent_avatar_id=agent_avatar_id,
+            agent_title=agent_title,
+            created_at=existing.created_at,
+            updated_at=now,
+        )
+
+    @staticmethod
+    def _row_to_agent(row: dict) -> AgentData:
+        return AgentData(
+            agent_id=row["agent_id"],
+            user_id=row["user_id"],
+            child_id=row["child_id"],
+            agent_name=row["agent_name"],
+            agent_avatar_id=row["agent_avatar_id"],
+            agent_title=row["agent_title"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+
+# Global agent repository instance — bound to the shared db_manager.
+agent_repo = AgentRepository()

--- a/backend/tests/contracts/test_agent_endpoint_contract.py
+++ b/backend/tests/contracts/test_agent_endpoint_contract.py
@@ -1,0 +1,352 @@
+"""
+Agent Endpoint Contract Tests (#439)
+
+Black-box contract on PUT/GET /api/v1/me/agent. Locks in:
+  - Avatar whitelist enforcement (INVALID_AVATAR).
+  - Safety check is invoked on agent_name and on free-text agent_title.
+  - Curated titles bypass the safety check (pre-vetted).
+  - Safety MCP failures must surface as 503 SAFETY_UNAVAILABLE
+    (fail-closed, never silent pass-through).
+  - Upsert is idempotent on (user_id, child_id).
+  - Distinct (user_id, child_id) pairs map to distinct rows.
+
+Parent Epic: #436 (My Agent — Personal Creative Buddy)
+Issue: #439
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from backend.src.api.deps import get_current_user
+from backend.src.main import app
+from backend.src.services.database import db_manager, agent_repo
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserData, UserRepository
+
+
+# ---------------------------------------------------------------------------
+# Test users — two distinct identities so we can probe (user, child) keying
+# ---------------------------------------------------------------------------
+
+
+_TEST_USER_A = UserData(
+    user_id="agent_test_user_a",
+    username="agent_user_a",
+    email="a@test.com",
+    password_hash="h",
+    display_name="A",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    created_at="",
+    updated_at="",
+    last_login_at=None,
+)
+
+
+_current_user_holder = {"user": _TEST_USER_A}
+
+
+async def _override_current_user() -> UserData:
+    return _current_user_holder["user"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    """In-memory DB shared with the global db_manager so the route sees it.
+
+    Also seeds the auth-overridden test user into the users table so
+    the FK on user_agents.user_id is satisfied.
+    """
+    # Save and replace the adapter on the global db_manager so app code
+    # using `from .database import agent_repo` hits our test DB.
+    fresh = DatabaseManager(":memory:")
+    await fresh.connect()
+    await init_schema(fresh)
+
+    saved_adapter = db_manager._adapter
+    db_manager._adapter = fresh._adapter
+
+    # Seed the user row directly so FK(user_id -> users.user_id) is
+    # satisfied for the deterministic user_id we pinned on _TEST_USER_A.
+    from datetime import datetime as _dt
+    now = _dt.now().isoformat()
+    await db_manager.execute(
+        """
+        INSERT INTO users (
+            user_id, username, email, password_hash, display_name,
+            is_active, is_verified, role,
+            membership_tier, referral_code, referred_by,
+            created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _TEST_USER_A.user_id,
+            _TEST_USER_A.username,
+            _TEST_USER_A.email,
+            _TEST_USER_A.password_hash,
+            _TEST_USER_A.display_name,
+            1,
+            1,
+            "child",
+            "free",
+            "TESTCODE",
+            None,
+            now,
+            now,
+        ),
+    )
+    await db_manager.commit()
+
+    yield fresh
+    db_manager._adapter = saved_adapter
+    await fresh.disconnect()
+
+
+@pytest_asyncio.fixture
+async def client(test_db):
+    """AsyncClient with auth dependency overridden to return _TEST_USER_A."""
+    _current_user_holder["user"] = _TEST_USER_A
+    app.dependency_overrides[get_current_user] = _override_current_user
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _safety_response(score: float) -> dict:
+    """Build the MCP-shaped result envelope the safety tool returns."""
+    return {
+        "content": [
+            {"type": "text", "text": json.dumps({"safety_score": score})}
+        ]
+    }
+
+
+def _valid_body(**overrides) -> dict:
+    body = {
+        "agent_name": "Sparkle",
+        "agent_avatar_id": "emoji:🦊",
+        "agent_title": "Story Wizard",  # curated -> skips title safety
+        "child_id": "child_test_001",
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Avatar whitelist
+# ---------------------------------------------------------------------------
+
+
+class TestAvatarWhitelist:
+    """Avatar must come from the curated emoji whitelist."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_avatar_outside_whitelist(self, client):
+        # 🦖 is intentionally NOT in the curated list.
+        body = _valid_body(agent_avatar_id="emoji:🦖")
+        # Even though we hit the avatar branch first, mock safety to be safe.
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=_safety_response(0.99)),
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 400
+        assert r.json()["detail"]["code"] == "INVALID_AVATAR"
+
+    @pytest.mark.asyncio
+    async def test_accepts_avatar_in_whitelist(self, client):
+        body = _valid_body(agent_avatar_id="emoji:🐶")
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=_safety_response(0.99)),
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Safety check on name
+# ---------------------------------------------------------------------------
+
+
+class TestNameSafety:
+    """Agent name must always pass the safety check."""
+
+    @pytest.mark.asyncio
+    async def test_unsafe_name_rejected(self, client):
+        # Mock returns safety_score below 0.85 -> route must reject.
+        body = _valid_body(agent_name="something_unsafe")
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=_safety_response(0.50)),
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 400
+        assert r.json()["detail"]["code"] == "UNSAFE_AGENT_NAME"
+
+    @pytest.mark.asyncio
+    async def test_safe_name_accepted(self, client):
+        body = _valid_body(agent_name="Sparkle")
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=_safety_response(0.99)),
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Curated title bypass
+# ---------------------------------------------------------------------------
+
+
+class TestCuratedTitleBypass:
+    """Curated titles skip the safety check; free-text titles do not."""
+
+    @pytest.mark.asyncio
+    async def test_curated_title_skips_title_safety_check(self, client):
+        """Brave Lion is in CURATED_TITLES -> safety MCP called once (for name only)."""
+        body = _valid_body(agent_title="Brave Lion")
+        mock_safety = AsyncMock(return_value=_safety_response(0.99))
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=mock_safety,
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 200, r.text
+        # Exactly one call — for the name. The title bypassed because curated.
+        assert mock_safety.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_free_text_title_invokes_title_safety_check(self, client):
+        """Non-curated title -> safety MCP called twice (title + name)."""
+        body = _valid_body(agent_title="My Cool Title")
+        mock_safety = AsyncMock(return_value=_safety_response(0.99))
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=mock_safety,
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 200, r.text
+        # Title check + name check = 2 calls.
+        assert mock_safety.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed when safety MCP is unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyFailClosed:
+    """Safety MCP failure must surface as 503 SAFETY_UNAVAILABLE."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_raises_returns_503(self, client):
+        """When the MCP tool raises, the route must return 503 with SAFETY_UNAVAILABLE."""
+        body = _valid_body()  # curated title, so only name is safety-checked
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 503
+        assert r.json()["detail"]["code"] == "SAFETY_UNAVAILABLE"
+
+    @pytest.mark.asyncio
+    async def test_mcp_error_envelope_returns_503(self, client):
+        """When the MCP returns an error envelope (no safety_score), fail closed."""
+        body = _valid_body()
+        bad = {
+            "content": [
+                {"type": "text", "text": json.dumps({"error": "MCP unavailable"})}
+            ]
+        }
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=bad),
+        ):
+            r = await client.put("/api/v1/me/agent", json=body)
+        assert r.status_code == 503
+        assert r.json()["detail"]["code"] == "SAFETY_UNAVAILABLE"
+
+
+# ---------------------------------------------------------------------------
+# Upsert idempotency and key separation
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertIdempotency:
+    """PUT /me/agent must be idempotent on (user_id, child_id)."""
+
+    @pytest.mark.asyncio
+    async def test_repeated_put_same_body_same_agent_id(self, client):
+        body = _valid_body(child_id="child_idempotent")
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=_safety_response(0.99)),
+        ):
+            r1 = await client.put("/api/v1/me/agent", json=body)
+            r2 = await client.put("/api/v1/me/agent", json=body)
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r1.json()["agent_id"] == r2.json()["agent_id"]
+
+    @pytest.mark.asyncio
+    async def test_different_child_id_yields_distinct_agent(self, client):
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=_safety_response(0.99)),
+        ):
+            r1 = await client.put(
+                "/api/v1/me/agent", json=_valid_body(child_id="child_one")
+            )
+            r2 = await client.put(
+                "/api/v1/me/agent", json=_valid_body(child_id="child_two")
+            )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r1.json()["agent_id"] != r2.json()["agent_id"]
+
+
+# ---------------------------------------------------------------------------
+# GET /me/agent
+# ---------------------------------------------------------------------------
+
+
+class TestGetAgent:
+    """GET /api/v1/me/agent returns 404 when no row exists."""
+
+    @pytest.mark.asyncio
+    async def test_unknown_child_id_returns_404(self, client):
+        r = await client.get(
+            "/api/v1/me/agent", params={"child_id": "child_does_not_exist"}
+        )
+        assert r.status_code == 404
+        assert r.json()["detail"]["code"] == "AGENT_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_returns_agent_after_upsert(self, client):
+        body = _valid_body(child_id="child_get_test")
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety",
+            new=AsyncMock(return_value=_safety_response(0.99)),
+        ):
+            put = await client.put("/api/v1/me/agent", json=body)
+        assert put.status_code == 200
+        get = await client.get(
+            "/api/v1/me/agent", params={"child_id": "child_get_test"}
+        )
+        assert get.status_code == 200
+        assert get.json()["agent_id"] == put.json()["agent_id"]

--- a/backend/tests/contracts/test_agent_repository_contract.py
+++ b/backend/tests/contracts/test_agent_repository_contract.py
@@ -1,0 +1,239 @@
+"""
+Agent Repository Contract Tests (#439)
+
+Defines the expected interface and behavior of AgentRepository.
+Tests upsert semantics, idempotency, and ID format.
+
+Parent Epic: #436 (My Agent — Personal Creative Buddy)
+Issue: #439
+"""
+
+import re
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database.agent_repository import (
+    AgentData,
+    AgentRepository,
+    agent_repo,
+)
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserRepository
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest_asyncio.fixture
+async def db():
+    """In-memory database with full schema for agent tests."""
+    manager = DatabaseManager(":memory:")
+    await manager.connect()
+    await init_schema(manager)
+    yield manager
+    await manager.disconnect()
+
+
+@pytest_asyncio.fixture
+async def repo(db):
+    """AgentRepository bound to the test database."""
+    r = AgentRepository()
+    r._db = db
+    return r
+
+
+@pytest_asyncio.fixture
+async def user(db):
+    """Create a user (FK target for user_agents.user_id)."""
+    user_repo_instance = UserRepository()
+    user_repo_instance._db = db
+    return await user_repo_instance.create_user(
+        username="agent_user",
+        email="agent@test.com",
+        password_hash="h",
+    )
+
+
+# ============================================================================
+# Contract: Module exports
+# ============================================================================
+
+
+class TestModuleExports:
+    """agent_repository module exports expected symbols."""
+
+    def test_singleton_exists(self):
+        assert agent_repo is not None
+
+    def test_singleton_is_repository(self):
+        assert isinstance(agent_repo, AgentRepository)
+
+    def test_dataclass_fields(self):
+        # AgentData must expose every field documented in the spec.
+        expected = {
+            "agent_id",
+            "user_id",
+            "child_id",
+            "agent_name",
+            "agent_avatar_id",
+            "agent_title",
+            "created_at",
+            "updated_at",
+        }
+        actual = {f.name for f in AgentData.__dataclass_fields__.values()}
+        assert expected.issubset(actual), (
+            f"AgentData missing fields: {expected - actual}"
+        )
+
+
+# ============================================================================
+# Contract: get_agent
+# ============================================================================
+
+
+class TestGetAgent:
+    """get_agent(user_id, child_id) returns the row or None."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self, repo, user):
+        """No row -> None."""
+        result = await repo.get_agent(user.user_id, "child_not_there")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_data_when_present(self, repo, user):
+        """After upsert -> get_agent returns AgentData."""
+        await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_a",
+            agent_name="Sparkle",
+            agent_avatar_id="emoji:🦊",
+            agent_title="Story Wizard",
+        )
+        got = await repo.get_agent(user.user_id, "child_a")
+        assert got is not None
+        assert isinstance(got, AgentData)
+        assert got.agent_name == "Sparkle"
+        assert got.agent_avatar_id == "emoji:🦊"
+        assert got.agent_title == "Story Wizard"
+        assert got.user_id == user.user_id
+        assert got.child_id == "child_a"
+
+
+# ============================================================================
+# Contract: upsert_agent — insert path
+# ============================================================================
+
+
+class TestUpsertAgentInsert:
+    """upsert_agent creates a new row when none exists."""
+
+    @pytest.mark.asyncio
+    async def test_creates_row_when_missing(self, repo, user):
+        """First call inserts a row and returns AgentData."""
+        result = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_b",
+            agent_name="Buddy",
+            agent_avatar_id="emoji:🐶",
+            agent_title="Brave Lion",
+        )
+        assert isinstance(result, AgentData)
+        assert result.agent_name == "Buddy"
+        assert result.created_at == result.updated_at  # First write -> equal
+
+    @pytest.mark.asyncio
+    async def test_agent_id_pattern(self, repo, user):
+        """agent_id must follow agt_<12 hex chars> for sortable, debuggable IDs."""
+        result = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_c",
+            agent_name="Buddy",
+            agent_avatar_id="emoji:🐶",
+            agent_title="Brave Lion",
+        )
+        assert re.fullmatch(r"agt_[0-9a-f]{12}", result.agent_id), (
+            f"agent_id format wrong: {result.agent_id}"
+        )
+
+
+# ============================================================================
+# Contract: upsert_agent — update path
+# ============================================================================
+
+
+class TestUpsertAgentUpdate:
+    """upsert_agent updates the existing row in place when one exists."""
+
+    @pytest.mark.asyncio
+    async def test_updates_in_place_for_same_pair(self, repo, user):
+        """Re-upsert with the same (user_id, child_id) keeps a single row."""
+        first = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_d",
+            agent_name="Buddy",
+            agent_avatar_id="emoji:🐶",
+            agent_title="Brave Lion",
+        )
+
+        second = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_d",
+            agent_name="Friend",
+            agent_avatar_id="emoji:🦊",
+            agent_title="Story Wizard",
+        )
+
+        # Same agent_id (stable) but changed payload.
+        assert second.agent_id == first.agent_id
+        assert second.agent_name == "Friend"
+        assert second.agent_avatar_id == "emoji:🦊"
+        assert second.agent_title == "Story Wizard"
+
+    @pytest.mark.asyncio
+    async def test_created_at_unchanged_updated_at_advances(self, repo, user):
+        """created_at is preserved, updated_at advances on re-upsert."""
+        import asyncio
+
+        first = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_e",
+            agent_name="Buddy",
+            agent_avatar_id="emoji:🐶",
+            agent_title="Brave Lion",
+        )
+        # Sleep enough to guarantee a distinct ISO timestamp.
+        await asyncio.sleep(0.005)
+        second = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_e",
+            agent_name="Friend",
+            agent_avatar_id="emoji:🦊",
+            agent_title="Story Wizard",
+        )
+        assert second.created_at == first.created_at
+        assert second.updated_at >= first.updated_at
+        assert second.updated_at != first.created_at or second.updated_at > first.updated_at
+
+    @pytest.mark.asyncio
+    async def test_distinct_pairs_get_distinct_rows(self, repo, user):
+        """Different (user_id, child_id) yield two rows with distinct agent_ids."""
+        a = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_f1",
+            agent_name="A",
+            agent_avatar_id="emoji:🐶",
+            agent_title="Brave Lion",
+        )
+        b = await repo.upsert_agent(
+            user_id=user.user_id,
+            child_id="child_f2",
+            agent_name="B",
+            agent_avatar_id="emoji:🐱",
+            agent_title="Story Wizard",
+        )
+        assert a.agent_id != b.agent_id


### PR DESCRIPTION
Fixes #439

**Parent Epic**: #436 (My Agent — Personal Creative Buddy)

Third PR in the Epic #436 unblocker pack. Builds on top of #438 (schema)
and #441 (avatar whitelist), both already merged to main.

## Summary
- New `AgentRepository` with upsert semantics keyed on `(user_id, child_id)`. `agent_id` is generated as `agt_<12 hex>` and preserved across updates so future cross-references stay valid.
- New `GET /api/v1/me/agent?child_id=...` and `PUT /api/v1/me/agent` endpoints. PUT runs the avatar whitelist check, then a safety pipeline that fail-closes to HTTP 503 `SAFETY_UNAVAILABLE` on any MCP failure (raise, malformed envelope, missing `safety_score`).
- Curated titles from PRD §3.11.3 (`CURATED_TITLES`/`CURATED_TITLES_SET` in `agent_constants.py`) bypass the safety MCP because the product team has already reviewed them. Free-text titles and the agent name always go through `check_content_safety`.
- `UserResponse` now exposes `has_agent` and `onboarded_at` (plus `nickname`, `default_child_id`, `parent_consent_at`). `GET /me` looks up `has_agent` for `default_child_id` per request — we'll denormalize later if profiling shows it matters.
- 22 new contract tests in `backend/tests/contracts/test_agent_endpoint_contract.py` and `test_agent_repository_contract.py`.

## Decisions beyond the plan
- **CURATED_TITLES_SET naming.** The handoff partial work used `CURATED_TITLE_SET`; renamed to `CURATED_TITLES_SET` to match the spec.
- **Router prefix.** `APIRouter(prefix="/api/v1/me/agent")` per spec, with the routes mounted at empty path (`@router.get("")` / `@router.put("")`).
- **`_user_to_response` stayed sync.** Adding the `has_agent` lookup only inside `get_me` keeps register/login/update_me/change_password unchanged. New users naturally show `has_agent=False` on those flows because they have no `default_child_id` yet.
- **Test fixture seeds the user row directly** via raw SQL (bypassing `UserRepository.create_user`) so the deterministic `_TEST_USER_A.user_id` survives the round-trip and satisfies `FOREIGN KEY(user_id) REFERENCES users(user_id)`.
- **Safety-call import.** Followed the existing `interactive_story.py` pattern — direct import of `check_content_safety` at module top — which made monkeypatching against `backend.src.api.routes.agents.check_content_safety` straightforward.

## Test plan
- [x] `python -m pytest tests/contracts/test_agent_endpoint_contract.py tests/contracts/test_agent_repository_contract.py -v` — 22/22 pass
- [x] `python -m pytest tests/contracts/ -v` — 447 pass, 13 fail (pre-existing chromadb `PersistentClient` + safety prompt failures, called out in the issue plan as out of scope; reproduce on main)
- [ ] Manual smoke after merge: `PUT /api/v1/me/agent` with curated title invokes safety once (name only); with free-text title invokes it twice; reject `emoji:🦖` with `INVALID_AVATAR`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)