### PR TITLE
feat(onboarding): POST /me/onboarding/complete with parent-consent gate (#440)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -832,6 +832,12 @@ class UpsertAgentRequest(BaseModel):
     child_id: str = Field(..., min_length=1, description="Child profile this agent is bound to")
 
 
+class CompleteOnboardingRequest(BaseModel):
+    """POST /me/onboarding/complete body — gates onboarding completion behind parent consent (#440)."""
+    parent_consent: bool = Field(..., description="True iff a parent has granted consent for the child's buddy persona to be shown publicly when sharing")
+    child_id: str = Field(..., min_length=1, description="Child profile being onboarded")
+
+
 class ReferralStatusResponse(BaseModel):
     """Referral progress and membership tier status (PRD §3.9.4)"""
     referral_code: str = Field(..., description="User's unique referral code")

--- a/backend/src/api/routes/onboarding.py
+++ b/backend/src/api/routes/onboarding.py
@@ -1,0 +1,86 @@
+"""
+Onboarding API Routes (#440)
+
+POST /api/v1/me/onboarding/complete — gates onboarding completion behind
+explicit parent consent and confirms an agent persona has been created
+for the active child profile. Part of Epic #436 (My Agent — personalized
+buddy persona).
+
+Behaviour:
+  1. parent_consent != True       -> 400 PARENT_CONSENT_REQUIRED
+  2. agent missing for (user, child_id) -> 412 AGENT_REQUIRED
+  3. Idempotent: when users.onboarded_at is already non-null, return
+     200 with the existing timestamps unchanged. Same applies to
+     parent_consent_at — we never overwrite a prior consent timestamp.
+  4. First completion: write both onboarded_at AND parent_consent_at in
+     a single UPDATE so they land atomically.
+"""
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ..deps import get_current_user
+from ..models import CompleteOnboardingRequest, UserResponse
+from ...services.database import agent_repo, user_repo
+from ...services.user_service import UserData
+from .users import _user_to_response
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/me/onboarding", tags=["My Agent"])
+
+
+@router.post(
+    "/complete",
+    response_model=UserResponse,
+    summary="Complete onboarding (parent-consent gate)",
+    description=(
+        "Mark the current user as onboarded once they have an agent persona "
+        "for the active child profile and a parent has granted consent. "
+        "Returns 412 if no agent exists yet, 400 if parent_consent is missing. "
+        "Idempotent — replaying the same call returns the existing timestamps."
+    ),
+)
+async def complete_onboarding(
+    request: CompleteOnboardingRequest,
+    user: UserData = Depends(get_current_user),
+):
+    if not request.parent_consent:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "PARENT_CONSENT_REQUIRED"},
+        )
+
+    agent = await agent_repo.get_agent(user.user_id, request.child_id)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "AGENT_REQUIRED"},
+        )
+
+    # Idempotent path: if either timestamp is already set, return the
+    # current state unchanged. We refetch fresh to capture any
+    # concurrent writes (and to pick up onboarding fields if the
+    # request authenticator returned a stale UserData).
+    fresh = await user_repo.get_by_id(user.user_id)
+    if fresh is None:
+        # Defensive — should not happen if get_current_user succeeded.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail={"code": "USER_LOOKUP_FAILED"},
+        )
+
+    if fresh.onboarded_at is None or fresh.parent_consent_at is None:
+        now_iso = datetime.now().isoformat()
+        # update_onboarding_fields builds a single UPDATE statement, so
+        # passing both timestamps writes them atomically.
+        await user_repo.update_onboarding_fields(
+            user_id=user.user_id,
+            onboarded_at=fresh.onboarded_at or now_iso,
+            parent_consent_at=fresh.parent_consent_at or now_iso,
+        )
+        fresh = await user_repo.get_by_id(user.user_id)
+
+    return _user_to_response(fresh, has_agent=True)

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -349,6 +349,7 @@ from .api.routes import (
     kids_daily,
     library,
     memory,
+    onboarding,
     subscriptions,
     usage,
     users,
@@ -363,6 +364,7 @@ app.include_router(video.router)
 app.include_router(voice.router)
 app.include_router(users.router)
 app.include_router(agents.router)
+app.include_router(onboarding.router)
 app.include_router(kids_daily.router)
 app.include_router(inspiration_daily.router)
 app.include_router(subscriptions.router)

--- a/backend/tests/contracts/test_onboarding_endpoint_contract.py
+++ b/backend/tests/contracts/test_onboarding_endpoint_contract.py
@@ -1,0 +1,234 @@
+"""
+Onboarding Endpoint Contract Tests (#440)
+
+Black-box contract on POST /api/v1/me/onboarding/complete. Locks in:
+  - 400 PARENT_CONSENT_REQUIRED when parent_consent != True
+  - 412 AGENT_REQUIRED when no agent exists for (user, child_id)
+  - 200 happy path: both onboarded_at and parent_consent_at set atomically
+  - Idempotency: a replay returns the SAME timestamps as the first call
+  - 401 when authentication is missing
+
+Parent Epic: #436 (My Agent — Personal Creative Buddy)
+Issue: #440
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from backend.src.api.deps import get_current_user
+from backend.src.main import app
+from backend.src.services.database import (
+    agent_repo,
+    db_manager,
+    user_repo,
+)
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserData
+
+
+# ---------------------------------------------------------------------------
+# Test user — auth-overridden to a deterministic identity
+# ---------------------------------------------------------------------------
+
+
+_TEST_USER_A = UserData(
+    user_id="onboarding_user_a",
+    username="onboarding_a",
+    email="ob_a@test.com",
+    password_hash="h",
+    display_name="OnboardingA",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    created_at="",
+    updated_at="",
+    last_login_at=None,
+)
+
+
+async def _override_current_user() -> UserData:
+    return _TEST_USER_A
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    fresh = DatabaseManager(":memory:")
+    await fresh.connect()
+    await init_schema(fresh)
+
+    saved_adapter = db_manager._adapter
+    db_manager._adapter = fresh._adapter
+
+    from datetime import datetime as _dt
+    now = _dt.now().isoformat()
+    await db_manager.execute(
+        """
+        INSERT INTO users (
+            user_id, username, email, password_hash, display_name,
+            is_active, is_verified, role,
+            membership_tier, referral_code, referred_by,
+            created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _TEST_USER_A.user_id,
+            _TEST_USER_A.username,
+            _TEST_USER_A.email,
+            _TEST_USER_A.password_hash,
+            _TEST_USER_A.display_name,
+            1,
+            1,
+            "child",
+            "free",
+            "OBCODE",
+            None,
+            now,
+            now,
+        ),
+    )
+    await db_manager.commit()
+
+    yield fresh
+    db_manager._adapter = saved_adapter
+    await fresh.disconnect()
+
+
+@pytest_asyncio.fixture
+async def auth_client(test_db):
+    """AsyncClient with auth dependency overridden to return _TEST_USER_A."""
+    app.dependency_overrides[get_current_user] = _override_current_user
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest_asyncio.fixture
+async def anon_client(test_db):
+    """AsyncClient WITHOUT the auth override — exercises the 401 path."""
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _seed_agent(child_id: str = "child_001") -> None:
+    await agent_repo.upsert_agent(
+        user_id=_TEST_USER_A.user_id,
+        child_id=child_id,
+        agent_name="Sparkle",
+        agent_avatar_id="emoji:🦁",
+        agent_title="Brave Lion",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parent-consent gate (400)
+# ---------------------------------------------------------------------------
+
+
+class TestParentConsentGate:
+    @pytest.mark.asyncio
+    async def test_consent_false_rejected(self, auth_client):
+        await _seed_agent()
+        r = await auth_client.post(
+            "/api/v1/me/onboarding/complete",
+            json={"parent_consent": False, "child_id": "child_001"},
+        )
+        assert r.status_code == 400
+        assert r.json()["detail"]["code"] == "PARENT_CONSENT_REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# Agent-required gate (412)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRequiredGate:
+    @pytest.mark.asyncio
+    async def test_no_agent_returns_412(self, auth_client):
+        # No _seed_agent() call — there is no agent for this child_id.
+        r = await auth_client.post(
+            "/api/v1/me/onboarding/complete",
+            json={"parent_consent": True, "child_id": "child_unbound"},
+        )
+        assert r.status_code == 412
+        assert r.json()["detail"]["code"] == "AGENT_REQUIRED"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — both timestamps set atomically
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_first_completion_sets_both_timestamps(self, auth_client):
+        await _seed_agent()
+        r = await auth_client.post(
+            "/api/v1/me/onboarding/complete",
+            json={"parent_consent": True, "child_id": "child_001"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["onboarded_at"] is not None
+        assert body["parent_consent_at"] is not None
+        assert body["has_agent"] is True
+
+        # Verify the row in the DB also reflects both timestamps.
+        fresh = await user_repo.get_by_id(_TEST_USER_A.user_id)
+        assert fresh is not None
+        assert fresh.onboarded_at is not None
+        assert fresh.parent_consent_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — same timestamps on replay
+# ---------------------------------------------------------------------------
+
+
+class TestIdempotency:
+    @pytest.mark.asyncio
+    async def test_replay_returns_same_timestamps(self, auth_client):
+        await _seed_agent()
+        first = await auth_client.post(
+            "/api/v1/me/onboarding/complete",
+            json={"parent_consent": True, "child_id": "child_001"},
+        )
+        assert first.status_code == 200, first.text
+        first_body = first.json()
+
+        second = await auth_client.post(
+            "/api/v1/me/onboarding/complete",
+            json={"parent_consent": True, "child_id": "child_001"},
+        )
+        assert second.status_code == 200, second.text
+        second_body = second.json()
+
+        assert first_body["onboarded_at"] == second_body["onboarded_at"], (
+            "onboarded_at must not be overwritten on replay"
+        )
+        assert first_body["parent_consent_at"] == second_body["parent_consent_at"], (
+            "parent_consent_at must not be overwritten on replay"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Auth gate (401)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthRequired:
+    @pytest.mark.asyncio
+    async def test_missing_auth_returns_401(self, anon_client):
+        r = await anon_client.post(
+            "/api/v1/me/onboarding/complete",
+            json={"parent_consent": True, "child_id": "child_001"},
+        )
+        assert r.status_code == 401


### PR DESCRIPTION
Fixes #440

Parent epic: #436

## Summary

Adds the onboarding completion endpoint that finalises a user's first-login flow. Gates completion behind two checks (parent consent + agent persona exists), writes both timestamps atomically, and is idempotent on retry.

| Condition | Status | Code |
|---|---|---|
| \`parent_consent != True\` | 400 | \`PARENT_CONSENT_REQUIRED\` |
| No agent for \`(user, child_id)\` | 412 | \`AGENT_REQUIRED\` |
| Happy path (first time) | 200 | sets both \`onboarded_at\` + \`parent_consent_at\` in one UPDATE |
| Happy path (replay) | 200 | returns the existing timestamps unchanged |
| No auth | 401 | (existing dep) |

## Files

- New: \`backend/src/api/routes/onboarding.py\` — kept onboarding in its own module so \`routes/agents.py\` stays scoped to \`/me/agent\`
- New: \`backend/tests/contracts/test_onboarding_endpoint_contract.py\` — 5 contract tests
- Edit: \`backend/src/api/models.py\` — \`CompleteOnboardingRequest\`
- Edit: \`backend/src/main.py\` — register \`onboarding.router\`

## Test plan

- [x] 400 on \`parent_consent=False\`
- [x] 412 on missing agent
- [x] 200 happy path: both timestamps non-null, atomic UPDATE
- [x] Idempotency: replay returns same timestamps (no overwrite)
- [x] 401 on missing auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)