### PR TITLE
feat(my-agent): MyAgentPage UI with edit form and curated titles (#442)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ const ProfilePage = lazy(() => import("./pages/ProfilePage"));
 const NewsPage = lazy(() => import("./pages/NewsPage"));
 const MorningShowPage = lazy(() => import("./pages/MorningShowPage"));
 const NewsDetailPage = lazy(() => import("./pages/NewsDetailPage"));
+const MyAgentPage = lazy(() => import("./pages/MyAgentPage"));
 
 function App() {
   return (
@@ -47,6 +48,7 @@ function App() {
               element={<MorningShowPage />}
             />
             <Route path="profile" element={<ProfilePage />} />
+            <Route path="my-agent" element={<MyAgentPage />} />
           </Route>
         </Routes>
       </Suspense>

--- a/frontend/src/api/services/agentService.test.ts
+++ b/frontend/src/api/services/agentService.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Logic-only tests for agentService. Mocks apiClient and exercises
+ * just the 404 -> null contract; full request shape is asserted
+ * implicitly by the params we hand to the mocked client.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AxiosError } from "axios";
+
+vi.mock("../client", () => ({
+  default: {
+    get: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+import apiClient from "../client";
+import { getAgent, putAgent } from "./agentService";
+
+const mockedGet = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+const mockedPut = apiClient.put as unknown as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  mockedGet.mockReset();
+  mockedPut.mockReset();
+});
+
+describe("getAgent", () => {
+  it("returns the Agent on 200", async () => {
+    const fake = {
+      agent_id: "agt_abc",
+      user_id: "u1",
+      child_id: "c1",
+      agent_name: "Sparkle",
+      agent_avatar_id: "emoji:🦊",
+      agent_title: "Story Wizard",
+      created_at: "2026-01-01T00:00:00",
+      updated_at: "2026-01-01T00:00:00",
+    };
+    mockedGet.mockResolvedValueOnce({ data: fake });
+    const result = await getAgent("c1");
+    expect(result).toEqual(fake);
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/me/agent",
+      expect.objectContaining({ params: { child_id: "c1" } }),
+    );
+  });
+
+  it("resolves to null on 404", async () => {
+    const err = new AxiosError("not found");
+    // @ts-expect-error -- attaching minimal AxiosResponse for the test
+    err.response = { status: 404, data: { detail: { code: "AGENT_NOT_FOUND" } } };
+    mockedGet.mockRejectedValueOnce(err);
+    const result = await getAgent("missing");
+    expect(result).toBeNull();
+  });
+
+  it("rethrows on non-404 errors", async () => {
+    const err = new AxiosError("server error");
+    // @ts-expect-error -- attaching minimal AxiosResponse for the test
+    err.response = { status: 500, data: {} };
+    mockedGet.mockRejectedValueOnce(err);
+    await expect(getAgent("c1")).rejects.toBe(err);
+  });
+});
+
+describe("putAgent", () => {
+  it("returns the upserted Agent", async () => {
+    const fake = {
+      agent_id: "agt_xyz",
+      user_id: "u1",
+      child_id: "c1",
+      agent_name: "Sparkle",
+      agent_avatar_id: "emoji:🦊",
+      agent_title: "Story Wizard",
+      created_at: "2026-01-01T00:00:00",
+      updated_at: "2026-01-02T00:00:00",
+    };
+    mockedPut.mockResolvedValueOnce({ data: fake });
+    const result = await putAgent({
+      agent_name: "Sparkle",
+      agent_avatar_id: "emoji:🦊",
+      agent_title: "Story Wizard",
+      child_id: "c1",
+    });
+    expect(result).toEqual(fake);
+    expect(mockedPut).toHaveBeenCalledWith(
+      "/me/agent",
+      expect.objectContaining({ child_id: "c1" }),
+    );
+  });
+});

--- a/frontend/src/api/services/agentService.ts
+++ b/frontend/src/api/services/agentService.ts
@@ -1,0 +1,48 @@
+/**
+ * Agent Service — API methods for the buddy persona endpoints (#442).
+ *
+ * Backend endpoints (#439):
+ *   GET  /me/agent?child_id=...   -> Agent or 404
+ *   PUT  /me/agent                -> Agent (upserted)
+ *
+ * apiClient already prefixes /api/v1 — call with bare paths.
+ */
+
+import { AxiosError } from "axios";
+import apiClient from "../client";
+import type { Agent, UpsertAgentPayload } from "@/types/agent";
+
+/**
+ * Fetch the agent persona for the given child. Resolves to `null` when
+ * the server returns 404 (no agent yet for this child profile) so the
+ * UI can render the empty/onboarding state without a try/catch.
+ */
+export async function getAgent(childId: string): Promise<Agent | null> {
+  try {
+    const r = await apiClient.get<Agent>("/me/agent", {
+      params: { child_id: childId },
+    });
+    return r.data;
+  } catch (err) {
+    if (
+      err instanceof AxiosError &&
+      err.response?.status === 404
+    ) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Upsert the agent persona. The server validates avatar whitelist,
+ * runs safety checks on agent_name and on free-text titles, and
+ * fails closed with 503 when the safety MCP is unavailable. Errors
+ * propagate to the caller so the form can map detail.code -> field.
+ */
+export async function putAgent(payload: UpsertAgentPayload): Promise<Agent> {
+  const r = await apiClient.put<Agent>("/me/agent", payload);
+  return r.data;
+}
+
+export const agentService = { getAgent, putAgent };

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -1,0 +1,34 @@
+/**
+ * useAgent — React Query hook for the buddy persona (#442).
+ *
+ * Mirrors the style of useMemoryApi.ts: a useQuery for the read path,
+ * a useMutation that invalidates the read query on success.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { agentService } from "@/api/services/agentService";
+import type { Agent, UpsertAgentPayload } from "@/types/agent";
+
+const AGENT_QUERY_KEY = (childId: string | undefined) =>
+  ["agent", childId ?? null] as const;
+
+export function useAgent(childId: string | undefined | null) {
+  const enabled = Boolean(childId);
+  return useQuery<Agent | null>({
+    queryKey: AGENT_QUERY_KEY(childId ?? undefined),
+    queryFn: () => agentService.getAgent(childId as string),
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useUpsertAgent() {
+  const qc = useQueryClient();
+  return useMutation<Agent, unknown, UpsertAgentPayload>({
+    mutationFn: (payload) => agentService.putAgent(payload),
+    onSuccess: (data) => {
+      qc.setQueryData(AGENT_QUERY_KEY(data.child_id), data);
+      qc.invalidateQueries({ queryKey: AGENT_QUERY_KEY(data.child_id) });
+    },
+  });
+}

--- a/frontend/src/lib/agentTitles.test.ts
+++ b/frontend/src/lib/agentTitles.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Logic-only tests for the curated titles list and the age-gating helper.
+ * No DOM rendering — `@testing-library/react` is intentionally not a
+ * dependency in this project, so we keep these to pure logic.
+ */
+import { describe, expect, it } from "vitest";
+import { CURATED_TITLES, customTitleAllowed } from "./agentTitles";
+
+describe("CURATED_TITLES", () => {
+  it("is exactly 20 entries — locked by PRD §3.11.3", () => {
+    expect(CURATED_TITLES.length).toBe(20);
+  });
+
+  it("has no duplicates", () => {
+    const seen = new Set<string>();
+    for (const t of CURATED_TITLES) {
+      expect(seen.has(t)).toBe(false);
+      seen.add(t);
+    }
+  });
+
+  it("starts with 'Story Wizard' (matches backend order)", () => {
+    expect(CURATED_TITLES[0]).toBe("Story Wizard");
+  });
+});
+
+describe("customTitleAllowed", () => {
+  it("returns true only for 9-12", () => {
+    expect(customTitleAllowed("9-12")).toBe(true);
+  });
+  it("returns false for younger tiers", () => {
+    expect(customTitleAllowed("3-5")).toBe(false);
+    expect(customTitleAllowed("6-8")).toBe(false);
+  });
+  it("returns false when age is unknown", () => {
+    expect(customTitleAllowed(undefined)).toBe(false);
+    expect(customTitleAllowed(null)).toBe(false);
+  });
+});

--- a/frontend/src/lib/agentTitles.ts
+++ b/frontend/src/lib/agentTitles.ts
@@ -1,0 +1,43 @@
+/**
+ * Curated buddy titles. Mirror of backend/src/services/agent_constants.py
+ * CURATED_TITLES (PRD §3.11.3). Order matters and must match the backend
+ * exactly so the curated-bypass safety check on the server agrees with
+ * the in-app picker.
+ *
+ * Free-text titles outside this list are allowed only for the 9-12 age
+ * group, and are safety-checked server-side before persistence.
+ */
+export const CURATED_TITLES = [
+  "Story Wizard",
+  "Brave Lion",
+  "Galaxy Explorer",
+  "Dragon Friend",
+  "Magic Painter",
+  "Forest Guardian",
+  "Ocean Adventurer",
+  "Star Dreamer",
+  "Dance Captain",
+  "Inventor",
+  "Riddle Master",
+  "Cloud Surfer",
+  "Tiny Hero",
+  "Silly Scientist",
+  "Music Maker",
+  "Treasure Hunter",
+  "Kindness Knight",
+  "Robot Buddy",
+  "Time Traveler",
+  "Sunshine Maker",
+] as const;
+
+export type CuratedTitle = (typeof CURATED_TITLES)[number];
+
+import type { AgeGroup } from "@/types/api";
+
+/**
+ * Free-text custom titles are allowed only in the 9-12 age tier per PRD §3.11.2.
+ * Younger tiers stay constrained to the curated list.
+ */
+export function customTitleAllowed(age: AgeGroup | undefined | null): boolean {
+  return age === "9-12";
+}

--- a/frontend/src/pages/MyAgentPage/AgentTitlePicker.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentTitlePicker.tsx
@@ -1,0 +1,95 @@
+/**
+ * AgentTitlePicker — dropdown of curated buddy titles + optional free-text
+ * input for older children (PRD §3.11.2).
+ *
+ * Issue: #442 | Parent epic: #436
+ */
+
+import { useState } from "react";
+import { CURATED_TITLES, customTitleAllowed } from "@/lib/agentTitles";
+import type { AgeGroup } from "@/types/api";
+
+const CUSTOM_SENTINEL = "__custom__";
+
+interface Props {
+  value: string;
+  onChange: (next: string) => void;
+  ageGroup: AgeGroup | undefined | null;
+  disabled?: boolean;
+  error?: string | null;
+}
+
+export default function AgentTitlePicker({
+  value,
+  onChange,
+  ageGroup,
+  disabled,
+  error,
+}: Props) {
+  const allowCustom = customTitleAllowed(ageGroup);
+  const isCurated = (CURATED_TITLES as readonly string[]).includes(value);
+  // When the current value is not in the curated list, we must be in
+  // custom mode (or the parent is restoring server state). For ages
+  // <9-12 this can happen if someone tampers with the field — we
+  // surface the value in a read-only fallback.
+  const [mode, setMode] = useState<"curated" | "custom">(
+    isCurated || !value ? "curated" : "custom",
+  );
+
+  const onSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const v = e.target.value;
+    if (v === CUSTOM_SENTINEL) {
+      setMode("custom");
+      onChange("");
+      return;
+    }
+    setMode("curated");
+    onChange(v);
+  };
+
+  const onCustomChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value.slice(0, 32));
+  };
+
+  const selectValue = mode === "custom" ? CUSTOM_SENTINEL : value;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium text-gray-700">
+        Buddy title
+      </label>
+      <select
+        className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:bg-gray-100"
+        value={selectValue}
+        disabled={disabled}
+        onChange={onSelectChange}
+        aria-label="Buddy title"
+      >
+        <option value="" disabled>
+          Pick a title…
+        </option>
+        {CURATED_TITLES.map((title) => (
+          <option key={title} value={title}>
+            {title}
+          </option>
+        ))}
+        {allowCustom && (
+          <option value={CUSTOM_SENTINEL}>✏️ Custom title</option>
+        )}
+      </select>
+      {mode === "custom" && allowCustom && (
+        <input
+          className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:bg-gray-100"
+          type="text"
+          value={value}
+          maxLength={32}
+          placeholder="Type a custom title (1-32 chars)"
+          disabled={disabled}
+          onChange={onCustomChange}
+          aria-label="Custom buddy title"
+        />
+      )}
+      {error && <p className="text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/MyAgentPage/index.tsx
+++ b/frontend/src/pages/MyAgentPage/index.tsx
@@ -1,0 +1,256 @@
+/**
+ * MyAgentPage — view + edit of the user's buddy persona (#442).
+ *
+ * Renders:
+ *   - Welcome header (uses the active child's name when available)
+ *   - Agent name input (max 32) with character counter and inline error
+ *   - 5x4 avatar grid sourced from the shared ANIMAL_EMOJIS list
+ *   - AgentTitlePicker (curated dropdown + free-text for ages 9-12)
+ *   - Save button (disabled while pending), with success + failure toasts
+ *
+ * Backend contract (#439):
+ *   - PUT /me/agent rejects with detail.code = INVALID_AVATAR / UNSAFE_*
+ *     so we can map the failure back to the right field.
+ *
+ * NOTE: This page does NOT add the navigation entry or the
+ * <RequireOnboarded> route gate — those land in #444.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { AxiosError } from "axios";
+import { ANIMAL_EMOJIS } from "@/lib/avatars";
+import useChildStore from "@/store/useChildStore";
+import { useAgent, useUpsertAgent } from "@/hooks/useAgent";
+import AgentTitlePicker from "./AgentTitlePicker";
+import type { AgentErrorDetail } from "@/types/agent";
+
+const MAX_NAME = 32;
+
+interface FieldErrors {
+  name?: string;
+  avatar?: string;
+  title?: string;
+  general?: string;
+}
+
+function avatarIdFor(emoji: string): string {
+  return `emoji:${emoji}`;
+}
+
+function detailFrom(err: unknown): AgentErrorDetail | null {
+  if (!(err instanceof AxiosError)) return null;
+  const data = err.response?.data;
+  if (data && typeof data === "object" && "detail" in data) {
+    const d = (data as { detail: unknown }).detail;
+    if (d && typeof d === "object" && "code" in d) {
+      return d as AgentErrorDetail;
+    }
+  }
+  return null;
+}
+
+export default function MyAgentPage() {
+  const currentChild = useChildStore((s) => s.currentChild);
+  const defaultChildId = useChildStore((s) => s.defaultChildId);
+  const childId = currentChild?.child_id ?? defaultChildId;
+  const ageGroup = currentChild?.age_group;
+
+  const { data: existing, isLoading } = useAgent(childId);
+  const upsert = useUpsertAgent();
+
+  const [name, setName] = useState("");
+  const [avatarId, setAvatarId] = useState<string>(
+    avatarIdFor(ANIMAL_EMOJIS[0]),
+  );
+  const [title, setTitle] = useState("Story Wizard");
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  // Hydrate form when the existing agent loads.
+  useEffect(() => {
+    if (existing) {
+      setName(existing.agent_name);
+      setAvatarId(existing.agent_avatar_id);
+      setTitle(existing.agent_title);
+    }
+  }, [existing]);
+
+  const childGreeting = useMemo(() => {
+    const childName = currentChild?.name?.trim();
+    return childName ? `${childName}'s creative buddy` : "Meet your creative buddy";
+  }, [currentChild?.name]);
+
+  const onSave = async () => {
+    setErrors({});
+    if (!childId) {
+      setErrors({ general: "No active child profile found." });
+      return;
+    }
+    if (!name.trim()) {
+      setErrors({ name: "Give your buddy a name (1-32 characters)." });
+      return;
+    }
+    if (!title.trim()) {
+      setErrors({ title: "Pick a title or write your own." });
+      return;
+    }
+    try {
+      await upsert.mutateAsync({
+        agent_name: name.trim(),
+        agent_avatar_id: avatarId,
+        agent_title: title.trim(),
+        child_id: childId,
+      });
+      setSavedAt(Date.now());
+    } catch (err) {
+      const detail = detailFrom(err);
+      if (!detail) {
+        setErrors({
+          general: "We couldn't save your buddy. Try again in a moment.",
+        });
+        return;
+      }
+      switch (detail.code) {
+        case "INVALID_AVATAR":
+          setErrors({ avatar: "Pick a different animal — that one isn't allowed." });
+          break;
+        case "UNSAFE_AGENT_NAME":
+        case "INVALID_AGENT_NAME":
+          setErrors({
+            name:
+              detail.reason ??
+              "Try a different name — that one didn't pass our safety check.",
+          });
+          break;
+        case "UNSAFE_AGENT_TITLE":
+        case "INVALID_AGENT_TITLE":
+          setErrors({
+            title:
+              detail.reason ??
+              "Try a different title — that one didn't pass our safety check.",
+          });
+          break;
+        case "SAFETY_UNAVAILABLE":
+          setErrors({
+            general:
+              "Our safety checker is taking a break. Please try again in a minute.",
+          });
+          break;
+        default:
+          setErrors({ general: detail.reason ?? "Something went wrong saving your buddy." });
+      }
+    }
+  };
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold text-gray-900">{childGreeting}</h1>
+        <p className="text-sm text-gray-600">
+          Your buddy is the name and animal we'll show whenever you share a story.
+          Pick anything you like — you can always change it later.
+        </p>
+      </header>
+
+      {isLoading ? (
+        <p className="text-gray-500">Loading…</p>
+      ) : (
+        <section className="flex flex-col gap-6 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm">
+          {/* Name */}
+          <div className="flex flex-col gap-2">
+            <label htmlFor="agent-name" className="text-sm font-medium text-gray-700">
+              Buddy name
+            </label>
+            <input
+              id="agent-name"
+              type="text"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500 disabled:bg-gray-100"
+              value={name}
+              maxLength={MAX_NAME}
+              placeholder="e.g. Sparkle"
+              disabled={upsert.isPending}
+              onChange={(e) => setName(e.target.value.slice(0, MAX_NAME))}
+              aria-describedby="agent-name-counter"
+            />
+            <div className="flex items-center justify-between">
+              <p id="agent-name-counter" className="text-xs text-gray-500">
+                {name.length}/{MAX_NAME}
+              </p>
+              {errors.name && (
+                <p className="text-xs text-red-600">{errors.name}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Avatar */}
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium text-gray-700">Buddy animal</span>
+            <div
+              role="radiogroup"
+              aria-label="Buddy animal"
+              className="grid grid-cols-5 gap-2"
+            >
+              {ANIMAL_EMOJIS.map((emoji) => {
+                const id = avatarIdFor(emoji);
+                const selected = avatarId === id;
+                return (
+                  <button
+                    key={emoji}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    aria-label={`Choose ${emoji}`}
+                    disabled={upsert.isPending}
+                    onClick={() => setAvatarId(id)}
+                    className={[
+                      "flex aspect-square items-center justify-center rounded-xl border-2 text-2xl transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500",
+                      selected
+                        ? "border-violet-500 bg-violet-50"
+                        : "border-gray-200 hover:border-gray-300",
+                    ].join(" ")}
+                  >
+                    {emoji}
+                  </button>
+                );
+              })}
+            </div>
+            {errors.avatar && (
+              <p className="text-xs text-red-600">{errors.avatar}</p>
+            )}
+          </div>
+
+          {/* Title */}
+          <AgentTitlePicker
+            value={title}
+            onChange={setTitle}
+            ageGroup={ageGroup}
+            disabled={upsert.isPending}
+            error={errors.title ?? null}
+          />
+
+          {/* Save */}
+          <div className="flex flex-col gap-2">
+            {errors.general && (
+              <p className="text-sm text-red-600" role="alert">
+                {errors.general}
+              </p>
+            )}
+            {savedAt && !errors.general && (
+              <p className="text-sm text-emerald-600" role="status">
+                Buddy saved!
+              </p>
+            )}
+            <button
+              type="button"
+              className="self-end rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:bg-gray-300"
+              disabled={upsert.isPending}
+              onClick={onSave}
+            >
+              {upsert.isPending ? "Saving…" : existing ? "Save buddy" : "Meet my buddy"}
+            </button>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/types/agent.ts
+++ b/frontend/src/types/agent.ts
@@ -1,0 +1,45 @@
+/**
+ * Agent persona types — mirror of backend AgentResponse / UpsertAgentRequest.
+ *
+ * Issue: #442 (frontend) | Parent epic: #436
+ */
+
+export interface Agent {
+  agent_id: string;
+  user_id: string;
+  child_id: string;
+  agent_name: string;
+  /** Avatar id from the whitelist, e.g. "emoji:🦊". */
+  agent_avatar_id: string;
+  agent_title: string;
+  /** ISO timestamp string. */
+  created_at: string;
+  /** ISO timestamp string. */
+  updated_at: string;
+}
+
+export interface UpsertAgentPayload {
+  agent_name: string;
+  agent_avatar_id: string;
+  agent_title: string;
+  child_id: string;
+}
+
+/**
+ * Server-side rejection codes returned in 4xx error envelopes by
+ * PUT /me/agent. The route attaches a 400 with detail.code = one of
+ * these so the form can surface inline errors to the right field.
+ */
+export type AgentErrorCode =
+  | "INVALID_AVATAR"
+  | "UNSAFE_AGENT_NAME"
+  | "INVALID_AGENT_NAME"
+  | "UNSAFE_AGENT_TITLE"
+  | "INVALID_AGENT_TITLE"
+  | "SAFETY_UNAVAILABLE";
+
+export interface AgentErrorDetail {
+  code: AgentErrorCode | string;
+  reason?: string;
+  score?: number;
+}


### PR DESCRIPTION
Fixes #442

Parent epic: #436
Depends on backend stories #438 / #439 / #441 (already on main).

## Summary

User-facing buddy editor at \`/my-agent\`. Consumes the agent endpoints landed in #439 and the shared avatar list from #441. Lazy-loaded route added under \`PageContainer\`. The \`<RequireOnboarded>\` gate and the nav entry are deferred to #444 per the spec.

## Layout

- Header with the active child's name when available
- Buddy name input (max 32, character counter, inline error)
- 5×4 avatar grid sourced from \`frontend/src/lib/avatars.ts\` (the same 20 emojis already used by Profile)
- \`AgentTitlePicker\` — dropdown of 20 curated titles. The "✏️ Custom title" option appears **only for age 9–12** (PRD §3.11.2); selecting it unlocks a free-text input (max 32) which the backend safety-checks before persistence.
- Save button disabled while pending; success / failure messaging surfaces inline.

## Error mapping

The backend route returns \`{ detail: { code: ..., reason?, score? } }\`. The page maps each code to the right field:

| code | maps to |
|---|---|
| \`INVALID_AVATAR\` | avatar grid error |
| \`UNSAFE_AGENT_NAME\` / \`INVALID_AGENT_NAME\` | name field |
| \`UNSAFE_AGENT_TITLE\` / \`INVALID_AGENT_TITLE\` | title field |
| \`SAFETY_UNAVAILABLE\` | general toast |

## Tests (logic-level)

Vitest is configured with jsdom but \`@testing-library/react\` is **not** a project dependency, so this PR keeps to logic-level tests; page-render tests can be added when that lands.

- \`src/lib/agentTitles.test.ts\` — 5 tests: list locked at 20, no duplicates, head matches backend order; \`customTitleAllowed\` only true for age 9–12 (false for 3-5/6-8/undefined/null).
- \`src/api/services/agentService.test.ts\` — 5 tests: \`getAgent\` returns null on 404 and rethrows on 500; \`putAgent\` returns the upserted agent.

10/10 pass; \`tsc --noEmit\` clean.

## Out of scope

- Navigation entry in \`PageContainer\` (#444)
- \`<RequireOnboarded>\` route gate (#444)
- OnboardingModal that auto-opens on first visit (#443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)