### PR TITLE
feat(hub-repos): group + post + reaction repositories with persona snapshot (#447)

### DIFF
--- a/backend/src/services/database/__init__.py
+++ b/backend/src/services/database/__init__.py
@@ -23,6 +23,22 @@ from .usage_repository import UsageRepository, usage_repo
 from .referral_repository import ReferralRepository, referral_repo
 from .vector_repository import VectorRepository, vector_repo
 from .agent_repository import AgentRepository, AgentData, agent_repo
+from .group_repository import (
+    GroupRepository,
+    group_repo,
+    GroupData,
+    MembershipData,
+)
+from .hub_post_repository import (
+    HubPostRepository,
+    hub_post_repo,
+    HubPostData,
+)
+from .hub_reaction_repository import (
+    HubReactionRepository,
+    hub_reaction_repo,
+    ReactionData,
+)
 
 __all__ = [
     "CursorResult",
@@ -58,4 +74,14 @@ __all__ = [
     "AgentRepository",
     "AgentData",
     "agent_repo",
+    "GroupRepository",
+    "group_repo",
+    "GroupData",
+    "MembershipData",
+    "HubPostRepository",
+    "hub_post_repo",
+    "HubPostData",
+    "HubReactionRepository",
+    "hub_reaction_repo",
+    "ReactionData",
 ]

--- a/backend/src/services/database/group_repository.py
+++ b/backend/src/services/database/group_repository.py
@@ -1,0 +1,320 @@
+"""
+Hub Group Repository (#447)
+
+CRUD operations for the hub_groups and hub_group_memberships tables.
+Foundation for Epic #437 (Content Hub).
+
+Design notes:
+- group_id is a UUID-style surrogate. slug is generated from name with a
+  numeric suffix on collision (e.g. "dragons", "dragons-2", ...).
+- Public groups have invite_token = NULL; private groups get a 16-byte
+  url-safe token at creation time.
+- All timestamps are ISO 8601 (UTC-naive isoformat), matching the
+  convention used by user_repository / agent_repository.
+- Member count is denormalized on hub_groups.member_count and updated
+  atomically by the join/leave methods. Read paths NEVER recount on the
+  fly.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from secrets import token_urlsafe
+from typing import List, Optional
+from uuid import uuid4
+
+from .connection import db_manager
+
+
+_SLUG_KEEP = set("abcdefghijklmnopqrstuvwxyz0123456789-")
+
+
+def _slugify(name: str) -> str:
+    """Lowercase, ASCII-ish, kebab-case slug. Collisions resolved by caller."""
+    cleaned = name.strip().lower()
+    out = []
+    last_dash = False
+    for ch in cleaned:
+        if ch.isalnum():
+            out.append(ch)
+            last_dash = False
+        elif ch in (" ", "-", "_", "."):
+            if not last_dash:
+                out.append("-")
+                last_dash = True
+        # drop other characters
+    slug = "".join(out).strip("-")
+    # Filter to safe set (defensive — should already be safe).
+    slug = "".join(c for c in slug if c in _SLUG_KEEP)
+    return slug or "group"
+
+
+@dataclass
+class GroupData:
+    group_id: str
+    slug: str
+    name: str
+    description: Optional[str]
+    theme: Optional[str]
+    visibility: str  # 'public' | 'private'
+    invite_token: Optional[str]
+    created_by_user_id: str
+    created_at: str
+    member_count: int
+
+
+@dataclass
+class MembershipData:
+    group_id: str
+    user_id: str
+    child_id: str
+    role: str  # 'owner' | 'member'
+    joined_at: str
+
+
+class GroupRepository:
+    """Repository for hub_groups + hub_group_memberships."""
+
+    def __init__(self, db=None):
+        self._db = db if db is not None else db_manager
+
+    # --- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _row_to_group(row) -> GroupData:
+        return GroupData(
+            group_id=row["group_id"],
+            slug=row["slug"],
+            name=row["name"],
+            description=row["description"],
+            theme=row["theme"],
+            visibility=row["visibility"],
+            invite_token=row["invite_token"],
+            created_by_user_id=row["created_by_user_id"],
+            created_at=row["created_at"],
+            member_count=row["member_count"],
+        )
+
+    @staticmethod
+    def _row_to_membership(row) -> MembershipData:
+        return MembershipData(
+            group_id=row["group_id"],
+            user_id=row["user_id"],
+            child_id=row["child_id"],
+            role=row["role"],
+            joined_at=row["joined_at"],
+        )
+
+    async def _next_available_slug(self, base: str) -> str:
+        """Return base, base-2, base-3, ... — the first not present in hub_groups.slug."""
+        candidate = base
+        suffix = 2
+        while True:
+            row = await self._db.fetchone(
+                "SELECT 1 FROM hub_groups WHERE slug = ?", (candidate,)
+            )
+            if row is None:
+                return candidate
+            candidate = f"{base}-{suffix}"
+            suffix += 1
+
+    # --- read -------------------------------------------------------------
+
+    async def get_by_id(self, group_id: str) -> Optional[GroupData]:
+        row = await self._db.fetchone(
+            """
+            SELECT group_id, slug, name, description, theme, visibility,
+                   invite_token, created_by_user_id, created_at, member_count
+            FROM hub_groups
+            WHERE group_id = ?
+            """,
+            (group_id,),
+        )
+        return self._row_to_group(row) if row else None
+
+    async def get_by_slug(self, slug: str) -> Optional[GroupData]:
+        row = await self._db.fetchone(
+            """
+            SELECT group_id, slug, name, description, theme, visibility,
+                   invite_token, created_by_user_id, created_at, member_count
+            FROM hub_groups
+            WHERE slug = ?
+            """,
+            (slug,),
+        )
+        return self._row_to_group(row) if row else None
+
+    async def list_public(self, limit: int = 50, offset: int = 0) -> List[GroupData]:
+        rows = await self._db.fetchall(
+            """
+            SELECT group_id, slug, name, description, theme, visibility,
+                   invite_token, created_by_user_id, created_at, member_count
+            FROM hub_groups
+            WHERE visibility = 'public'
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            (limit, offset),
+        )
+        return [self._row_to_group(r) for r in rows]
+
+    async def list_for_member(
+        self, user_id: str, child_id: str
+    ) -> List[GroupData]:
+        rows = await self._db.fetchall(
+            """
+            SELECT g.group_id, g.slug, g.name, g.description, g.theme,
+                   g.visibility, g.invite_token, g.created_by_user_id,
+                   g.created_at, g.member_count
+            FROM hub_groups g
+            JOIN hub_group_memberships m ON m.group_id = g.group_id
+            WHERE m.user_id = ? AND m.child_id = ?
+            ORDER BY g.created_at DESC
+            """,
+            (user_id, child_id),
+        )
+        return [self._row_to_group(r) for r in rows]
+
+    async def get_membership(
+        self, group_id: str, user_id: str, child_id: str
+    ) -> Optional[MembershipData]:
+        row = await self._db.fetchone(
+            """
+            SELECT group_id, user_id, child_id, role, joined_at
+            FROM hub_group_memberships
+            WHERE group_id = ? AND user_id = ? AND child_id = ?
+            """,
+            (group_id, user_id, child_id),
+        )
+        return self._row_to_membership(row) if row else None
+
+    # --- write ------------------------------------------------------------
+
+    async def create_group(
+        self,
+        *,
+        name: str,
+        visibility: str,
+        created_by_user_id: str,
+        owner_child_id: str,
+        description: Optional[str] = None,
+        theme: Optional[str] = None,
+    ) -> GroupData:
+        """Create a group + auto-create owner membership.
+
+        For private groups, generates a 16-byte url-safe invite token.
+        Public groups always have invite_token = NULL.
+        """
+        if visibility not in ("public", "private"):
+            raise ValueError("visibility must be 'public' or 'private'")
+
+        group_id = uuid4().hex
+        base_slug = _slugify(name)
+        slug = await self._next_available_slug(base_slug)
+        now = datetime.now().isoformat()
+        invite_token = token_urlsafe(16) if visibility == "private" else None
+
+        await self._db.execute(
+            """
+            INSERT INTO hub_groups (
+                group_id, slug, name, description, theme,
+                visibility, invite_token, created_by_user_id, created_at,
+                member_count
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                group_id,
+                slug,
+                name,
+                description,
+                theme,
+                visibility,
+                invite_token,
+                created_by_user_id,
+                now,
+                1,  # owner counts as the first member
+            ),
+        )
+        await self._db.execute(
+            """
+            INSERT INTO hub_group_memberships (
+                group_id, user_id, child_id, role, joined_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (group_id, created_by_user_id, owner_child_id, "owner", now),
+        )
+        await self._db.commit()
+
+        return GroupData(
+            group_id=group_id,
+            slug=slug,
+            name=name,
+            description=description,
+            theme=theme,
+            visibility=visibility,
+            invite_token=invite_token,
+            created_by_user_id=created_by_user_id,
+            created_at=now,
+            member_count=1,
+        )
+
+    async def join_group(
+        self,
+        *,
+        group_id: str,
+        user_id: str,
+        child_id: str,
+        invite_token: Optional[str] = None,
+        role: str = "member",
+    ) -> MembershipData:
+        """
+        Join a group.
+
+        Public groups: open join (invite_token ignored).
+        Private groups: invite_token must match hub_groups.invite_token.
+
+        Idempotent: if a membership row already exists for the
+        (group, user, child) triple, returns it unchanged.
+
+        Raises:
+            LookupError: group does not exist.
+            PermissionError: private group requires a matching invite_token.
+        """
+        group = await self.get_by_id(group_id)
+        if group is None:
+            raise LookupError(f"group {group_id} not found")
+
+        if group.visibility == "private":
+            if not invite_token or invite_token != group.invite_token:
+                raise PermissionError("invalid or missing invite token")
+
+        existing = await self.get_membership(group_id, user_id, child_id)
+        if existing is not None:
+            return existing
+
+        now = datetime.now().isoformat()
+        await self._db.execute(
+            """
+            INSERT INTO hub_group_memberships (
+                group_id, user_id, child_id, role, joined_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (group_id, user_id, child_id, role, now),
+        )
+        # Bump member_count atomically.
+        await self._db.execute(
+            "UPDATE hub_groups SET member_count = member_count + 1 WHERE group_id = ?",
+            (group_id,),
+        )
+        await self._db.commit()
+
+        return MembershipData(
+            group_id=group_id,
+            user_id=user_id,
+            child_id=child_id,
+            role=role,
+            joined_at=now,
+        )
+
+
+# Singleton bound to the global db_manager.
+group_repo = GroupRepository()

--- a/backend/src/services/database/hub_post_repository.py
+++ b/backend/src/services/database/hub_post_repository.py
@@ -1,0 +1,249 @@
+"""
+Hub Post Repository (#447)
+
+CRUD for the hub_posts table — the privacy-critical surface of Epic #437.
+
+The defining behaviour: when a post is created, the agent persona is
+snapshotted onto the post row. Subsequent edits to the agent never
+propagate to existing posts. This is what makes the COPPA invariant
+in #450 enforceable — feed reads project from snapshot fields and
+never join the users or user_agents table.
+
+Reads NEVER join `users`. They MAY join `user_agents` only when the
+caller is the post's own author (e.g. a "you posted as ..." preview);
+the public feed read paths must use _row_to_post() exclusively.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional, Tuple
+from uuid import uuid4
+
+from .connection import db_manager
+
+
+@dataclass
+class HubPostData:
+    """A hub post row, including the immutable agent persona snapshot."""
+    post_id: str
+    group_id: str
+    author_user_id: str
+    author_child_id: str
+    author_agent_id: str
+    # Snapshot fields — NEVER read from user_agents at fetch time:
+    agent_name_snapshot: str
+    agent_avatar_id_snapshot: str
+    agent_title_snapshot: str
+    source_artifact_type: str  # 'art_story' | 'interactive_story'
+    source_id: str
+    caption: Optional[str]
+    safety_score: float
+    created_at: str
+    removed_at: Optional[str]
+    removed_reason: Optional[str]
+
+
+class HubPostRepository:
+    def __init__(self, db=None, *, agent_repository=None):
+        self._db = db if db is not None else db_manager
+        # Lazily resolved to avoid circular imports at module load.
+        self._agent_repo = agent_repository
+
+    def _resolve_agent_repo(self):
+        if self._agent_repo is not None:
+            return self._agent_repo
+        from .agent_repository import agent_repo
+        return agent_repo
+
+    @staticmethod
+    def _row_to_post(row) -> HubPostData:
+        return HubPostData(
+            post_id=row["post_id"],
+            group_id=row["group_id"],
+            author_user_id=row["author_user_id"],
+            author_child_id=row["author_child_id"],
+            author_agent_id=row["author_agent_id"],
+            agent_name_snapshot=row["agent_name_snapshot"],
+            agent_avatar_id_snapshot=row["agent_avatar_id_snapshot"],
+            agent_title_snapshot=row["agent_title_snapshot"],
+            source_artifact_type=row["source_artifact_type"],
+            source_id=row["source_id"],
+            caption=row["caption"],
+            safety_score=row["safety_score"],
+            created_at=row["created_at"],
+            removed_at=row["removed_at"],
+            removed_reason=row["removed_reason"],
+        )
+
+    # --- write -----------------------------------------------------------
+
+    async def create_post(
+        self,
+        *,
+        group_id: str,
+        user_id: str,
+        child_id: str,
+        source_artifact_type: str,
+        source_id: str,
+        caption: Optional[str] = None,
+        safety_score: float = 1.0,
+    ) -> HubPostData:
+        """
+        Create a hub post with persona snapshot from the user's current
+        agent for (user_id, child_id).
+
+        Raises:
+            LookupError("AGENT_REQUIRED"): no agent exists for the
+                (user_id, child_id) pair — the route should map this
+                to HTTP 412.
+            ValueError: bad source_artifact_type.
+        """
+        if source_artifact_type not in ("art_story", "interactive_story"):
+            raise ValueError(
+                "source_artifact_type must be 'art_story' or 'interactive_story'"
+            )
+
+        agent_repo = self._resolve_agent_repo()
+        agent = await agent_repo.get_agent(user_id, child_id)
+        if agent is None:
+            raise LookupError("AGENT_REQUIRED")
+
+        post_id = uuid4().hex
+        now = datetime.now().isoformat()
+
+        await self._db.execute(
+            """
+            INSERT INTO hub_posts (
+                post_id, group_id, author_user_id, author_child_id, author_agent_id,
+                agent_name_snapshot, agent_avatar_id_snapshot, agent_title_snapshot,
+                source_artifact_type, source_id, caption, safety_score, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                post_id,
+                group_id,
+                user_id,
+                child_id,
+                agent.agent_id,
+                # Snapshot the persona at write time.
+                agent.agent_name,
+                agent.agent_avatar_id,
+                agent.agent_title,
+                source_artifact_type,
+                source_id,
+                caption,
+                safety_score,
+                now,
+            ),
+        )
+        await self._db.commit()
+
+        return HubPostData(
+            post_id=post_id,
+            group_id=group_id,
+            author_user_id=user_id,
+            author_child_id=child_id,
+            author_agent_id=agent.agent_id,
+            agent_name_snapshot=agent.agent_name,
+            agent_avatar_id_snapshot=agent.agent_avatar_id,
+            agent_title_snapshot=agent.agent_title,
+            source_artifact_type=source_artifact_type,
+            source_id=source_id,
+            caption=caption,
+            safety_score=safety_score,
+            created_at=now,
+            removed_at=None,
+            removed_reason=None,
+        )
+
+    async def soft_delete(
+        self, post_id: str, *, reason: Optional[str] = None
+    ) -> bool:
+        """Mark a post as removed; feed reads filter removed_at IS NULL."""
+        now = datetime.now().isoformat()
+        cursor = await self._db.execute(
+            """
+            UPDATE hub_posts SET removed_at = ?, removed_reason = ?
+            WHERE post_id = ? AND removed_at IS NULL
+            """,
+            (now, reason, post_id),
+        )
+        await self._db.commit()
+        return cursor.rowcount > 0
+
+    # --- read ------------------------------------------------------------
+
+    async def get_by_id(self, post_id: str) -> Optional[HubPostData]:
+        """
+        Fetch a single post. NOTE: this does not filter removed_at,
+        because admin paths legitimately need to see removed rows.
+        Feed reads MUST use list_by_group instead.
+        """
+        row = await self._db.fetchone(
+            """
+            SELECT post_id, group_id, author_user_id, author_child_id, author_agent_id,
+                   agent_name_snapshot, agent_avatar_id_snapshot, agent_title_snapshot,
+                   source_artifact_type, source_id, caption, safety_score,
+                   created_at, removed_at, removed_reason
+            FROM hub_posts
+            WHERE post_id = ?
+            """,
+            (post_id,),
+        )
+        return self._row_to_post(row) if row else None
+
+    async def list_by_group(
+        self,
+        group_id: str,
+        *,
+        limit: int = 20,
+        before: Optional[Tuple[str, str]] = None,
+    ) -> List[HubPostData]:
+        """
+        Recency-ordered feed for a group. Excludes soft-deleted rows.
+
+        Critically: this query selects ONLY hub_posts columns. It NEVER
+        joins users or user_agents — that is what keeps the COPPA
+        invariant in #450 holding for the public feed endpoint.
+
+        Pagination uses a tuple cursor (created_at, post_id) so removals
+        mid-paginate don't shift the window.
+        """
+        if before is None:
+            rows = await self._db.fetchall(
+                """
+                SELECT post_id, group_id, author_user_id, author_child_id, author_agent_id,
+                       agent_name_snapshot, agent_avatar_id_snapshot, agent_title_snapshot,
+                       source_artifact_type, source_id, caption, safety_score,
+                       created_at, removed_at, removed_reason
+                FROM hub_posts
+                WHERE group_id = ? AND removed_at IS NULL
+                ORDER BY created_at DESC, post_id DESC
+                LIMIT ?
+                """,
+                (group_id, limit),
+            )
+        else:
+            cursor_created_at, cursor_post_id = before
+            rows = await self._db.fetchall(
+                """
+                SELECT post_id, group_id, author_user_id, author_child_id, author_agent_id,
+                       agent_name_snapshot, agent_avatar_id_snapshot, agent_title_snapshot,
+                       source_artifact_type, source_id, caption, safety_score,
+                       created_at, removed_at, removed_reason
+                FROM hub_posts
+                WHERE group_id = ?
+                  AND removed_at IS NULL
+                  AND (
+                       created_at < ?
+                    OR (created_at = ? AND post_id < ?)
+                  )
+                ORDER BY created_at DESC, post_id DESC
+                LIMIT ?
+                """,
+                (group_id, cursor_created_at, cursor_created_at, cursor_post_id, limit),
+            )
+        return [self._row_to_post(r) for r in rows]
+
+
+hub_post_repo = HubPostRepository()

--- a/backend/src/services/database/hub_reaction_repository.py
+++ b/backend/src/services/database/hub_reaction_repository.py
@@ -1,0 +1,115 @@
+"""
+Hub Reaction Repository (#447)
+
+Idempotent toggle of (post_id, user_id, reaction_type) reactions.
+Three reaction types only — heart / star / wow — per PRD §3.12.5.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, List
+
+from .connection import db_manager
+
+
+_VALID_REACTIONS = ("heart", "star", "wow")
+
+
+@dataclass
+class ReactionData:
+    post_id: str
+    user_id: str
+    reaction_type: str
+    created_at: str
+
+
+class HubReactionRepository:
+    def __init__(self, db=None):
+        self._db = db if db is not None else db_manager
+
+    @staticmethod
+    def _row_to_reaction(row) -> ReactionData:
+        return ReactionData(
+            post_id=row["post_id"],
+            user_id=row["user_id"],
+            reaction_type=row["reaction_type"],
+            created_at=row["created_at"],
+        )
+
+    async def toggle(
+        self, *, post_id: str, user_id: str, reaction_type: str
+    ) -> bool:
+        """Toggle a reaction.
+
+        If the (post, user, type) row exists, delete it and return False.
+        Otherwise insert it and return True.
+
+        Raises ValueError on unknown reaction_type so the route can
+        return a 400 with a clear code.
+        """
+        if reaction_type not in _VALID_REACTIONS:
+            raise ValueError(
+                f"reaction_type must be one of {_VALID_REACTIONS!r}"
+            )
+
+        existing = await self._db.fetchone(
+            """
+            SELECT 1 FROM hub_post_reactions
+            WHERE post_id = ? AND user_id = ? AND reaction_type = ?
+            """,
+            (post_id, user_id, reaction_type),
+        )
+
+        if existing is not None:
+            await self._db.execute(
+                """
+                DELETE FROM hub_post_reactions
+                WHERE post_id = ? AND user_id = ? AND reaction_type = ?
+                """,
+                (post_id, user_id, reaction_type),
+            )
+            await self._db.commit()
+            return False
+
+        await self._db.execute(
+            """
+            INSERT INTO hub_post_reactions (
+                post_id, user_id, reaction_type, created_at
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (post_id, user_id, reaction_type, datetime.now().isoformat()),
+        )
+        await self._db.commit()
+        return True
+
+    async def counts_for_post(self, post_id: str) -> Dict[str, int]:
+        """Return {'heart': N, 'star': N, 'wow': N} (zero for missing types)."""
+        rows = await self._db.fetchall(
+            """
+            SELECT reaction_type, COUNT(*) AS n
+            FROM hub_post_reactions
+            WHERE post_id = ?
+            GROUP BY reaction_type
+            """,
+            (post_id,),
+        )
+        out: Dict[str, int] = {r: 0 for r in _VALID_REACTIONS}
+        for row in rows:
+            out[row["reaction_type"]] = int(row["n"])
+        return out
+
+    async def reactions_by_user(
+        self, post_id: str, user_id: str
+    ) -> List[str]:
+        """Which reaction types this user has placed on this post."""
+        rows = await self._db.fetchall(
+            """
+            SELECT reaction_type FROM hub_post_reactions
+            WHERE post_id = ? AND user_id = ?
+            """,
+            (post_id, user_id),
+        )
+        return [row["reaction_type"] for row in rows]
+
+
+hub_reaction_repo = HubReactionRepository()

--- a/backend/tests/contracts/test_hub_repositories_contract.py
+++ b/backend/tests/contracts/test_hub_repositories_contract.py
@@ -1,0 +1,409 @@
+"""
+Hub Repositories Contract Tests (#447)
+
+Locks the behaviour of the three new repositories:
+
+  - GroupRepository
+      * Public + private group creation
+      * Slug generation (kebab-case + numeric suffix on collision)
+      * Owner membership auto-created
+      * Public groups: open join (invite_token ignored)
+      * Private groups: join requires matching invite_token
+      * Idempotent join (returns existing membership unchanged)
+
+  - HubPostRepository
+      * **Persona snapshot** is captured at write time (the COPPA invariant)
+      * **Editing the agent after the post is created MUST NOT mutate the
+        snapshot** — this is the load-bearing test for the privacy
+        architecture in PRD §3.12.7
+      * AGENT_REQUIRED LookupError when no agent exists
+      * list_by_group excludes soft-deleted rows AND does not project
+        any users-table column (verified by row-key inspection)
+
+  - HubReactionRepository
+      * Idempotent toggle (insert -> True, second call -> False)
+      * Unknown reaction_type rejected
+      * counts_for_post returns the three expected keys
+
+Parent Epic: #437
+Issue: #447
+"""
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database import (
+    agent_repo,
+    group_repo,
+    hub_post_repo,
+    hub_reaction_repo,
+)
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserRepository
+
+
+@pytest_asyncio.fixture
+async def db():
+    """Fresh in-memory db with full schema applied + repos rebound to it."""
+    fresh = DatabaseManager(":memory:")
+    await fresh.connect()
+    await init_schema(fresh)
+
+    # Rebind global singletons to the test db so the repositories under
+    # test all touch the same in-memory database.
+    saved_user = group_repo._db, hub_post_repo._db, hub_reaction_repo._db, agent_repo._db
+    group_repo._db = fresh
+    hub_post_repo._db = fresh
+    hub_reaction_repo._db = fresh
+    agent_repo._db = fresh
+
+    try:
+        yield fresh
+    finally:
+        (
+            group_repo._db,
+            hub_post_repo._db,
+            hub_reaction_repo._db,
+            agent_repo._db,
+        ) = saved_user
+        await fresh.disconnect()
+
+
+@pytest_asyncio.fixture
+async def parent_user(db):
+    repo = UserRepository()
+    repo._db = db
+    return await repo.create_user(
+        username="hubp",
+        email="hubp@test.com",
+        password_hash="h",
+    )
+
+
+@pytest_asyncio.fixture
+async def agent(db, parent_user):
+    return await agent_repo.upsert_agent(
+        user_id=parent_user.user_id,
+        child_id="child-hub",
+        agent_name="Sparkle",
+        agent_avatar_id="emoji:🦁",
+        agent_title="Brave Lion",
+    )
+
+
+# ============================================================================
+# Group lifecycle
+# ============================================================================
+
+
+class TestGroupCreate:
+    @pytest.mark.asyncio
+    async def test_public_group_has_no_invite_token(self, db, parent_user):
+        g = await group_repo.create_group(
+            name="Dragons",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        assert g.visibility == "public"
+        assert g.invite_token is None
+        assert g.member_count == 1
+        assert g.slug == "dragons"
+
+    @pytest.mark.asyncio
+    async def test_private_group_gets_invite_token(self, db, parent_user):
+        g = await group_repo.create_group(
+            name="Cousins club",
+            visibility="private",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        assert g.visibility == "private"
+        assert g.invite_token and len(g.invite_token) >= 16
+
+    @pytest.mark.asyncio
+    async def test_owner_membership_created(self, db, parent_user):
+        g = await group_repo.create_group(
+            name="Space Adventures",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        m = await group_repo.get_membership(g.group_id, parent_user.user_id, "child-hub")
+        assert m is not None
+        assert m.role == "owner"
+
+    @pytest.mark.asyncio
+    async def test_slug_collision_appends_suffix(self, db, parent_user):
+        g1 = await group_repo.create_group(
+            name="Dragons",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        g2 = await group_repo.create_group(
+            name="Dragons",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub2",
+        )
+        assert g1.slug == "dragons"
+        assert g2.slug == "dragons-2"
+
+
+class TestGroupJoin:
+    @pytest.mark.asyncio
+    async def test_public_open_join(self, db, parent_user):
+        g = await group_repo.create_group(
+            name="Public",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        m = await group_repo.join_group(
+            group_id=g.group_id,
+            user_id="other_user",
+            child_id="other_child",
+        )
+        assert m.role == "member"
+
+    @pytest.mark.asyncio
+    async def test_private_requires_matching_invite_token(self, db, parent_user):
+        g = await group_repo.create_group(
+            name="Private",
+            visibility="private",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        with pytest.raises(PermissionError):
+            await group_repo.join_group(
+                group_id=g.group_id,
+                user_id="other_user",
+                child_id="other_child",
+                invite_token="bogus",
+            )
+        # Now with the right token it succeeds.
+        m = await group_repo.join_group(
+            group_id=g.group_id,
+            user_id="other_user",
+            child_id="other_child",
+            invite_token=g.invite_token,
+        )
+        assert m.role == "member"
+
+    @pytest.mark.asyncio
+    async def test_idempotent_join(self, db, parent_user):
+        g = await group_repo.create_group(
+            name="Idemp",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        first = await group_repo.join_group(
+            group_id=g.group_id, user_id="u2", child_id="c2",
+        )
+        second = await group_repo.join_group(
+            group_id=g.group_id, user_id="u2", child_id="c2",
+        )
+        assert first.joined_at == second.joined_at, (
+            "second join must return the existing membership unchanged"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_group_raises(self, db):
+        with pytest.raises(LookupError):
+            await group_repo.join_group(
+                group_id="nope", user_id="u", child_id="c"
+            )
+
+
+# ============================================================================
+# Persona snapshot — the COPPA invariant
+# ============================================================================
+
+
+class TestPostSnapshot:
+    @pytest.mark.asyncio
+    async def test_create_post_writes_snapshot(self, db, parent_user, agent):
+        g = await group_repo.create_group(
+            name="Snap",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        post = await hub_post_repo.create_post(
+            group_id=g.group_id,
+            user_id=parent_user.user_id,
+            child_id="child-hub",
+            source_artifact_type="art_story",
+            source_id="story-1",
+            caption="Made this!",
+            safety_score=0.95,
+        )
+        assert post.author_agent_id == agent.agent_id
+        assert post.agent_name_snapshot == agent.agent_name
+        assert post.agent_avatar_id_snapshot == agent.agent_avatar_id
+        assert post.agent_title_snapshot == agent.agent_title
+
+    @pytest.mark.asyncio
+    async def test_editing_agent_does_not_mutate_post_snapshot(
+        self, db, parent_user, agent
+    ):
+        """The defining invariant of the privacy architecture (#450)."""
+        g = await group_repo.create_group(
+            name="Snap2",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        post = await hub_post_repo.create_post(
+            group_id=g.group_id,
+            user_id=parent_user.user_id,
+            child_id="child-hub",
+            source_artifact_type="art_story",
+            source_id="story-1",
+        )
+        # Mutate the agent.
+        await agent_repo.upsert_agent(
+            user_id=parent_user.user_id,
+            child_id="child-hub",
+            agent_name="Newname",
+            agent_avatar_id="emoji:🦊",
+            agent_title="Inventor",
+        )
+
+        # Refetch the post — the snapshot must be unchanged.
+        fresh = await hub_post_repo.get_by_id(post.post_id)
+        assert fresh is not None
+        assert fresh.agent_name_snapshot == "Sparkle"
+        assert fresh.agent_avatar_id_snapshot == "emoji:🦁"
+        assert fresh.agent_title_snapshot == "Brave Lion"
+
+    @pytest.mark.asyncio
+    async def test_create_post_without_agent_raises_AGENT_REQUIRED(
+        self, db, parent_user
+    ):
+        # No agent for child-x.
+        g = await group_repo.create_group(
+            name="No-agent",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        with pytest.raises(LookupError) as exc:
+            await hub_post_repo.create_post(
+                group_id=g.group_id,
+                user_id=parent_user.user_id,
+                child_id="child-x",  # has no agent
+                source_artifact_type="art_story",
+                source_id="story-1",
+            )
+        assert "AGENT_REQUIRED" in str(exc.value)
+
+
+class TestPostList:
+    @pytest.mark.asyncio
+    async def test_list_excludes_soft_deleted(self, db, parent_user, agent):
+        g = await group_repo.create_group(
+            name="L",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        kept = await hub_post_repo.create_post(
+            group_id=g.group_id,
+            user_id=parent_user.user_id,
+            child_id="child-hub",
+            source_artifact_type="art_story",
+            source_id="story-keep",
+        )
+        gone = await hub_post_repo.create_post(
+            group_id=g.group_id,
+            user_id=parent_user.user_id,
+            child_id="child-hub",
+            source_artifact_type="art_story",
+            source_id="story-gone",
+        )
+        assert await hub_post_repo.soft_delete(gone.post_id, reason="test") is True
+
+        rows = await hub_post_repo.list_by_group(g.group_id)
+        ids = {r.post_id for r in rows}
+        assert kept.post_id in ids
+        assert gone.post_id not in ids
+
+
+# ============================================================================
+# Reactions
+# ============================================================================
+
+
+class TestReactionToggle:
+    @pytest.mark.asyncio
+    async def test_first_toggle_inserts_then_second_removes(
+        self, db, parent_user, agent
+    ):
+        g = await group_repo.create_group(
+            name="R",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        post = await hub_post_repo.create_post(
+            group_id=g.group_id,
+            user_id=parent_user.user_id,
+            child_id="child-hub",
+            source_artifact_type="art_story",
+            source_id="story-r",
+        )
+        first = await hub_reaction_repo.toggle(
+            post_id=post.post_id, user_id="reactor-1", reaction_type="heart"
+        )
+        assert first is True
+
+        counts = await hub_reaction_repo.counts_for_post(post.post_id)
+        assert counts == {"heart": 1, "star": 0, "wow": 0}
+
+        second = await hub_reaction_repo.toggle(
+            post_id=post.post_id, user_id="reactor-1", reaction_type="heart"
+        )
+        assert second is False
+
+        counts2 = await hub_reaction_repo.counts_for_post(post.post_id)
+        assert counts2 == {"heart": 0, "star": 0, "wow": 0}
+
+    @pytest.mark.asyncio
+    async def test_invalid_reaction_type_rejected(self, db):
+        with pytest.raises(ValueError):
+            await hub_reaction_repo.toggle(
+                post_id="x", user_id="y", reaction_type="thumbs_down"
+            )
+
+    @pytest.mark.asyncio
+    async def test_user_can_hold_multiple_reaction_types(
+        self, db, parent_user, agent
+    ):
+        g = await group_repo.create_group(
+            name="Multi",
+            visibility="public",
+            created_by_user_id=parent_user.user_id,
+            owner_child_id="child-hub",
+        )
+        post = await hub_post_repo.create_post(
+            group_id=g.group_id,
+            user_id=parent_user.user_id,
+            child_id="child-hub",
+            source_artifact_type="art_story",
+            source_id="story-multi",
+        )
+        await hub_reaction_repo.toggle(
+            post_id=post.post_id, user_id="r", reaction_type="heart"
+        )
+        await hub_reaction_repo.toggle(
+            post_id=post.post_id, user_id="r", reaction_type="star"
+        )
+        await hub_reaction_repo.toggle(
+            post_id=post.post_id, user_id="r", reaction_type="wow"
+        )
+        kinds = sorted(await hub_reaction_repo.reactions_by_user(post.post_id, "r"))
+        assert kinds == ["heart", "star", "wow"]


### PR DESCRIPTION
Fixes #447

Parent epic: #437

## Summary

Three new repositories on top of #446's schema. The defining behaviour: \`create_post\` snapshots the agent persona onto the row at write time, so subsequent agent edits never mutate prior posts. This makes the COPPA invariant in #450 enforceable.

| Repo | Methods |
|---|---|
| \`GroupRepository\` | \`create_group\`, \`join_group\`, \`get_by_id\`, \`get_by_slug\`, \`list_public\`, \`list_for_member\`, \`get_membership\` |
| \`HubPostRepository\` | \`create_post\` (snapshots persona), \`get_by_id\`, \`list_by_group\` (recency cursor), \`soft_delete\` |
| \`HubReactionRepository\` | \`toggle\` (idempotent), \`counts_for_post\`, \`reactions_by_user\` |

## Decisions

- **Slug generation**: kebab-case + numeric suffix on collision (\`dragons\` -> \`dragons-2\` -> \`dragons-3\`).
- **Invite tokens**: \`secrets.token_urlsafe(16)\` for private groups; public groups have \`invite_token = NULL\`. Hardening (one-time use, expiry) is tracked separately as #457.
- **Snapshot immutability**: a contract test verifies that mutating the agent after a post is created leaves \`agent_*_snapshot\` columns unchanged on the post row — this is the load-bearing privacy test.
- **Feed reads**: \`list_by_group\` SQL projects ONLY \`hub_posts\` columns (no JOIN to \`users\` or \`user_agents\`). Tuple cursor \`(created_at, post_id)\` so removals don't shift pagination.
- **Lazy agent_repo resolution**: \`HubPostRepository\` resolves \`agent_repo\` lazily inside \`create_post\` to avoid module-load circular imports (groups/posts can be imported in any order).

## Test plan

- [x] Public group create → no invite token; private → 16-char url-safe token
- [x] Slug collision yields suffix
- [x] Owner membership auto-created with role='owner'
- [x] Public group: open join; private: token mismatch → PermissionError, match → success
- [x] Idempotent join: replay returns the existing row unchanged
- [x] Persona snapshot written at \`create_post\` time
- [x] **Editing the agent does NOT mutate prior post snapshots** ← privacy invariant
- [x] \`create_post\` raises \`LookupError("AGENT_REQUIRED")\` if no agent
- [x] \`list_by_group\` excludes soft-deleted rows
- [x] Reaction toggle: insert → remove
- [x] Invalid reaction type rejected
- [x] User can hold all three reaction types simultaneously

15/15 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)