### PR TITLE
feat(my-agent): RequireOnboarded route gate + My Agent nav entry (#444)

### DIFF
--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react'
 import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
+import { shouldRedirectToOnboarding } from './requireOnboarded'
 import { AnimatedBackground } from '@/components/depth/AnimatedBackground'
 import { ConfettiController } from '@/components/effects/Confetti'
 import GenerationStatusBar from '@/components/layout/GenerationStatusBar'
@@ -27,6 +29,31 @@ function PageContainerInner() {
   const totalStars = useDailyTaskStore((s) => s.totalStars)
 
   useGenerationNavigator()
+
+  // RequireOnboarded gate (#444): when an authenticated user has not yet
+  // finished onboarding (no users.onboarded_at), funnel them to /my-agent
+  // so they meet their buddy and parent grants consent before the rest
+  // of the app is available. The gate predicate is extracted to
+  // requireOnboarded.ts so it's unit-testable.
+  useEffect(() => {
+    if (
+      !shouldRedirectToOnboarding({
+        isAuthenticated,
+        onboardedAt: user?.onboarded_at,
+        pathname: location.pathname,
+      })
+    ) {
+      return
+    }
+    const ret = encodeURIComponent(location.pathname + location.search)
+    navigate(`/my-agent?return=${ret}`, { replace: true })
+  }, [
+    isAuthenticated,
+    user?.onboarded_at,
+    location.pathname,
+    location.search,
+    navigate,
+  ])
 
   const handleLogout = async () => {
     try {
@@ -66,6 +93,7 @@ function PageContainerInner() {
             {/* Navigation links */}
             <div className="flex items-center gap-4">
               <NavLink to="/library" icon="📚" label="My Library" />
+              <NavLink to="/my-agent" icon="🦊" label="My Agent" />
 
               {/* Auth section */}
               {isAuthenticated ? (

--- a/frontend/src/components/layout/PageContainer/requireOnboarded.test.ts
+++ b/frontend/src/components/layout/PageContainer/requireOnboarded.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { shouldRedirectToOnboarding } from "./requireOnboarded";
+
+describe("shouldRedirectToOnboarding", () => {
+  it("does NOT redirect anonymous users", () => {
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: false,
+        onboardedAt: null,
+        pathname: "/library",
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT redirect users who have already onboarded", () => {
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: true,
+        onboardedAt: "2026-01-01T00:00:00",
+        pathname: "/library",
+      }),
+    ).toBe(false);
+  });
+
+  it("redirects authenticated, not-yet-onboarded users on a guarded path", () => {
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: true,
+        onboardedAt: null,
+        pathname: "/library",
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT redirect when already on /my-agent (avoids loops)", () => {
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: true,
+        onboardedAt: null,
+        pathname: "/my-agent",
+      }),
+    ).toBe(false);
+  });
+
+  it("does NOT redirect on /login or /register so the user can sign in / out", () => {
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: true,
+        onboardedAt: null,
+        pathname: "/login",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: true,
+        onboardedAt: null,
+        pathname: "/register",
+      }),
+    ).toBe(false);
+  });
+
+  it("treats undefined onboardedAt the same as null (fresh user)", () => {
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: true,
+        onboardedAt: undefined,
+        pathname: "/upload",
+      }),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/components/layout/PageContainer/requireOnboarded.ts
+++ b/frontend/src/components/layout/PageContainer/requireOnboarded.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure helper that decides whether the RequireOnboarded effect in
+ * PageContainer should redirect the current request to /my-agent.
+ *
+ * Extracted so it's unit-testable without mounting the page tree
+ * (the project does not depend on @testing-library/react).
+ *
+ * Issue: #444 | Parent epic: #436
+ */
+
+export interface OnboardingGateInput {
+  isAuthenticated: boolean;
+  onboardedAt: string | null | undefined;
+  pathname: string;
+}
+
+export function shouldRedirectToOnboarding(
+  input: OnboardingGateInput,
+): boolean {
+  const { isAuthenticated, onboardedAt, pathname } = input;
+  if (!isAuthenticated) return false;
+  if (onboardedAt) return false;
+  if (pathname === "/my-agent") return false;
+  if (pathname.startsWith("/login")) return false;
+  if (pathname.startsWith("/register")) return false;
+  return true;
+}


### PR DESCRIPTION
Fixes #444

Parent epic: #436

## Summary

Adds the route-level gate that funnels first-login users into \`/my-agent\` before they can use the rest of the app, plus the \`My Agent\` nav entry next to \`My Library\`.

## Pieces

- \`PageContainer/requireOnboarded.ts\` — pure predicate \`shouldRedirectToOnboarding({ isAuthenticated, onboardedAt, pathname })\` that returns true iff the gate should fire.
- \`PageContainer/index.tsx\` — \`useEffect\` calls \`navigate('/my-agent?return=<encoded>', { replace: true })\` whenever the predicate flips true. Exempts \`/my-agent\`, \`/login\`, \`/register\` so the user can complete onboarding and so sign-in/out aren't blocked.
- New \`<NavLink to=\"/my-agent\" icon=\"🦊\" label=\"My Agent\" />\` rendered between \`/library\` and the avatar.

## Test plan

6 logic-only vitest cases on \`shouldRedirectToOnboarding\`:
- [x] Anonymous → no redirect
- [x] Already-onboarded → no redirect
- [x] Authenticated, not onboarded, on a guarded path → redirect
- [x] Already on \`/my-agent\` → no redirect (anti-loop)
- [x] On \`/login\` or \`/register\` → no redirect
- [x] Undefined \`onboardedAt\` is treated the same as \`null\`

All 6 pass; \`tsc --noEmit\` clean.

## Out of scope

- OnboardingModal that auto-opens on \`/my-agent\` for first-login users (#443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)