### PR TITLE
feat(my-agent): first-login OnboardingModal with age-gated copy variants (#443)

### DIFF
--- a/frontend/src/api/services/onboardingService.ts
+++ b/frontend/src/api/services/onboardingService.ts
@@ -1,0 +1,22 @@
+/**
+ * Onboarding Service — wrapper for POST /me/onboarding/complete (#440).
+ * Returns the full UserResponse so the auth store can sync onboarded_at
+ * and parent_consent_at without a second round-trip.
+ */
+
+import apiClient from "../client";
+import type { User } from "@/types/auth";
+
+export interface CompleteOnboardingPayload {
+  parent_consent: boolean;
+  child_id: string;
+}
+
+export async function completeOnboarding(
+  payload: CompleteOnboardingPayload,
+): Promise<User> {
+  const r = await apiClient.post<User>("/me/onboarding/complete", payload);
+  return r.data;
+}
+
+export const onboardingService = { completeOnboarding };

--- a/frontend/src/pages/MyAgentPage/OnboardingModal.tsx
+++ b/frontend/src/pages/MyAgentPage/OnboardingModal.tsx
@@ -1,0 +1,373 @@
+/**
+ * OnboardingModal — first-login auto-opening flow that walks the user
+ * through naming, avatar, title, and a parent-consent gate, then calls
+ * POST /me/onboarding/complete (#440) to flip users.onboarded_at on
+ * the server and sync the auth store.
+ *
+ * Per PRD §3.11.2 the step list shrinks for younger children:
+ *   3-5: avatar-only path with auto-suggested buddy name
+ *   6-8: name + avatar + curated title
+ *   9-12: full flow with optional free-text title
+ *
+ * Pure step-decision logic lives in onboardingState.ts so it's unit-testable
+ * without mounting the modal.
+ *
+ * Issue: #443 | Parent epic: #436
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { AxiosError } from "axios";
+import { ANIMAL_EMOJIS } from "@/lib/avatars";
+import { CURATED_TITLES, customTitleAllowed } from "@/lib/agentTitles";
+import { useUpsertAgent } from "@/hooks/useAgent";
+import { onboardingService } from "@/api/services/onboardingService";
+import useAuthStore from "@/store/useAuthStore";
+import type { AgeGroup } from "@/types/api";
+import type { AgentErrorDetail } from "@/types/agent";
+import {
+  AUTO_NAME_SUGGESTIONS,
+  stepsForAge,
+  type OnboardingStepKey,
+} from "./onboardingState";
+
+const MAX_NAME = 32;
+const MAX_TITLE = 32;
+
+interface Props {
+  open: boolean;
+  childId: string;
+  ageGroup: AgeGroup | undefined | null;
+  onClose: () => void;
+}
+
+function avatarIdFor(emoji: string): string {
+  return `emoji:${emoji}`;
+}
+
+function detailFrom(err: unknown): AgentErrorDetail | null {
+  if (!(err instanceof AxiosError)) return null;
+  const data = err.response?.data;
+  if (data && typeof data === "object" && "detail" in data) {
+    const d = (data as { detail: unknown }).detail;
+    if (d && typeof d === "object" && "code" in d) {
+      return d as AgentErrorDetail;
+    }
+  }
+  return null;
+}
+
+function pickRandomName(): string {
+  const i = Math.floor(Math.random() * AUTO_NAME_SUGGESTIONS.length);
+  return AUTO_NAME_SUGGESTIONS[i];
+}
+
+export default function OnboardingModal({
+  open,
+  childId,
+  ageGroup,
+  onClose,
+}: Props) {
+  const upsert = useUpsertAgent();
+  const setUser = useAuthStore((s) => s.setUser);
+
+  const steps = useMemo(() => stepsForAge(ageGroup), [ageGroup]);
+  const [stepIdx, setStepIdx] = useState(0);
+  const [name, setName] = useState(() =>
+    ageGroup === "3-5" ? pickRandomName() : "",
+  );
+  const [avatarId, setAvatarId] = useState<string>(
+    avatarIdFor(ANIMAL_EMOJIS[0]),
+  );
+  const [title, setTitle] = useState<string>(CURATED_TITLES[0]);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Reset state whenever the modal is opened so a re-open shows step 1.
+  useEffect(() => {
+    if (open) {
+      setStepIdx(0);
+      setError(null);
+      if (ageGroup === "3-5" && !name.trim()) {
+        setName(pickRandomName());
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!open) return null;
+  const currentStep: OnboardingStepKey | undefined = steps[stepIdx];
+  const isLast = stepIdx >= steps.length - 1;
+
+  const goNext = () => {
+    setError(null);
+    if (stepIdx < steps.length - 1) {
+      setStepIdx(stepIdx + 1);
+    }
+  };
+
+  const goBack = () => {
+    setError(null);
+    if (stepIdx > 0) setStepIdx(stepIdx - 1);
+  };
+
+  const handleConsent = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      // 1. Upsert the buddy (safety-checked server-side).
+      await upsert.mutateAsync({
+        agent_name: name.trim(),
+        agent_avatar_id: avatarId,
+        agent_title: title.trim(),
+        child_id: childId,
+      });
+      // 2. Mark onboarding complete with parent consent.
+      const updated = await onboardingService.completeOnboarding({
+        parent_consent: true,
+        child_id: childId,
+      });
+      // 3. Sync the auth store so RequireOnboarded stops redirecting.
+      setUser(updated);
+      onClose();
+    } catch (err) {
+      const detail = detailFrom(err);
+      if (detail?.code === "INVALID_AVATAR") {
+        setError("Pick a different animal — that one isn't allowed.");
+        setStepIdx(steps.indexOf("avatar"));
+      } else if (
+        detail?.code === "UNSAFE_AGENT_NAME" ||
+        detail?.code === "INVALID_AGENT_NAME"
+      ) {
+        setError(detail.reason ?? "Try a different name.");
+        const ni = steps.indexOf("name");
+        if (ni >= 0) setStepIdx(ni);
+      } else if (
+        detail?.code === "UNSAFE_AGENT_TITLE" ||
+        detail?.code === "INVALID_AGENT_TITLE"
+      ) {
+        setError(detail.reason ?? "Try a different title.");
+        const ti = steps.indexOf("title");
+        if (ti >= 0) setStepIdx(ti);
+      } else if (detail?.code === "SAFETY_UNAVAILABLE") {
+        setError("Our safety checker is taking a break. Try again in a minute.");
+      } else {
+        setError("We couldn't save your buddy. Try again in a moment.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="onboarding-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
+    >
+      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        <header className="flex flex-col gap-1">
+          <p className="text-xs uppercase tracking-wide text-violet-600">
+            Step {stepIdx + 1} of {steps.length}
+          </p>
+          <h2 id="onboarding-title" className="text-xl font-semibold text-gray-900">
+            {currentStep === "greeting" && "Hi! I'm your creative buddy."}
+            {currentStep === "name" && "What should I call you?"}
+            {currentStep === "avatar" && "Which animal am I?"}
+            {currentStep === "title" && "What's my title?"}
+            {currentStep === "consent" && "Meet your child's creative buddy"}
+          </h2>
+        </header>
+
+        <div className="mt-4 flex flex-col gap-4">
+          {currentStep === "greeting" && (
+            <div className="flex flex-col gap-2 text-sm text-gray-700">
+              <p>
+                I'm going to help you make stories. Let's pick what I look like
+                and what you call me — you can always change it later.
+              </p>
+            </div>
+          )}
+
+          {currentStep === "name" && (
+            <div className="flex flex-col gap-2">
+              <label htmlFor="ob-name" className="text-sm font-medium text-gray-700">
+                Buddy name
+              </label>
+              <input
+                id="ob-name"
+                type="text"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                value={name}
+                maxLength={MAX_NAME}
+                onChange={(e) => setName(e.target.value.slice(0, MAX_NAME))}
+                placeholder="e.g. Sparkle"
+              />
+              <p className="text-xs text-gray-500">
+                {name.length}/{MAX_NAME}
+              </p>
+            </div>
+          )}
+
+          {currentStep === "avatar" && (
+            <div className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-gray-700">
+                Pick an animal
+              </span>
+              <div role="radiogroup" className="grid grid-cols-5 gap-2">
+                {ANIMAL_EMOJIS.map((emoji) => {
+                  const id = avatarIdFor(emoji);
+                  const selected = avatarId === id;
+                  return (
+                    <button
+                      key={emoji}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      aria-label={`Choose ${emoji}`}
+                      onClick={() => setAvatarId(id)}
+                      className={[
+                        "flex aspect-square items-center justify-center rounded-xl border-2 text-2xl transition-colors",
+                        selected
+                          ? "border-violet-500 bg-violet-50"
+                          : "border-gray-200 hover:border-gray-300",
+                      ].join(" ")}
+                    >
+                      {emoji}
+                    </button>
+                  );
+                })}
+              </div>
+              {ageGroup === "3-5" && (
+                <p className="text-xs text-gray-500">
+                  We'll call your buddy <strong>{name}</strong>. Tap{" "}
+                  <button
+                    type="button"
+                    className="text-violet-600 underline"
+                    onClick={() => setName(pickRandomName())}
+                  >
+                    🔀 shuffle
+                  </button>{" "}
+                  for a different name.
+                </p>
+              )}
+            </div>
+          )}
+
+          {currentStep === "title" && (
+            <div className="flex flex-col gap-2">
+              <label className="text-sm font-medium text-gray-700">
+                Pick a title
+              </label>
+              <select
+                className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                value={CURATED_TITLES.includes(title as never) ? title : "__custom__"}
+                onChange={(e) => {
+                  if (e.target.value === "__custom__") setTitle("");
+                  else setTitle(e.target.value);
+                }}
+              >
+                {CURATED_TITLES.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+                {customTitleAllowed(ageGroup) && (
+                  <option value="__custom__">✏️ Custom title</option>
+                )}
+              </select>
+              {customTitleAllowed(ageGroup) &&
+                !CURATED_TITLES.includes(title as never) && (
+                  <input
+                    type="text"
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    value={title}
+                    maxLength={MAX_TITLE}
+                    onChange={(e) =>
+                      setTitle(e.target.value.slice(0, MAX_TITLE))
+                    }
+                    placeholder="Type a custom title (1-32 chars)"
+                  />
+                )}
+            </div>
+          )}
+
+          {currentStep === "consent" && (
+            <div className="flex flex-col gap-3 text-sm text-gray-700">
+              <p className="font-medium">For the parent / guardian</p>
+              <p>
+                This buddy is the name and animal your child picks to show on
+                stories they share publicly in Content Hub. We never show your
+                child's real name, email, or username — only the buddy.
+              </p>
+              <p>
+                You can change the buddy any time from "My Agent". Past stories
+                keep the buddy that posted them, so your child's creative
+                timeline stays consistent.
+              </p>
+              <p className="text-xs text-gray-500">
+                Note: We re-check the buddy's name and title for safety every
+                time it's edited.
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <footer className="mt-6 flex items-center justify-between">
+          {stepIdx > 0 ? (
+            <button
+              type="button"
+              className="text-sm font-medium text-gray-600 hover:text-gray-900"
+              onClick={goBack}
+              disabled={busy}
+            >
+              ← Back
+            </button>
+          ) : (
+            <span />
+          )}
+
+          {currentStep === "consent" ? (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                onClick={onClose}
+                disabled={busy}
+              >
+                Not now
+              </button>
+              <button
+                type="button"
+                className="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700 disabled:bg-gray-300"
+                onClick={handleConsent}
+                disabled={busy || !name.trim() || !title.trim()}
+              >
+                {busy ? "Saving…" : "I'm a parent and I'm OK with this"}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700 disabled:bg-gray-300"
+              onClick={goNext}
+              disabled={
+                (currentStep === "name" && !name.trim()) ||
+                (currentStep === "title" && !title.trim()) ||
+                isLast
+              }
+            >
+              Next →
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MyAgentPage/index.tsx
+++ b/frontend/src/pages/MyAgentPage/index.tsx
@@ -20,8 +20,11 @@ import { useEffect, useMemo, useState } from "react";
 import { AxiosError } from "axios";
 import { ANIMAL_EMOJIS } from "@/lib/avatars";
 import useChildStore from "@/store/useChildStore";
+import useAuthStore from "@/store/useAuthStore";
 import { useAgent, useUpsertAgent } from "@/hooks/useAgent";
 import AgentTitlePicker from "./AgentTitlePicker";
+import OnboardingModal from "./OnboardingModal";
+import { shouldAutoOpenOnboarding } from "./onboardingState";
 import type { AgentErrorDetail } from "@/types/agent";
 
 const MAX_NAME = 32;
@@ -57,6 +60,25 @@ export default function MyAgentPage() {
 
   const { data: existing, isLoading } = useAgent(childId);
   const upsert = useUpsertAgent();
+
+  // First-login modal: auto-opens when authenticated user has not yet
+  // completed onboarding (#443). The modal walks through name/avatar/title
+  // + parent consent and calls POST /me/onboarding/complete on submit.
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const onboardedAt = useAuthStore((s) => s.user?.onboarded_at);
+  const [modalOpen, setModalOpen] = useState(false);
+  useEffect(() => {
+    if (isLoading) return;
+    if (
+      shouldAutoOpenOnboarding({
+        isAuthenticated,
+        onboardedAt,
+        hasExistingAgent: existing != null,
+      })
+    ) {
+      setModalOpen(true);
+    }
+  }, [isAuthenticated, onboardedAt, existing, isLoading]);
 
   const [name, setName] = useState("");
   const [avatarId, setAvatarId] = useState<string>(
@@ -144,6 +166,12 @@ export default function MyAgentPage() {
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8">
+      <OnboardingModal
+        open={modalOpen}
+        childId={childId}
+        ageGroup={ageGroup}
+        onClose={() => setModalOpen(false)}
+      />
       <header className="flex flex-col gap-1">
         <h1 className="text-2xl font-semibold text-gray-900">{childGreeting}</h1>
         <p className="text-sm text-gray-600">

--- a/frontend/src/pages/MyAgentPage/onboardingState.test.ts
+++ b/frontend/src/pages/MyAgentPage/onboardingState.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_NAME_SUGGESTIONS,
+  shouldAutoOpenOnboarding,
+  stepsForAge,
+} from "./onboardingState";
+
+describe("shouldAutoOpenOnboarding", () => {
+  it("does NOT open for anonymous users", () => {
+    expect(
+      shouldAutoOpenOnboarding({
+        isAuthenticated: false,
+        onboardedAt: null,
+        hasExistingAgent: false,
+      }),
+    ).toBe(false);
+  });
+  it("does NOT open if onboardedAt is set", () => {
+    expect(
+      shouldAutoOpenOnboarding({
+        isAuthenticated: true,
+        onboardedAt: "2026-01-01T00:00:00",
+        hasExistingAgent: true,
+      }),
+    ).toBe(false);
+  });
+  it("opens when authenticated + not onboarded yet (no agent)", () => {
+    expect(
+      shouldAutoOpenOnboarding({
+        isAuthenticated: true,
+        onboardedAt: null,
+        hasExistingAgent: false,
+      }),
+    ).toBe(true);
+  });
+  it("opens when authenticated + not onboarded yet (agent exists but consent missing)", () => {
+    expect(
+      shouldAutoOpenOnboarding({
+        isAuthenticated: true,
+        onboardedAt: undefined,
+        hasExistingAgent: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("stepsForAge", () => {
+  it("3-5 gets a stripped flow without name/title steps", () => {
+    expect(stepsForAge("3-5")).toEqual(["greeting", "avatar", "consent"]);
+  });
+  it("6-8 gets the full flow", () => {
+    expect(stepsForAge("6-8")).toEqual([
+      "greeting",
+      "name",
+      "avatar",
+      "title",
+      "consent",
+    ]);
+  });
+  it("9-12 gets the full flow", () => {
+    expect(stepsForAge("9-12")).toEqual([
+      "greeting",
+      "name",
+      "avatar",
+      "title",
+      "consent",
+    ]);
+  });
+  it("undefined age falls back to the full flow", () => {
+    expect(stepsForAge(undefined)).toEqual([
+      "greeting",
+      "name",
+      "avatar",
+      "title",
+      "consent",
+    ]);
+  });
+});
+
+describe("AUTO_NAME_SUGGESTIONS", () => {
+  it("has at least 4 entries with no duplicates", () => {
+    expect(AUTO_NAME_SUGGESTIONS.length).toBeGreaterThanOrEqual(4);
+    const seen = new Set(AUTO_NAME_SUGGESTIONS);
+    expect(seen.size).toBe(AUTO_NAME_SUGGESTIONS.length);
+  });
+});

--- a/frontend/src/pages/MyAgentPage/onboardingState.ts
+++ b/frontend/src/pages/MyAgentPage/onboardingState.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure helpers that drive the OnboardingModal's auto-open and step
+ * sequencing. Extracted so they're unit-testable without mounting the
+ * page tree (the project does not depend on @testing-library/react).
+ *
+ * Issue: #443 | Parent epic: #436
+ */
+
+import type { AgeGroup } from "@/types/api";
+
+export interface AutoOpenInput {
+  isAuthenticated: boolean;
+  /** users.onboarded_at returned from /me. null/undefined = not yet. */
+  onboardedAt: string | null | undefined;
+  /** Existing agent for the active child (null if none yet). */
+  hasExistingAgent: boolean;
+}
+
+export function shouldAutoOpenOnboarding(input: AutoOpenInput): boolean {
+  if (!input.isAuthenticated) return false;
+  if (input.onboardedAt) return false;
+  // Show onboarding even if an agent already exists — onboarding completion
+  // is gated by parent consent, not by agent existence. A user might have
+  // saved a buddy in a prior session and bounced before parent consent.
+  return true;
+}
+
+export type OnboardingStepKey =
+  | "greeting"
+  | "name"
+  | "avatar"
+  | "title"
+  | "consent";
+
+/**
+ * Per-PRD §3.11.2 the onboarding flow shrinks for younger children:
+ *   3-5: avatar-only path with auto-named buddy
+ *   6-8: name + avatar + curated title
+ *   9-12: full flow with optional free-text title + nickname step
+ *
+ * The greeting and consent steps appear for all age groups.
+ */
+export function stepsForAge(age: AgeGroup | undefined | null): OnboardingStepKey[] {
+  if (age === "3-5") {
+    return ["greeting", "avatar", "consent"];
+  }
+  return ["greeting", "name", "avatar", "title", "consent"];
+}
+
+/**
+ * For 3-5 we auto-suggest a buddy name so the child doesn't have to
+ * type. The name skips the safety check on the server because it comes
+ * from a curated server-vetted pool — but to keep things simple we
+ * pull from a small client-side list and let the standard safety
+ * pipeline run on it. None of these strings should fail the safety
+ * gate.
+ */
+export const AUTO_NAME_SUGGESTIONS = [
+  "Sunny",
+  "Bubbles",
+  "Rosie",
+  "Pip",
+  "Coco",
+  "Toto",
+  "Luna",
+  "Dot",
+] as const;


### PR DESCRIPTION
Fixes #443

Parent epic: #436
Depends on #439 (PUT /me/agent), #440 (POST /me/onboarding/complete), #442 (MyAgentPage host) — all on main.

## Summary

Auto-opening modal that walks a first-login user through naming, avatar, title, and a parent-consent gate, then submits via PUT /me/agent + POST /me/onboarding/complete and syncs the auth store so the RequireOnboarded gate from #444 stops redirecting.

## Step list (PRD §3.11.2)

| Age | Steps |
|---|---|
| 3-5 | greeting → avatar → consent (buddy auto-named with a shuffle affordance) |
| 6-8 | greeting → name → avatar → title (curated dropdown) → consent |
| 9-12 | greeting → name → avatar → title (curated **or** custom free-text) → consent |

## Pieces

- \`onboardingState.ts\` — pure helpers: \`shouldAutoOpenOnboarding\`, \`stepsForAge\`, \`AUTO_NAME_SUGGESTIONS\`. Unit-tested.
- \`OnboardingModal.tsx\` — step-driven wizard. Maps server \`detail.code\` back to the right step on rejection.
- \`onboardingService.ts\` — \`completeOnboarding({ parent_consent, child_id })\` wrapper around POST /me/onboarding/complete, returns the updated \`User\`.
- \`MyAgentPage/index.tsx\` — wires the modal: auto-opens when \`shouldAutoOpenOnboarding\` returns true.

## Parent-consent copy

Locked to PRD §3.11.2 wording:

> This buddy is the name and animal your child picks to show on stories they share publicly in Content Hub. We never show your child's real name, email, or username — only the buddy.
>
> You can change the buddy any time from "My Agent". Past stories keep the buddy that posted them, so your child's creative timeline stays consistent.

CTAs: \`I'm a parent and I'm OK with this\` / \`Not now\`.

## Test plan

9 logic-only vitest cases on \`onboardingState.ts\`:
- [x] \`shouldAutoOpenOnboarding\`: anonymous (no), already-onboarded (no), authenticated + not onboarded (yes — both with and without an existing agent)
- [x] \`stepsForAge\`: 3-5 stripped, 6-8 + 9-12 + undefined full
- [x] \`AUTO_NAME_SUGGESTIONS\`: ≥4 entries, no duplicates

All 9 pass; \`tsc --noEmit\` clean.

Page-render tests deferred until \`@testing-library/react\` is a project dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)