### PR TITLE
feat(my-agent): show buddy byline on My Library cards (#445)

### DIFF
--- a/frontend/src/components/common/AgentBylineChip.tsx
+++ b/frontend/src/components/common/AgentBylineChip.tsx
@@ -1,0 +1,35 @@
+/**
+ * AgentBylineChip — small "By <buddy>" tile reused across surfaces (#445).
+ *
+ * Renders nothing when the agent prop is missing so callers don't have
+ * to gate the render. Avatar uses the existing AvatarDisplay component
+ * which already understands the "emoji:<emoji>" prefix used by the
+ * shared avatar whitelist.
+ *
+ * Issue: #445 | Parent epic: #436
+ */
+
+import AvatarDisplay from "@/components/common/AvatarDisplay";
+import type { Agent } from "@/types/agent";
+
+interface Props {
+  agent: Agent | null | undefined;
+  className?: string;
+}
+
+export default function AgentBylineChip({ agent, className = "" }: Props) {
+  if (!agent) return null;
+  const text = `By ${agent.agent_name} the ${agent.agent_title}`;
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 text-xs text-gray-500 ${className}`}
+      title={text}
+    >
+      <AvatarDisplay avatarUrl={agent.agent_avatar_id} size="sm" />
+      <span className="truncate">
+        By <span className="font-semibold text-gray-700">{agent.agent_name}</span>{" "}
+        the {agent.agent_title}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/pages/LibraryPage/index.tsx
+++ b/frontend/src/pages/LibraryPage/index.tsx
@@ -25,6 +25,9 @@ import type {
   LibraryItemType,
   LibrarySortOrder,
 } from "@/api/services/libraryService";
+import { useAgent } from "@/hooks/useAgent";
+import AgentBylineChip from "@/components/common/AgentBylineChip";
+import type { Agent } from "@/types/agent";
 import { useLibraryPreferences } from "@/hooks/useLibraryPreferences";
 import MiniPlayer from "@/components/common/MiniPlayer";
 import { getAgeLayoutConfig } from "@/config/ageConfig";
@@ -357,6 +360,7 @@ function LibraryCard({
   showFavorite,
   onFavoriteToggled,
   showWordCount = true,
+  agent,
 }: {
   item: LibraryItem;
   onClick: () => void;
@@ -364,6 +368,7 @@ function LibraryCard({
   showFavorite: boolean;
   onFavoriteToggled?: () => void;
   showWordCount?: boolean;
+  agent?: Agent | null;
 }) {
   const [imgError, setImgError] = useState(false);
   const imgSrc = (item as any).thumbnail_url || item.image_url;
@@ -467,6 +472,9 @@ function LibraryCard({
               <h3 className="text-base font-bold text-gray-800 line-clamp-2">
                 {item.title}
               </h3>
+              {agent && (
+                <AgentBylineChip agent={agent} className="mt-1" />
+              )}
             </div>
             <div className="flex items-center gap-1.5 flex-shrink-0">
               {showFavorite && (
@@ -567,6 +575,7 @@ function ListRow({
   showFavorite,
   onFavoriteToggled,
   showWordCount = true,
+  agent,
 }: {
   item: LibraryItem;
   onClick: () => void;
@@ -574,6 +583,7 @@ function ListRow({
   showFavorite: boolean;
   onFavoriteToggled?: () => void;
   showWordCount?: boolean;
+  agent?: Agent | null;
 }) {
   const [imgError, setImgError] = useState(false);
   const imgSrc = (item as any).thumbnail_url || item.image_url;
@@ -665,6 +675,9 @@ function ListRow({
                 <h4 className="text-base font-semibold text-gray-800 line-clamp-2">
                   {item.title}
                 </h4>
+                {agent && (
+                  <AgentBylineChip agent={agent} className="mt-1" />
+                )}
               </div>
               <div className="flex items-center gap-1.5 flex-shrink-0">
                 {showFavorite && (
@@ -754,8 +767,16 @@ function LibraryPage() {
   const { storyHistory, clearHistory, setCurrentStory, removeStory } =
     useStoryStore();
   const { isAuthenticated, user } = useAuthStore();
-  const { currentChild } = useChildStore();
+  const { currentChild, defaultChildId } = useChildStore();
   const { viewMode, toggleViewMode } = useLibraryPreferences();
+  const childIdForAgent = currentChild?.child_id ?? defaultChildId;
+  // Buddy byline (#445) — fetched once for the page; passed into
+  // LibraryCard / ListRow so a single agent lookup decorates every card.
+  // Disabled when unauthenticated (the hook already guards on a missing
+  // child id, but we double-guard here to avoid an extra request).
+  const { data: pageAgent } = useAgent(
+    isAuthenticated ? childIdForAgent : undefined,
+  );
   const ageLayout = getAgeLayoutConfig(currentChild?.age_group);
   const isParent = user?.role === "parent";
   const canShowGrowthTimeline = ageLayout.showGrowthTimeline || isParent;
@@ -1106,6 +1127,7 @@ function LibraryPage() {
                         showFavorite={isAuthenticated}
                         onFavoriteToggled={handleFavoriteToggled}
                         showWordCount={ageLayout.showWordCount}
+                        agent={pageAgent}
                       />
                     ) : (
                       <LibraryCard
@@ -1115,6 +1137,7 @@ function LibraryPage() {
                         showFavorite={isAuthenticated}
                         onFavoriteToggled={handleFavoriteToggled}
                         showWordCount={ageLayout.showWordCount}
+                        agent={pageAgent}
                       />
                     )}
                   </motion.div>


### PR DESCRIPTION
Fixes #445

Parent epic: #436

## Summary

Adds a small \"By <buddy> the <title>\" chip under the title on every \`LibraryCard\` and \`ListRow\` in \`/library\`, so children see a consistent buddy identity across their private library and any future Content Hub posts (#452).

## Pieces

- New \`AgentBylineChip\` component (\`frontend/src/components/common/\`) — reuses \`AvatarDisplay\` which already understands the \`emoji:<emoji>\` prefix. Returns \`null\` when the agent is missing so callers don't have to gate the render. Will be reused by the Content Hub \`PostCard\` (#452).
- \`LibraryPage.tsx\` — calls \`useAgent(childId)\` once at the page level (gated on \`isAuthenticated\`) and threads the result into \`LibraryCard\` / \`ListRow\` via an optional \`agent\` prop.

## Why a page-level fetch (and not per-card)

Today the buddy is per \`(user_id, child_id)\` — there is exactly one visible buddy on \`/library\` at any moment, so caching it at the page level is correct and avoids a per-card request fan-out. When child profiles become first-class with multiple children visible at once, this can be revisited.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Renders nothing when no agent (e.g. unauthenticated, or agent not yet created)

Page-render tests deferred until \`@testing-library/react\` is a project dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)