### PR TITLE
feat(hub): GET/POST /hub/groups + join endpoints (#448)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -838,6 +838,50 @@ class CompleteOnboardingRequest(BaseModel):
     child_id: str = Field(..., min_length=1, description="Child profile being onboarded")
 
 
+# ---------------------------------------------------------------------------
+# Content Hub — groups (#448)
+# ---------------------------------------------------------------------------
+
+
+class CreateGroupRequest(BaseModel):
+    """POST /hub/groups body."""
+    name: str = Field(..., min_length=1, max_length=80, description="Group display name")
+    visibility: str = Field(..., description="public | private")
+    description: Optional[str] = Field(None, max_length=500)
+    theme: Optional[str] = Field(None, max_length=50, description="Optional theme tag, e.g. 'fantasy'")
+
+
+class GroupResponse(BaseModel):
+    """Group payload returned to clients.
+
+    invite_token is intentionally Optional — it is included ONLY in the
+    create-response (to the owner) or in get-by-id when the caller IS
+    the group's owner. List/get responses to non-owners must scrub it.
+    """
+    group_id: str
+    slug: str
+    name: str
+    description: Optional[str] = None
+    theme: Optional[str] = None
+    visibility: str
+    invite_token: Optional[str] = None
+    created_at: str
+    member_count: int
+
+
+class ListGroupsResponse(BaseModel):
+    """GET /hub/groups response."""
+    items: List[GroupResponse]
+    total: int
+
+
+class JoinGroupResponse(BaseModel):
+    """POST /hub/groups/{id}/join response."""
+    group_id: str
+    role: str
+    joined_at: str
+
+
 class ReferralStatusResponse(BaseModel):
     """Referral progress and membership tier status (PRD §3.9.4)"""
     referral_code: str = Field(..., description="User's unique referral code")

--- a/backend/src/api/routes/hub/__init__.py
+++ b/backend/src/api/routes/hub/__init__.py
@@ -1,0 +1,18 @@
+"""
+Content Hub Routes (Epic #437).
+
+Aggregates the sub-routers under one importable `hub` module so:
+  - main.py registers a single `app.include_router(hub.router)`.
+  - The COPPA contract test (#450) finds the package via
+    `from src.api.routes import hub`, which flips its skipif gate
+    from True to False and activates the privacy invariant tests.
+"""
+
+from fastapi import APIRouter
+
+from . import groups
+
+router = APIRouter()
+router.include_router(groups.router)
+
+__all__ = ["router"]

--- a/backend/src/api/routes/hub/groups.py
+++ b/backend/src/api/routes/hub/groups.py
@@ -1,0 +1,195 @@
+"""
+Hub Group Routes (#448) — list, create, join, get.
+
+Endpoints
+  GET  /api/v1/hub/groups               -> list (public + caller's private)
+  POST /api/v1/hub/groups               -> create (public or private)
+  GET  /api/v1/hub/groups/{group_id}    -> detail
+  POST /api/v1/hub/groups/{group_id}/join -> join, optional ?invite=token
+
+Behaviour
+  - Public groups: open join (any onboarded user).
+  - Private groups: invite_token must match the row at create time.
+  - Private invite_token is exposed ONCE in the create response so the
+    inviter can copy/paste a link. List/get responses NEVER expose the
+    invite_token to anyone other than members. (Safety belt: the
+    response model omits the field for non-members.)
+
+Onboarding gate
+  Posting requires onboarding (#440) — but joining/listing does not.
+  The narrow check is: any user with a valid auth token can browse
+  public groups; only onboarded users can join. We enforce join's
+  onboarding requirement so we never end up with members who can't
+  actually post anything to the group.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from ...deps import get_current_user
+from ...models import (
+    CreateGroupRequest,
+    GroupResponse,
+    JoinGroupResponse,
+    ListGroupsResponse,
+)
+from ....services.database import group_repo
+from ....services.user_service import UserData
+
+
+router = APIRouter(prefix="/api/v1/hub/groups", tags=["Content Hub"])
+
+
+def _to_response(group, *, include_invite_token: bool = False) -> GroupResponse:
+    """Convert GroupData to GroupResponse.
+
+    Privacy: invite_token is included ONLY when include_invite_token=True
+    (e.g. on create-response or for an owner viewing their own group).
+    """
+    return GroupResponse(
+        group_id=group.group_id,
+        slug=group.slug,
+        name=group.name,
+        description=group.description,
+        theme=group.theme,
+        visibility=group.visibility,
+        invite_token=group.invite_token if include_invite_token else None,
+        created_at=group.created_at,
+        member_count=group.member_count,
+    )
+
+
+def _require_onboarded(user: UserData) -> None:
+    """Common helper: a user must have onboarded_at set to act on groups."""
+    if user.onboarded_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "ONBOARDING_REQUIRED"},
+        )
+
+
+@router.get(
+    "",
+    response_model=ListGroupsResponse,
+    summary="List groups (public + caller's private)",
+)
+async def list_groups(
+    user: UserData = Depends(get_current_user),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    public = await group_repo.list_public(limit=limit, offset=offset)
+    if user.default_child_id:
+        joined = await group_repo.list_for_member(
+            user_id=user.user_id, child_id=user.default_child_id
+        )
+    else:
+        joined = []
+
+    seen_ids = {g.group_id for g in public}
+    # Include any private groups the caller is a member of, deduped.
+    extras = [g for g in joined if g.group_id not in seen_ids]
+    items = [_to_response(g) for g in public] + [
+        _to_response(g, include_invite_token=False) for g in extras
+    ]
+    return ListGroupsResponse(items=items, total=len(items))
+
+
+@router.post(
+    "",
+    response_model=GroupResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a group (public or private)",
+)
+async def create_group(
+    body: CreateGroupRequest,
+    user: UserData = Depends(get_current_user),
+):
+    _require_onboarded(user)
+    if user.default_child_id is None:
+        # Unusual — onboarding completion sets default_child_id on the
+        # first PUT /me/agent (#455). If we somehow get here with no
+        # child profile bound, the create can't satisfy the membership
+        # FK invariant downstream.
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "CHILD_PROFILE_REQUIRED"},
+        )
+    if body.visibility not in ("public", "private"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"code": "INVALID_VISIBILITY"},
+        )
+
+    group = await group_repo.create_group(
+        name=body.name,
+        visibility=body.visibility,
+        created_by_user_id=user.user_id,
+        owner_child_id=user.default_child_id,
+        description=body.description,
+        theme=body.theme,
+    )
+    # Expose the invite_token exactly once — at create time — so the
+    # owner can copy/paste it. List/get responses scrub the field.
+    return _to_response(group, include_invite_token=True)
+
+
+@router.get(
+    "/{group_id}",
+    response_model=GroupResponse,
+    summary="Get a group by id",
+)
+async def get_group(
+    group_id: str,
+    user: UserData = Depends(get_current_user),
+):
+    group = await group_repo.get_by_id(group_id)
+    if group is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "GROUP_NOT_FOUND"},
+        )
+    # Owner sees the invite_token; everyone else does not.
+    is_owner = group.created_by_user_id == user.user_id
+    return _to_response(group, include_invite_token=is_owner)
+
+
+@router.post(
+    "/{group_id}/join",
+    response_model=JoinGroupResponse,
+    summary="Join a group (open for public, invite-token for private)",
+)
+async def join_group(
+    group_id: str,
+    user: UserData = Depends(get_current_user),
+    invite: Optional[str] = Query(None, alias="invite"),
+):
+    _require_onboarded(user)
+    if user.default_child_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "CHILD_PROFILE_REQUIRED"},
+        )
+    try:
+        membership = await group_repo.join_group(
+            group_id=group_id,
+            user_id=user.user_id,
+            child_id=user.default_child_id,
+            invite_token=invite,
+        )
+    except LookupError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "GROUP_NOT_FOUND"},
+        )
+    except PermissionError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "INVALID_INVITE_TOKEN"},
+        )
+    return JoinGroupResponse(
+        group_id=membership.group_id,
+        role=membership.role,
+        joined_at=membership.joined_at,
+    )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -343,6 +343,7 @@ from .api.routes import (
     agents,
     artifacts,
     audio,
+    hub,
     image_to_story,
     inspiration_daily,
     interactive_story,
@@ -365,6 +366,7 @@ app.include_router(voice.router)
 app.include_router(users.router)
 app.include_router(agents.router)
 app.include_router(onboarding.router)
+app.include_router(hub.router)
 app.include_router(kids_daily.router)
 app.include_router(inspiration_daily.router)
 app.include_router(subscriptions.router)

--- a/backend/tests/contracts/test_hub_groups_endpoint_contract.py
+++ b/backend/tests/contracts/test_hub_groups_endpoint_contract.py
@@ -1,0 +1,358 @@
+"""
+Hub Group Endpoint Contract Tests (#448)
+
+Locks the surface of:
+  GET  /api/v1/hub/groups
+  POST /api/v1/hub/groups
+  GET  /api/v1/hub/groups/{group_id}
+  POST /api/v1/hub/groups/{group_id}/join
+
+Privacy guarantees verified:
+  - Non-owner GET /hub/groups/{id} scrubs invite_token
+  - List response scrubs invite_token for the caller's joined privates
+  - Create response DOES expose invite_token (to the inviter, once)
+
+Parent Epic: #437
+Issue: #448
+"""
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from backend.src.api.deps import get_current_user
+from backend.src.main import app
+from backend.src.services.database import db_manager, group_repo
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserData
+
+
+_OWNER = UserData(
+    user_id="hub_owner",
+    username="hub_owner",
+    email="hub_owner@test.com",
+    password_hash="h",
+    display_name="Owner",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    created_at="",
+    updated_at="",
+    last_login_at=None,
+    nickname=None,
+    onboarded_at="2026-01-01T00:00:00",
+    parent_consent_at="2026-01-01T00:00:00",
+    default_child_id="child-owner",
+)
+
+
+_PEER = UserData(
+    user_id="hub_peer",
+    username="hub_peer",
+    email="hub_peer@test.com",
+    password_hash="h",
+    display_name="Peer",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    created_at="",
+    updated_at="",
+    last_login_at=None,
+    nickname=None,
+    onboarded_at="2026-01-01T00:00:00",
+    parent_consent_at="2026-01-01T00:00:00",
+    default_child_id="child-peer",
+)
+
+
+_FRESH = UserData(
+    user_id="hub_fresh",
+    username="hub_fresh",
+    email="hub_fresh@test.com",
+    password_hash="h",
+    display_name="Fresh",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    created_at="",
+    updated_at="",
+    last_login_at=None,
+    nickname=None,
+    onboarded_at=None,        # NOT onboarded
+    parent_consent_at=None,
+    default_child_id=None,
+)
+
+
+_holder: dict = {"user": _OWNER}
+
+
+async def _override_current_user() -> UserData:
+    return _holder["user"]
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    fresh = DatabaseManager(":memory:")
+    await fresh.connect()
+    await init_schema(fresh)
+
+    saved_adapter = db_manager._adapter
+    db_manager._adapter = fresh._adapter
+
+    # Seed both owner and peer rows so FKs on hub_groups / memberships hold.
+    from datetime import datetime as _dt
+    now = _dt.now().isoformat()
+    for user in (_OWNER, _PEER, _FRESH):
+        await db_manager.execute(
+            """
+            INSERT INTO users (
+                user_id, username, email, password_hash, display_name,
+                is_active, is_verified, role,
+                membership_tier, referral_code, referred_by,
+                created_at, updated_at, onboarded_at, parent_consent_at,
+                default_child_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user.user_id,
+                user.username,
+                user.email,
+                user.password_hash,
+                user.display_name,
+                1,
+                1,
+                "child",
+                "free",
+                f"CODE_{user.user_id}",
+                None,
+                now,
+                now,
+                user.onboarded_at,
+                user.parent_consent_at,
+                user.default_child_id,
+            ),
+        )
+    await db_manager.commit()
+
+    yield fresh
+    db_manager._adapter = saved_adapter
+    await fresh.disconnect()
+
+
+@pytest_asyncio.fixture
+async def client(test_db):
+    _holder["user"] = _OWNER
+    app.dependency_overrides[get_current_user] = _override_current_user
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def _switch_user(user: UserData) -> None:
+    _holder["user"] = user
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGroup:
+    @pytest.mark.asyncio
+    async def test_public_create_returns_no_invite_token_in_payload(self, client):
+        r = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "Dragons", "visibility": "public"},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["visibility"] == "public"
+        # Public groups never have an invite_token.
+        assert body.get("invite_token") in (None, "")
+        assert body["slug"] == "dragons"
+
+    @pytest.mark.asyncio
+    async def test_private_create_exposes_invite_token_to_owner(self, client):
+        r = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "Cousins", "visibility": "private"},
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["visibility"] == "private"
+        assert body["invite_token"], "create response must expose invite_token to owner"
+        assert len(body["invite_token"]) >= 16
+
+    @pytest.mark.asyncio
+    async def test_create_requires_onboarded(self, client):
+        _switch_user(_FRESH)
+        r = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "Should fail", "visibility": "public"},
+        )
+        assert r.status_code == 412
+        assert r.json()["detail"]["code"] == "ONBOARDING_REQUIRED"
+
+    @pytest.mark.asyncio
+    async def test_invalid_visibility_rejected(self, client):
+        r = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "x", "visibility": "everyone"},
+        )
+        # Either Pydantic 422 (string mismatch) or our 400 INVALID_VISIBILITY.
+        assert r.status_code in (400, 422)
+
+
+# ---------------------------------------------------------------------------
+# Get
+# ---------------------------------------------------------------------------
+
+
+class TestGetGroup:
+    @pytest.mark.asyncio
+    async def test_owner_sees_invite_token(self, client):
+        r1 = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "Mine", "visibility": "private"},
+        )
+        gid = r1.json()["group_id"]
+        # Same owner GET — should see the token.
+        r2 = await client.get(f"/api/v1/hub/groups/{gid}")
+        assert r2.status_code == 200
+        assert r2.json()["invite_token"], "owner must see invite_token on GET"
+
+    @pytest.mark.asyncio
+    async def test_non_owner_does_not_see_invite_token(self, client):
+        # Owner creates.
+        r1 = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "OwnerOnly", "visibility": "private"},
+        )
+        gid = r1.json()["group_id"]
+        # Switch to a different user; GET must scrub the token.
+        _switch_user(_PEER)
+        r2 = await client.get(f"/api/v1/hub/groups/{gid}")
+        assert r2.status_code == 200
+        body = r2.json()
+        assert body.get("invite_token") in (None, ""), (
+            "non-owner GET must NOT expose invite_token"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unknown_group_returns_404(self, client):
+        r = await client.get("/api/v1/hub/groups/does-not-exist")
+        assert r.status_code == 404
+        assert r.json()["detail"]["code"] == "GROUP_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Join
+# ---------------------------------------------------------------------------
+
+
+class TestJoinGroup:
+    @pytest.mark.asyncio
+    async def test_public_open_join(self, client):
+        r1 = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "PubJoin", "visibility": "public"},
+        )
+        gid = r1.json()["group_id"]
+        _switch_user(_PEER)
+        r2 = await client.post(f"/api/v1/hub/groups/{gid}/join")
+        assert r2.status_code == 200, r2.text
+        assert r2.json()["role"] == "member"
+
+    @pytest.mark.asyncio
+    async def test_private_requires_invite_token(self, client):
+        r1 = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "PrivJoin", "visibility": "private"},
+        )
+        token = r1.json()["invite_token"]
+        gid = r1.json()["group_id"]
+
+        _switch_user(_PEER)
+        # No token — 403.
+        r2 = await client.post(f"/api/v1/hub/groups/{gid}/join")
+        assert r2.status_code == 403
+        assert r2.json()["detail"]["code"] == "INVALID_INVITE_TOKEN"
+
+        # Wrong token — 403.
+        r3 = await client.post(f"/api/v1/hub/groups/{gid}/join?invite=bogus")
+        assert r3.status_code == 403
+
+        # Right token — 200.
+        r4 = await client.post(
+            f"/api/v1/hub/groups/{gid}/join?invite={token}"
+        )
+        assert r4.status_code == 200, r4.text
+
+    @pytest.mark.asyncio
+    async def test_join_requires_onboarded(self, client):
+        r1 = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "Need-onboard", "visibility": "public"},
+        )
+        gid = r1.json()["group_id"]
+        _switch_user(_FRESH)
+        r2 = await client.post(f"/api/v1/hub/groups/{gid}/join")
+        assert r2.status_code == 412
+        assert r2.json()["detail"]["code"] == "ONBOARDING_REQUIRED"
+
+    @pytest.mark.asyncio
+    async def test_unknown_group_returns_404(self, client):
+        r = await client.post("/api/v1/hub/groups/missing/join")
+        assert r.status_code == 404
+        assert r.json()["detail"]["code"] == "GROUP_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+
+
+class TestListGroups:
+    @pytest.mark.asyncio
+    async def test_list_includes_public_and_my_private(self, client):
+        # Owner creates one of each.
+        await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "PublicOne", "visibility": "public"},
+        )
+        await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "PrivateOne", "visibility": "private"},
+        )
+
+        # Owner lists — should see both.
+        r = await client.get("/api/v1/hub/groups")
+        assert r.status_code == 200, r.text
+        items = r.json()["items"]
+        names = {it["name"] for it in items}
+        assert {"PublicOne", "PrivateOne"} <= names
+
+        # Switch to peer (not a member) — sees public, NOT the private.
+        _switch_user(_PEER)
+        r2 = await client.get("/api/v1/hub/groups")
+        names2 = {it["name"] for it in r2.json()["items"]}
+        assert "PublicOne" in names2
+        assert "PrivateOne" not in names2
+
+    @pytest.mark.asyncio
+    async def test_list_scrubs_invite_token_for_non_owners(self, client):
+        await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "Hidden token", "visibility": "private"},
+        )
+        # Owner list — invite_token is None in the listing payload because
+        # we keep the create-response as the only place it's exposed.
+        r = await client.get("/api/v1/hub/groups")
+        assert r.status_code == 200
+        for it in r.json()["items"]:
+            # The list endpoint does NOT echo invite_token even to owners,
+            # because list payloads are wider blast-radius than create.
+            assert it.get("invite_token") in (None, "")


### PR DESCRIPTION
Fixes #448

Parent epic: #437
Depends on #447 (hub repositories — already on main).

## Summary

First half of the Content Hub HTTP surface. Posts ship in #449.

| Endpoint | Behaviour |
|---|---|
| \`GET /api/v1/hub/groups\` | Public groups + caller's joined privates |
| \`POST /api/v1/hub/groups\` | Create (public or private). Owner gets the invite_token in the response. |
| \`GET /api/v1/hub/groups/{group_id}\` | Detail. invite_token only visible to the owner. |
| \`POST /api/v1/hub/groups/{group_id}/join?invite=...\` | Public: open join. Private: must match \`invite_token\`. |

## Privacy posture

\`invite_token\` exposure is narrow:
- Create response (to the inviter, once)
- \`GET /hub/groups/{id}\` only when caller is owner
- **Never in list responses**, even to owners — list payloads have a wider blast radius

## Onboarding gate

\`create\` and \`join\` require \`users.onboarded_at\` non-null (412 \`ONBOARDING_REQUIRED\`). \`list\` / \`get\` open to any authenticated user.

## Routing

New \`routes/hub/\` package with \`__init__.py\` aggregating sub-routers. This is the module the COPPA contract test from #450 imports — when this PR lands together with #449's \`posts\` sub-router, the skip-guarded tests auto-activate.

## Test plan

13 contract tests, all passing:

- [x] Public create → no \`invite_token\`; private → \`invite_token\` ≥ 16 chars
- [x] Create requires onboarding (412)
- [x] Owner GET → sees \`invite_token\`; non-owner GET → scrubbed
- [x] Public join open; private join 403 on missing/wrong token, 200 on match
- [x] Join requires onboarding (412)
- [x] List shows public + caller's joined privates; non-member peer can't see private; \`invite_token\` is null in list payloads even for owners
- [x] 404 on unknown group ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)