### PR TITLE
feat(hub): admin moderation endpoint to soft-delete a hub post (#456)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -922,6 +922,22 @@ class ListHubPostsResponse(BaseModel):
     next_cursor: Optional[HubPostCursor] = None
 
 
+# ---------------------------------------------------------------------------
+# Admin Hub moderation (#456)
+# ---------------------------------------------------------------------------
+
+
+class RemoveHubPostRequest(BaseModel):
+    reason: Optional[str] = Field(None, max_length=200, description="Free-text moderation reason captured on hub_posts.removed_reason")
+
+
+class RemoveHubPostResponse(BaseModel):
+    post_id: str
+    removed_at: str
+    removed_reason: Optional[str] = None
+    already_removed: bool = False
+
+
 class ReferralStatusResponse(BaseModel):
     """Referral progress and membership tier status (PRD §3.9.4)"""
     referral_code: str = Field(..., description="User's unique referral code")

--- a/backend/src/api/routes/admin_hub.py
+++ b/backend/src/api/routes/admin_hub.py
@@ -1,0 +1,66 @@
+"""
+Admin Hub Moderation Routes (#456) — soft-delete a hub post.
+
+Minimal moderation surface for v1: an admin can mark a post as
+removed, which strips it from group feeds while preserving the row
+for audit. Full moderation queue UI is deferred to v2.
+
+Endpoints
+  POST /api/v1/admin/hub/posts/{post_id}/remove
+
+Why a separate router (not extending admin_artifacts)
+  admin_artifacts is scoped to the artifact-graph surface (#16).
+  Hub posts are a distinct domain — keeping the router separate
+  keeps the URL paths self-explanatory and avoids importing hub
+  state into the artifact admin.
+
+Provenance / audit log
+  hub_posts.removed_at + removed_reason capture the soft-delete
+  state. v2 can wire a ProvenanceTracker call here once that
+  module's API stabilises.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ..deps import get_admin_user
+from ..models import RemoveHubPostRequest, RemoveHubPostResponse
+from ...services.database import hub_post_repo
+from ...services.user_service import UserData
+
+
+router = APIRouter(prefix="/api/v1/admin/hub", tags=["Admin / Content Hub"])
+
+
+@router.post(
+    "/posts/{post_id}/remove",
+    response_model=RemoveHubPostResponse,
+    summary="Soft-delete a hub post (admin only)",
+)
+async def remove_hub_post(
+    post_id: str,
+    body: RemoveHubPostRequest,
+    admin: UserData = Depends(get_admin_user),
+):
+    post = await hub_post_repo.get_by_id(post_id)
+    if post is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "POST_NOT_FOUND"},
+        )
+    if post.removed_at is not None:
+        # Idempotent: already removed -> echo current state, do not error.
+        return RemoveHubPostResponse(
+            post_id=post.post_id,
+            removed_at=post.removed_at,
+            removed_reason=post.removed_reason,
+            already_removed=True,
+        )
+
+    await hub_post_repo.soft_delete(post_id, reason=body.reason)
+    fresh = await hub_post_repo.get_by_id(post_id)
+    return RemoveHubPostResponse(
+        post_id=fresh.post_id,
+        removed_at=fresh.removed_at,
+        removed_reason=fresh.removed_reason,
+        already_removed=False,
+    )

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -340,6 +340,7 @@ if os.getenv("STORAGE_BACKEND", "local").lower() != "supabase":
 
 from .api.routes import (
     admin_artifacts,
+    admin_hub,
     agents,
     artifacts,
     audio,
@@ -372,6 +373,7 @@ app.include_router(inspiration_daily.router)
 app.include_router(subscriptions.router)
 app.include_router(artifacts.router)
 app.include_router(admin_artifacts.router)
+app.include_router(admin_hub.router)
 app.include_router(library.router)
 app.include_router(memory.router)
 app.include_router(usage.router)

--- a/backend/tests/contracts/test_admin_hub_endpoint_contract.py
+++ b/backend/tests/contracts/test_admin_hub_endpoint_contract.py
@@ -1,0 +1,266 @@
+"""
+Admin Hub Moderation Contract Tests (#456)
+
+Locks the surface of:
+  POST /api/v1/admin/hub/posts/{post_id}/remove
+
+Coverage:
+  - Non-admin caller -> 403
+  - Unknown post_id -> 404 POST_NOT_FOUND
+  - Happy path: removed_at + removed_reason set; post disappears from
+    GET /hub/groups/{id}/posts
+  - Idempotent: replay returns already_removed=True with the same
+    removed_at unchanged
+  - Provenance: hub_posts.removed_reason is preserved verbatim
+
+Parent Epic: #437
+Issue: #456
+"""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from backend.src.api.deps import get_admin_user, get_current_user
+from backend.src.main import app
+from backend.src.services.database import (
+    agent_repo,
+    db_manager,
+    group_repo,
+    hub_post_repo,
+)
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserData
+
+
+_ADMIN = UserData(
+    user_id="admin_user",
+    username="admin_user",
+    email="admin@test.com",
+    password_hash="h",
+    display_name="Admin",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    role="parent",
+    created_at="",
+    updated_at="",
+    last_login_at=None,
+    nickname=None,
+    onboarded_at="2026-01-01T00:00:00",
+    parent_consent_at="2026-01-01T00:00:00",
+    default_child_id="admin-child",
+)
+_NON_ADMIN = UserData(
+    user_id="non_admin",
+    username="non_admin",
+    email="non_admin@test.com",
+    password_hash="h",
+    display_name="Plain",
+    avatar_url=None,
+    is_active=True,
+    is_verified=True,
+    role="child",
+    created_at="",
+    updated_at="",
+    last_login_at=None,
+    nickname=None,
+    onboarded_at="2026-01-01T00:00:00",
+    parent_consent_at="2026-01-01T00:00:00",
+    default_child_id="non-admin-child",
+)
+
+_holder: dict = {"current": _ADMIN, "admin": _ADMIN}
+
+
+async def _override_current_user() -> UserData:
+    return _holder["current"]
+
+
+async def _override_admin_user() -> UserData:
+    # The route uses Depends(get_admin_user). The override returns the
+    # holder's admin (set to non-admin user when we want to simulate
+    # the 403 path) — we trip the 403 ourselves by raising HTTPException
+    # in the override when the simulated caller is not admin.
+    user = _holder["admin"]
+    if user is _NON_ADMIN:
+        from fastapi import HTTPException, status as _s
+        raise HTTPException(
+            status_code=_s.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+    return user
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    fresh = DatabaseManager(":memory:")
+    await fresh.connect()
+    await init_schema(fresh)
+
+    saved_adapter = db_manager._adapter
+    db_manager._adapter = fresh._adapter
+
+    from datetime import datetime as _dt
+    now = _dt.now().isoformat()
+    for u in (_ADMIN, _NON_ADMIN):
+        await db_manager.execute(
+            """
+            INSERT INTO users (
+                user_id, username, email, password_hash, display_name,
+                is_active, is_verified, role,
+                membership_tier, referral_code, referred_by,
+                created_at, updated_at, onboarded_at, parent_consent_at,
+                default_child_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                u.user_id,
+                u.username,
+                u.email,
+                u.password_hash,
+                u.display_name,
+                1,
+                1,
+                u.role,
+                "free",
+                f"CODE_{u.user_id}",
+                None,
+                now,
+                now,
+                u.onboarded_at,
+                u.parent_consent_at,
+                u.default_child_id,
+            ),
+        )
+    await db_manager.commit()
+    yield fresh
+    db_manager._adapter = saved_adapter
+    await fresh.disconnect()
+
+
+@pytest_asyncio.fixture
+async def client(test_db):
+    _holder["current"] = _ADMIN
+    _holder["admin"] = _ADMIN
+    app.dependency_overrides[get_current_user] = _override_current_user
+    app.dependency_overrides[get_admin_user] = _override_admin_user
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_current_user, None)
+    app.dependency_overrides.pop(get_admin_user, None)
+
+
+def _safety(score: float) -> dict:
+    return {
+        "content": [{"type": "text", "text": json.dumps({"safety_score": score})}]
+    }
+
+
+async def _create_post(client: AsyncClient) -> str:
+    """Owner creates buddy + group + a post; returns post_id."""
+    await agent_repo.upsert_agent(
+        user_id=_ADMIN.user_id,
+        child_id=_ADMIN.default_child_id,
+        agent_name="Sparkle",
+        agent_avatar_id="emoji:🦁",
+        agent_title="Brave Lion",
+    )
+    r1 = await client.post(
+        "/api/v1/hub/groups",
+        json={"name": "Mod", "visibility": "public"},
+    )
+    assert r1.status_code == 201, r1.text
+    gid = r1.json()["group_id"]
+    with patch(
+        "backend.src.api.routes.hub.posts.check_content_safety",
+        new=AsyncMock(return_value=_safety(0.99)),
+    ):
+        r2 = await client.post(
+            f"/api/v1/hub/groups/{gid}/posts",
+            json={"source_artifact_type": "art_story", "source_id": "to-remove"},
+        )
+    assert r2.status_code == 201, r2.text
+    return r2.json()["post_id"], gid
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveHubPost:
+    @pytest.mark.asyncio
+    async def test_unknown_post_returns_404(self, client):
+        r = await client.post(
+            "/api/v1/admin/hub/posts/missing/remove",
+            json={"reason": "spam"},
+        )
+        assert r.status_code == 404
+        assert r.json()["detail"]["code"] == "POST_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_non_admin_caller_returns_403(self, client):
+        post_id, _gid = await _create_post(client)
+        # Flip the simulated admin to non-admin -> override raises 403.
+        _holder["admin"] = _NON_ADMIN
+        r = await client.post(
+            f"/api/v1/admin/hub/posts/{post_id}/remove",
+            json={"reason": "spam"},
+        )
+        assert r.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_remove_marks_post_and_strips_from_feed(self, client):
+        post_id, gid = await _create_post(client)
+
+        r = await client.post(
+            f"/api/v1/admin/hub/posts/{post_id}/remove",
+            json={"reason": "tmp policy violation"},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["post_id"] == post_id
+        assert body["removed_at"]
+        assert body["removed_reason"] == "tmp policy violation"
+        assert body["already_removed"] is False
+
+        # Feed must no longer include it.
+        feed = await client.get(f"/api/v1/hub/groups/{gid}/posts")
+        ids = {p["post_id"] for p in feed.json()["items"]}
+        assert post_id not in ids
+
+    @pytest.mark.asyncio
+    async def test_idempotent_replay(self, client):
+        post_id, _gid = await _create_post(client)
+        r1 = await client.post(
+            f"/api/v1/admin/hub/posts/{post_id}/remove",
+            json={"reason": "first"},
+        )
+        first = r1.json()
+        r2 = await client.post(
+            f"/api/v1/admin/hub/posts/{post_id}/remove",
+            json={"reason": "second-should-be-ignored"},
+        )
+        second = r2.json()
+        assert r2.status_code == 200
+        assert second["already_removed"] is True
+        # First reason wins; second call doesn't overwrite.
+        assert second["removed_reason"] == "first"
+        assert second["removed_at"] == first["removed_at"]
+
+    @pytest.mark.asyncio
+    async def test_no_reason_is_allowed(self, client):
+        post_id, _gid = await _create_post(client)
+        r = await client.post(
+            f"/api/v1/admin/hub/posts/{post_id}/remove",
+            json={},
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["removed_reason"] is None


### PR DESCRIPTION
Fixes #456

Parent epic: #437

## Summary

Minimum viable moderation surface for Content Hub v1.

\`\`\`
POST /api/v1/admin/hub/posts/{post_id}/remove
{"reason": "..."}
\`\`\`

| Status | Trigger |
|---|---|
| 200 | Soft-delete success — \`removed_at\` + \`removed_reason\` set, post stripped from feeds |
| 200 + \`already_removed: true\` | Replay — original timestamp + reason returned unchanged |
| 404 \`POST_NOT_FOUND\` | Unknown id |
| 403 | Non-admin caller (existing \`get_admin_user\` gate) |

## Decisions

- **New router** (\`routes/admin_hub.py\`) instead of extending \`admin_artifacts.py\`. The artifact admin surface is scoped to the artifact-graph (#16) — keeping hub moderation separate makes URLs self-explanatory and avoids cross-domain coupling.
- **First reason wins on replay.** A second call doesn't overwrite \`removed_reason\`; the first moderator's note is the audit-relevant one.
- **Soft-delete only.** The row stays for audit; the feed query already filters \`removed_at IS NULL\` (verified end-to-end by the contract test).

## Out of scope (deferred to v2)

- Moderation queue UI / batch actions
- Report-then-auto-hide threshold
- Provenance tracker integration — the row itself is the v1 audit log

## Test plan

5 contract tests:

- [x] Unknown post → 404 \`POST_NOT_FOUND\`
- [x] Non-admin → 403
- [x] Happy path: \`removed_at\` set, \`removed_reason\` echoes input, post disappears from \`GET /hub/groups/{id}/posts\`
- [x] Idempotent replay: \`already_removed=true\`, first reason unchanged
- [x] No reason allowed (nullable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)