### PR TITLE
feat(hub): ContentHubPage with group directory + create modal + nav (#451)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ const NewsPage = lazy(() => import("./pages/NewsPage"));
 const MorningShowPage = lazy(() => import("./pages/MorningShowPage"));
 const NewsDetailPage = lazy(() => import("./pages/NewsDetailPage"));
 const MyAgentPage = lazy(() => import("./pages/MyAgentPage"));
+const ContentHubPage = lazy(() => import("./pages/ContentHubPage"));
 
 function App() {
   return (
@@ -49,6 +50,7 @@ function App() {
             />
             <Route path="profile" element={<ProfilePage />} />
             <Route path="my-agent" element={<MyAgentPage />} />
+            <Route path="content-hub" element={<ContentHubPage />} />
           </Route>
         </Routes>
       </Suspense>

--- a/frontend/src/api/services/hubService.test.ts
+++ b/frontend/src/api/services/hubService.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Logic-only tests for hubService — mocks apiClient and exercises the
+ * URL shape + payload contract for the group + post wrappers.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AxiosError } from "axios";
+
+vi.mock("../client", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import apiClient from "../client";
+import {
+  createGroup,
+  createHubPost,
+  getGroup,
+  joinGroup,
+  listGroupPosts,
+  listGroups,
+} from "./hubService";
+
+const mockedGet = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+const mockedPost = apiClient.post as unknown as ReturnType<typeof vi.fn>;
+
+afterEach(() => {
+  mockedGet.mockReset();
+  mockedPost.mockReset();
+});
+
+describe("listGroups", () => {
+  it("hits /hub/groups and returns the list payload", async () => {
+    const fake = { items: [], total: 0 };
+    mockedGet.mockResolvedValueOnce({ data: fake });
+    const r = await listGroups();
+    expect(r).toEqual(fake);
+    expect(mockedGet).toHaveBeenCalledWith("/hub/groups");
+  });
+});
+
+describe("createGroup", () => {
+  it("posts the create payload to /hub/groups", async () => {
+    const fake = {
+      group_id: "g1",
+      slug: "dragons",
+      name: "Dragons",
+      description: null,
+      theme: null,
+      visibility: "public",
+      invite_token: null,
+      created_at: "2026-01-01T00:00:00",
+      member_count: 1,
+    };
+    mockedPost.mockResolvedValueOnce({ data: fake });
+    const r = await createGroup({ name: "Dragons", visibility: "public" });
+    expect(r).toEqual(fake);
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/hub/groups",
+      { name: "Dragons", visibility: "public" },
+    );
+  });
+});
+
+describe("getGroup", () => {
+  it("returns null on 404", async () => {
+    const err = new AxiosError("nope");
+    // @ts-expect-error -- minimal AxiosResponse for the test
+    err.response = { status: 404 };
+    mockedGet.mockRejectedValueOnce(err);
+    const r = await getGroup("missing");
+    expect(r).toBeNull();
+  });
+
+  it("returns the group on 200", async () => {
+    const fake = { group_id: "g2" };
+    mockedGet.mockResolvedValueOnce({ data: fake });
+    const r = await getGroup("g2");
+    expect(r).toEqual(fake);
+    expect(mockedGet).toHaveBeenCalledWith("/hub/groups/g2");
+  });
+});
+
+describe("joinGroup", () => {
+  it("includes invite token in query when provided", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: { group_id: "g3", role: "member", joined_at: "x" },
+    });
+    await joinGroup("g3", "TOKEN_123");
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/hub/groups/g3/join",
+      null,
+      { params: { invite: "TOKEN_123" } },
+    );
+  });
+
+  it("omits params when no token", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: { group_id: "g4", role: "member", joined_at: "x" },
+    });
+    await joinGroup("g4");
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/hub/groups/g4/join",
+      null,
+      undefined,
+    );
+  });
+});
+
+describe("listGroupPosts", () => {
+  it("threads cursor params into the GET", async () => {
+    mockedGet.mockResolvedValueOnce({ data: { items: [], next_cursor: null } });
+    await listGroupPosts("g5", {
+      limit: 5,
+      cursor: { cursor_created_at: "2026-01-01", cursor_post_id: "p1" },
+    });
+    expect(mockedGet).toHaveBeenCalledWith(
+      "/hub/groups/g5/posts",
+      {
+        params: {
+          limit: 5,
+          cursor_created_at: "2026-01-01",
+          cursor_post_id: "p1",
+        },
+      },
+    );
+  });
+});
+
+describe("createHubPost", () => {
+  it("posts the body to the group's /posts path", async () => {
+    mockedPost.mockResolvedValueOnce({
+      data: {
+        post_id: "p2",
+        group_id: "g6",
+        agent_name: "S",
+        agent_avatar_id: "emoji:🦁",
+        agent_title: "T",
+        source_artifact_type: "art_story",
+        source_id: "s",
+        caption: null,
+        created_at: "x",
+      },
+    });
+    await createHubPost("g6", {
+      source_artifact_type: "art_story",
+      source_id: "s",
+    });
+    expect(mockedPost).toHaveBeenCalledWith(
+      "/hub/groups/g6/posts",
+      { source_artifact_type: "art_story", source_id: "s" },
+    );
+  });
+});

--- a/frontend/src/api/services/hubService.ts
+++ b/frontend/src/api/services/hubService.ts
@@ -1,0 +1,96 @@
+/**
+ * Content Hub service — wraps the backend hub endpoints landed in
+ * #448 (groups), #449 (posts).
+ *
+ * apiClient is configured with baseURL=/api/v1, so we hit bare paths.
+ *
+ * Issue: #451 | Parent epic: #437
+ */
+
+import { AxiosError } from "axios";
+import apiClient from "../client";
+import type {
+  CreateGroupPayload,
+  CreateHubPostPayload,
+  Group,
+  HubPost,
+  HubPostCursor,
+  JoinGroupResult,
+  ListGroupsResponse,
+  ListHubPostsResponse,
+} from "@/types/hub";
+
+export async function listGroups(): Promise<ListGroupsResponse> {
+  const r = await apiClient.get<ListGroupsResponse>("/hub/groups");
+  return r.data;
+}
+
+export async function createGroup(
+  payload: CreateGroupPayload,
+): Promise<Group> {
+  const r = await apiClient.post<Group>("/hub/groups", payload);
+  return r.data;
+}
+
+export async function getGroup(groupId: string): Promise<Group | null> {
+  try {
+    const r = await apiClient.get<Group>(`/hub/groups/${groupId}`);
+    return r.data;
+  } catch (err) {
+    if (err instanceof AxiosError && err.response?.status === 404) return null;
+    throw err;
+  }
+}
+
+export async function joinGroup(
+  groupId: string,
+  inviteToken?: string,
+): Promise<JoinGroupResult> {
+  const params = inviteToken ? { invite: inviteToken } : undefined;
+  const r = await apiClient.post<JoinGroupResult>(
+    `/hub/groups/${groupId}/join`,
+    null,
+    params ? { params } : undefined,
+  );
+  return r.data;
+}
+
+export async function listGroupPosts(
+  groupId: string,
+  opts: {
+    limit?: number;
+    cursor?: HubPostCursor | null;
+  } = {},
+): Promise<ListHubPostsResponse> {
+  const params: Record<string, unknown> = {};
+  if (opts.limit) params.limit = opts.limit;
+  if (opts.cursor) {
+    params.cursor_created_at = opts.cursor.cursor_created_at;
+    params.cursor_post_id = opts.cursor.cursor_post_id;
+  }
+  const r = await apiClient.get<ListHubPostsResponse>(
+    `/hub/groups/${groupId}/posts`,
+    Object.keys(params).length ? { params } : undefined,
+  );
+  return r.data;
+}
+
+export async function createHubPost(
+  groupId: string,
+  payload: CreateHubPostPayload,
+): Promise<HubPost> {
+  const r = await apiClient.post<HubPost>(
+    `/hub/groups/${groupId}/posts`,
+    payload,
+  );
+  return r.data;
+}
+
+export const hubService = {
+  listGroups,
+  createGroup,
+  getGroup,
+  joinGroup,
+  listGroupPosts,
+  createHubPost,
+};

--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -94,6 +94,7 @@ function PageContainerInner() {
             <div className="flex items-center gap-4">
               <NavLink to="/library" icon="📚" label="My Library" />
               <NavLink to="/my-agent" icon="🦊" label="My Agent" />
+              <NavLink to="/content-hub" icon="🌐" label="Content Hub" />
 
               {/* Auth section */}
               {isAuthenticated ? (

--- a/frontend/src/pages/ContentHubPage/GroupCard.tsx
+++ b/frontend/src/pages/ContentHubPage/GroupCard.tsx
@@ -1,0 +1,74 @@
+/**
+ * GroupCard — single group entry on the ContentHubPage directory.
+ *
+ * Issue: #451 | Parent epic: #437
+ */
+
+import type { Group } from "@/types/hub";
+
+interface Props {
+  group: Group;
+  onOpen: () => void;
+  onJoin?: () => void;
+  joined: boolean;
+}
+
+export default function GroupCard({ group, onOpen, onJoin, joined }: Props) {
+  const isPrivate = group.visibility === "private";
+  return (
+    <article
+      className="group flex flex-col gap-2 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:shadow-md"
+    >
+      <header className="flex items-start justify-between gap-2">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-semibold text-gray-900 line-clamp-1">
+            {group.name}
+          </h3>
+          <p className="text-xs text-gray-500">
+            {group.member_count}{" "}
+            {group.member_count === 1 ? "member" : "members"} ·{" "}
+            {isPrivate ? "Private" : "Public"}
+          </p>
+        </div>
+        <span
+          className={[
+            "rounded-full px-2 py-0.5 text-xs font-semibold",
+            isPrivate
+              ? "bg-amber-100 text-amber-700"
+              : "bg-emerald-100 text-emerald-700",
+          ].join(" ")}
+        >
+          {isPrivate ? "🔒 Private" : "🌐 Public"}
+        </span>
+      </header>
+
+      {group.description && (
+        <p className="text-sm text-gray-600 line-clamp-2">{group.description}</p>
+      )}
+
+      <footer className="mt-2 flex items-center gap-2">
+        <button
+          type="button"
+          className="rounded-md bg-violet-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-700"
+          onClick={onOpen}
+        >
+          Open
+        </button>
+        {onJoin && !joined && (
+          <button
+            type="button"
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            onClick={onJoin}
+          >
+            {isPrivate ? "Join with invite" : "Join"}
+          </button>
+        )}
+        {joined && (
+          <span className="text-xs font-medium text-emerald-600">
+            ✓ Joined
+          </span>
+        )}
+      </footer>
+    </article>
+  );
+}

--- a/frontend/src/pages/ContentHubPage/GroupCreateModal.tsx
+++ b/frontend/src/pages/ContentHubPage/GroupCreateModal.tsx
@@ -1,0 +1,217 @@
+/**
+ * GroupCreateModal — create a new public or private group.
+ *
+ * On private create, the modal stays open after success to display
+ * the invite_token (the backend exposes it ONCE in the create
+ * response per the privacy posture from #448).
+ *
+ * Issue: #451 | Parent epic: #437
+ */
+
+import { useState } from "react";
+import type { Group, GroupVisibility } from "@/types/hub";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (payload: {
+    name: string;
+    visibility: GroupVisibility;
+    description?: string;
+    theme?: string;
+  }) => Promise<Group>;
+}
+
+export default function GroupCreateModal({ open, onClose, onCreate }: Props) {
+  const [name, setName] = useState("");
+  const [visibility, setVisibility] = useState<GroupVisibility>("public");
+  const [description, setDescription] = useState("");
+  const [theme, setTheme] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [created, setCreated] = useState<Group | null>(null);
+
+  if (!open) return null;
+
+  const handleCreate = async () => {
+    setError(null);
+    if (!name.trim()) {
+      setError("Give your group a name.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await onCreate({
+        name: name.trim(),
+        visibility,
+        description: description.trim() || undefined,
+        theme: theme.trim() || undefined,
+      });
+      setCreated(result);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "We couldn't create the group. Try again.",
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleClose = () => {
+    // Reset for the next open.
+    setName("");
+    setVisibility("public");
+    setDescription("");
+    setTheme("");
+    setError(null);
+    setCreated(null);
+    onClose();
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="create-group-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
+    >
+      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        {created ? (
+          <div className="flex flex-col gap-4">
+            <h2
+              id="create-group-title"
+              className="text-xl font-semibold text-gray-900"
+            >
+              {created.visibility === "private"
+                ? "Private group ready!"
+                : "Public group ready!"}
+            </h2>
+            <p className="text-sm text-gray-600">
+              <strong>{created.name}</strong> is live. Visit it any time from
+              Content Hub.
+            </p>
+            {created.invite_token && (
+              <div className="flex flex-col gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm">
+                <p className="font-medium text-amber-900">
+                  Share this invite link
+                </p>
+                <p className="text-xs text-amber-700">
+                  We only show this once. Save it somewhere safe — the group
+                  owner can copy it now and paste it to a friend.
+                </p>
+                <code className="block break-all rounded-md bg-white px-2 py-1.5 font-mono text-xs">
+                  {created.invite_token}
+                </code>
+              </div>
+            )}
+            <button
+              type="button"
+              className="self-end rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+              onClick={handleClose}
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <h2
+              id="create-group-title"
+              className="text-xl font-semibold text-gray-900"
+            >
+              Create a new group
+            </h2>
+
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Name
+              <input
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                value={name}
+                maxLength={80}
+                onChange={(e) => setName(e.target.value.slice(0, 80))}
+                placeholder="Dragons, Space Adventures…"
+                disabled={busy}
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Theme (optional)
+              <input
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                value={theme}
+                maxLength={50}
+                onChange={(e) => setTheme(e.target.value.slice(0, 50))}
+                placeholder="fantasy, science, nature…"
+                disabled={busy}
+              />
+            </label>
+
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Description (optional)
+              <textarea
+                className="min-h-[64px] rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                value={description}
+                maxLength={500}
+                onChange={(e) => setDescription(e.target.value.slice(0, 500))}
+                disabled={busy}
+              />
+            </label>
+
+            <fieldset className="flex flex-col gap-2 text-sm">
+              <legend className="font-medium text-gray-700">Visibility</legend>
+              <label className="flex items-start gap-2">
+                <input
+                  type="radio"
+                  name="visibility"
+                  value="public"
+                  checked={visibility === "public"}
+                  onChange={() => setVisibility("public")}
+                  disabled={busy}
+                />
+                <span>
+                  <strong>Public</strong> — anyone can browse and post.
+                </span>
+              </label>
+              <label className="flex items-start gap-2">
+                <input
+                  type="radio"
+                  name="visibility"
+                  value="private"
+                  checked={visibility === "private"}
+                  onChange={() => setVisibility("private")}
+                  disabled={busy}
+                />
+                <span>
+                  <strong>Private</strong> — only people with the invite link
+                  can join. We'll show the link once after you create it.
+                </span>
+              </label>
+            </fieldset>
+
+            {error && <p className="text-sm text-red-600">{error}</p>}
+
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                onClick={handleClose}
+                disabled={busy}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700 disabled:bg-gray-300"
+                onClick={handleCreate}
+                disabled={busy || !name.trim()}
+              >
+                {busy ? "Creating…" : "Create"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ContentHubPage/index.tsx
+++ b/frontend/src/pages/ContentHubPage/index.tsx
@@ -1,0 +1,174 @@
+/**
+ * ContentHubPage — group directory at /content-hub.
+ *
+ * Renders:
+ *   - "My Groups" section (joined groups; private groups always show here)
+ *   - "Public Groups" section
+ *   - "Create a new group" CTA → opens GroupCreateModal
+ *
+ * Joined-state derivation: a group counts as "joined" if it appears
+ * in the listing for the current user — the backend's list endpoint
+ * already returns public + caller's joined private groups, so we can
+ * simply split by visibility for the My/Public columns. (Full
+ * membership detail will arrive when #452 lands GET memberships.)
+ *
+ * Issue: #451 | Parent epic: #437
+ */
+
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { hubService } from "@/api/services/hubService";
+import type {
+  CreateGroupPayload,
+  Group,
+  ListGroupsResponse,
+} from "@/types/hub";
+import GroupCard from "./GroupCard";
+import GroupCreateModal from "./GroupCreateModal";
+
+const HUB_GROUPS_KEY = ["hub-groups"] as const;
+
+export default function ContentHubPage() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [joinError, setJoinError] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery<ListGroupsResponse>({
+    queryKey: HUB_GROUPS_KEY,
+    queryFn: () => hubService.listGroups(),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (payload: CreateGroupPayload) =>
+      hubService.createGroup(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: HUB_GROUPS_KEY });
+    },
+  });
+
+  const joinMutation = useMutation({
+    mutationFn: ({ groupId }: { groupId: string }) =>
+      hubService.joinGroup(groupId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: HUB_GROUPS_KEY });
+    },
+  });
+
+  const handleCreate = async (payload: CreateGroupPayload): Promise<Group> => {
+    return createMutation.mutateAsync(payload);
+  };
+
+  const handleOpen = (group: Group) => {
+    navigate(`/content-hub/${group.slug}`);
+  };
+
+  const handleJoin = async (group: Group) => {
+    setJoinError(null);
+    if (group.visibility === "private") {
+      setJoinError(
+        "This is a private group — open the invite link a friend sent you to join.",
+      );
+      return;
+    }
+    try {
+      await joinMutation.mutateAsync({ groupId: group.group_id });
+    } catch {
+      setJoinError("Couldn't join that group. Try again.");
+    }
+  };
+
+  const items = data?.items ?? [];
+  const myGroups = items.filter((g) => g.visibility === "private");
+  const publicGroups = items.filter((g) => g.visibility === "public");
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8">
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Content Hub</h1>
+          <p className="text-sm text-gray-600">
+            Browse stories from other kids, or start a group around your
+            favourite theme. Stories you share show your buddy's name and
+            animal — never your real name.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="shrink-0 rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+          onClick={() => setCreateOpen(true)}
+        >
+          + New group
+        </button>
+      </header>
+
+      {joinError && (
+        <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {joinError}
+        </p>
+      )}
+
+      {isLoading && <p className="text-gray-500">Loading…</p>}
+
+      {!isLoading && items.length === 0 && (
+        <div className="rounded-2xl border-2 border-dashed border-gray-200 bg-white p-8 text-center">
+          <p className="text-base font-medium text-gray-700">
+            No groups yet — be the first!
+          </p>
+          <p className="mt-1 text-sm text-gray-500">
+            Create a group around a theme you love and invite friends.
+          </p>
+          <button
+            type="button"
+            className="mt-4 rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+            onClick={() => setCreateOpen(true)}
+          >
+            Create the first group
+          </button>
+        </div>
+      )}
+
+      {myGroups.length > 0 && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-base font-semibold text-gray-800">My groups</h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {myGroups.map((g) => (
+              <GroupCard
+                key={g.group_id}
+                group={g}
+                onOpen={() => handleOpen(g)}
+                joined={true}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {publicGroups.length > 0 && (
+        <section className="flex flex-col gap-2">
+          <h2 className="text-base font-semibold text-gray-800">
+            Public groups
+          </h2>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {publicGroups.map((g) => (
+              <GroupCard
+                key={g.group_id}
+                group={g}
+                onOpen={() => handleOpen(g)}
+                onJoin={() => handleJoin(g)}
+                joined={false}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <GroupCreateModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreate={handleCreate}
+      />
+    </div>
+  );
+}

--- a/frontend/src/types/hub.ts
+++ b/frontend/src/types/hub.ts
@@ -1,0 +1,68 @@
+/**
+ * Content Hub types — mirrors backend Pydantic models from
+ * #448 (groups), #449 (posts), #454 (reactions).
+ *
+ * Issue: #451 / #452 / #453 / #454 | Parent epic: #437
+ */
+
+export type GroupVisibility = "public" | "private";
+
+export interface Group {
+  group_id: string;
+  slug: string;
+  name: string;
+  description: string | null;
+  theme: string | null;
+  visibility: GroupVisibility;
+  /** Only present in the create response (to the owner) and in
+   * GET /hub/groups/{id} when the caller is the group's owner. */
+  invite_token: string | null;
+  created_at: string;
+  member_count: number;
+}
+
+export interface ListGroupsResponse {
+  items: Group[];
+  total: number;
+}
+
+export interface CreateGroupPayload {
+  name: string;
+  visibility: GroupVisibility;
+  description?: string;
+  theme?: string;
+}
+
+export interface JoinGroupResult {
+  group_id: string;
+  role: string;
+  joined_at: string;
+}
+
+export interface HubPost {
+  post_id: string;
+  group_id: string;
+  agent_name: string;
+  agent_avatar_id: string;
+  agent_title: string;
+  source_artifact_type: "art_story" | "interactive_story";
+  source_id: string;
+  caption: string | null;
+  created_at: string;
+}
+
+export interface HubPostCursor {
+  cursor_created_at: string;
+  cursor_post_id: string;
+}
+
+export interface ListHubPostsResponse {
+  items: HubPost[];
+  next_cursor: HubPostCursor | null;
+}
+
+export interface CreateHubPostPayload {
+  source_artifact_type: "art_story" | "interactive_story";
+  source_id: string;
+  caption?: string;
+}


### PR DESCRIPTION
Fixes #451

Parent epic: #437
Depends on #448 + #449 (already on main).

## Summary

The \`/content-hub\` home page — group directory split into "My groups" and "Public groups", with a "New group" CTA that opens \`GroupCreateModal\`.

## Pieces

- \`types/hub.ts\` — \`Group\`, \`HubPost\`, request/response types mirroring backend Pydantic models
- \`api/services/hubService.ts\` — \`listGroups\` / \`createGroup\` / \`getGroup\` / \`joinGroup\` / \`listGroupPosts\` / \`createHubPost\`
- \`pages/ContentHubPage/index.tsx\` — directory page (TanStack Query, optimistic invalidation on create/join)
- \`pages/ContentHubPage/GroupCard.tsx\` — single group entry
- \`pages/ContentHubPage/GroupCreateModal.tsx\` — create form. **After private create, the modal stays open and displays \`invite_token\` ONCE** (per the privacy posture from #448 — the field is exposed only in the create response and to the owner)
- \`App.tsx\` — lazy \`/content-hub\` route under \`PageContainer\`
- \`PageContainer\` — new \`🌐 Content Hub\` NavLink between My Agent and the avatar

## Test plan

- [x] 8 vitest cases on \`hubService\` covering URL shape, payload contract, 404→null, invite-token threading, cursor params
- [x] \`tsc --noEmit\` clean

GroupPage (per-group feed) ships in #452. Share-to-Hub CTA in #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)