### PR TITLE
feat(hub): Share to Content Hub CTA on StoryPage + InteractiveStoryPage (#453)

### DIFF
--- a/frontend/src/components/hub/ShareToHubModal.tsx
+++ b/frontend/src/components/hub/ShareToHubModal.tsx
@@ -1,0 +1,243 @@
+/**
+ * ShareToHubModal — group picker + caption input for sharing a story
+ * to Content Hub (#453).
+ *
+ * Reuses the hubService client landed in #451:
+ *   - listGroups() for the group picker
+ *   - createHubPost(groupId, payload) for the actual share
+ *
+ * Server-side gates (#449) that we surface as friendly errors:
+ *   - 412 ONBOARDING_REQUIRED -> "Finish meeting your buddy first"
+ *     (the modal closes and routes the user to /my-agent)
+ *   - 412 AGENT_REQUIRED      -> same as above
+ *   - 403 NOT_A_MEMBER        -> "You'll need to join this group first"
+ *   - 400 UNSAFE_CAPTION      -> inline error on the caption field
+ *   - 503 SAFETY_UNAVAILABLE  -> "Try again in a minute" toast
+ *
+ * Issue: #453 | Parent epic: #437
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AxiosError } from "axios";
+import { useQuery } from "@tanstack/react-query";
+import { hubService } from "@/api/services/hubService";
+import type { Group } from "@/types/hub";
+
+const MAX_CAPTION = 280;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  source: {
+    artifact_type: "art_story" | "interactive_story";
+    source_id: string;
+  };
+  /** Optional success callback — receives the new post_id. */
+  onShared?: (postId: string, groupSlug: string) => void;
+}
+
+export default function ShareToHubModal({
+  open,
+  onClose,
+  source,
+  onShared,
+}: Props) {
+  const navigate = useNavigate();
+  const [groupId, setGroupId] = useState<string>("");
+  const [caption, setCaption] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["hub-groups"],
+    queryFn: () => hubService.listGroups(),
+    enabled: open,
+  });
+
+  const groups: Group[] = data?.items ?? [];
+
+  // Pre-select first group whenever the list arrives.
+  useEffect(() => {
+    if (open && !groupId && groups.length > 0) {
+      setGroupId(groups[0].group_id);
+    }
+  }, [open, groupId, groups]);
+
+  // Reset state on close.
+  useEffect(() => {
+    if (!open) {
+      setError(null);
+      setCaption("");
+    }
+  }, [open]);
+
+  const selected = useMemo(
+    () => groups.find((g) => g.group_id === groupId),
+    [groups, groupId],
+  );
+
+  if (!open) return null;
+
+  const handleShare = async () => {
+    setError(null);
+    if (!groupId) {
+      setError("Pick a group to share to.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const post = await hubService.createHubPost(groupId, {
+        source_artifact_type: source.artifact_type,
+        source_id: source.source_id,
+        caption: caption.trim() || undefined,
+      });
+      const slug = selected?.slug ?? groupId;
+      onShared?.(post.post_id, slug);
+      onClose();
+      navigate(`/content-hub/${slug}`);
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        const detail = err.response?.data?.detail as
+          | { code?: string; reason?: string }
+          | undefined;
+        switch (detail?.code) {
+          case "ONBOARDING_REQUIRED":
+          case "AGENT_REQUIRED":
+            onClose();
+            navigate(
+              `/my-agent?return=${encodeURIComponent(window.location.pathname)}`,
+            );
+            return;
+          case "NOT_A_MEMBER":
+            setError("You'll need to join this group before posting.");
+            break;
+          case "UNSAFE_CAPTION":
+            setError(
+              detail.reason ??
+                "That caption didn't pass our safety check — try a different one.",
+            );
+            break;
+          case "SAFETY_UNAVAILABLE":
+            setError("Our safety checker is taking a break. Try again in a minute.");
+            break;
+          default:
+            setError(detail?.reason ?? "Couldn't share to Content Hub.");
+        }
+      } else {
+        setError("Couldn't share to Content Hub. Try again.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="share-to-hub-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4 py-8"
+    >
+      <div className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl">
+        <header>
+          <h2
+            id="share-to-hub-title"
+            className="text-xl font-semibold text-gray-900"
+          >
+            Share to Content Hub
+          </h2>
+          <p className="mt-1 text-sm text-gray-600">
+            Your buddy will be the author — your real name and email never
+            show up here.
+          </p>
+        </header>
+
+        <div className="mt-4 flex flex-col gap-3">
+          {isLoading ? (
+            <p className="text-sm text-gray-500">Loading groups…</p>
+          ) : groups.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-700">
+              <p className="font-medium">No groups yet.</p>
+              <p className="mt-1 text-xs text-gray-500">
+                Create a group from Content Hub first, then come back to share.
+              </p>
+              <button
+                type="button"
+                className="mt-2 rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-white"
+                onClick={() => {
+                  onClose();
+                  navigate("/content-hub");
+                }}
+              >
+                Open Content Hub
+              </button>
+            </div>
+          ) : (
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Pick a group
+              <select
+                className="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                value={groupId}
+                onChange={(e) => setGroupId(e.target.value)}
+                disabled={busy}
+              >
+                {groups.map((g) => (
+                  <option key={g.group_id} value={g.group_id}>
+                    {g.name} ({g.visibility})
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          {groups.length > 0 && (
+            <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+              Caption (optional)
+              <textarea
+                className="min-h-[64px] rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                value={caption}
+                maxLength={MAX_CAPTION}
+                onChange={(e) =>
+                  setCaption(e.target.value.slice(0, MAX_CAPTION))
+                }
+                placeholder="Tell other kids what your story is about…"
+                disabled={busy}
+              />
+              <span className="text-xs text-gray-500">
+                {caption.length}/{MAX_CAPTION}
+              </span>
+            </label>
+          )}
+
+          {error && (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <footer className="mt-6 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            onClick={onClose}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          {groups.length > 0 && (
+            <button
+              type="button"
+              className="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700 disabled:bg-gray-300"
+              onClick={handleShare}
+              disabled={busy || !groupId}
+            >
+              {busy ? "Sharing…" : "Share"}
+            </button>
+          )}
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/InteractiveStoryPage/index.tsx
+++ b/frontend/src/pages/InteractiveStoryPage/index.tsx
@@ -20,6 +20,7 @@ import useAuthStore from "@/store/useAuthStore";
 import useChildStore, { DEFAULT_INTERESTS } from "@/store/useChildStore";
 import type { AgeGroup, StoryLengthMode } from "@/types/api";
 import type { AnimationPhase } from "@/types/streaming";
+import ShareToHubModal from "@/components/hub/ShareToHubModal";
 import LoginPrompt from "@/components/common/LoginPrompt";
 import SuggestedThemes from "@/components/common/SuggestedThemes";
 
@@ -110,6 +111,9 @@ function InteractiveStoryPage() {
   const [saveStatus, setSaveStatus] = useState<
     "idle" | "saving" | "saved" | "error"
   >("idle");
+
+  // Share-to-Content-Hub modal (#453)
+  const [shareOpen, setShareOpen] = useState(false);
 
   // Resume only when URL contains ?session=
   const [isResuming, setIsResuming] = useState(false);
@@ -691,7 +695,32 @@ function InteractiveStoryPage() {
               Back to Home
             </Button>
           </div>
+
+          {/* Share-to-Content-Hub CTA (#453) */}
+          {sessionId && (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="primary"
+                size="lg"
+                onClick={() => setShareOpen(true)}
+                leftIcon={<span>🌐</span>}
+              >
+                Share to Content Hub
+              </Button>
+            </div>
+          )}
         </motion.div>
+      )}
+
+      {sessionId && (
+        <ShareToHubModal
+          open={shareOpen}
+          onClose={() => setShareOpen(false)}
+          source={{
+            artifact_type: "interactive_story",
+            source_id: sessionId,
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/pages/StoryPage/index.tsx
+++ b/frontend/src/pages/StoryPage/index.tsx
@@ -12,6 +12,7 @@ import useStoryStore from "@/store/useStoryStore";
 import useChildStore from "@/store/useChildStore";
 import storyService from "@/api/services/storyService";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
+import ShareToHubModal from "@/components/hub/ShareToHubModal";
 
 function deriveStoryTitleFromText(storyText: string | undefined): string {
   if (!storyText) return "Your Story";
@@ -53,6 +54,8 @@ function StoryPage() {
 
   // Show banner only when navigating directly from the upload/generation flow
   const [showBanner, setShowBanner] = useState(false);
+  // Share-to-Content-Hub modal (#453)
+  const [shareOpen, setShareOpen] = useState(false);
 
   useEffect(() => {
     if (justGenerated) {
@@ -264,15 +267,32 @@ function StoryPage() {
         </Button>
       </motion.div>
 
-      {/* Share prompt */}
-      <motion.p
-        className="share-prompt"
+      {/* Share prompt + Share to Content Hub CTA (#453) */}
+      <motion.div
+        className="share-prompt flex flex-col items-center gap-3"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.5 }}
       >
-        Love this story? Share it with your family!
-      </motion.p>
+        <p>Love this story? Share it with your family!</p>
+        {storyId && (
+          <button
+            type="button"
+            className="rounded-md bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-violet-700"
+            onClick={() => setShareOpen(true)}
+          >
+            🌐 Share to Content Hub
+          </button>
+        )}
+      </motion.div>
+
+      {storyId && (
+        <ShareToHubModal
+          open={shareOpen}
+          onClose={() => setShareOpen(false)}
+          source={{ artifact_type: "art_story", source_id: storyId }}
+        />
+      )}
     </motion.div>
   );
 }


### PR DESCRIPTION
Fixes #453

Parent epic: #437
Depends on #449 (post endpoint), #451 (hubService + ContentHubPage). Both on main.

## Summary

The entry-point that turns a private creation into a hub post — a shared modal hosted on both story-result pages.

## Pieces

- New \`components/hub/ShareToHubModal.tsx\` — group picker (listGroups via TanStack), optional caption (≤280), Share → \`hubService.createHubPost(groupId, payload)\`. Navigates to \`/content-hub/<slug>\` on success.
- \`StoryPage\` — keeps the existing "share with your family!" line and adds a \`🌐 Share to Content Hub\` button below it. Source: \`{ artifact_type: 'art_story', source_id: storyId }\`.
- \`InteractiveStoryPage\` — end-of-story screen gets the same button under the existing Save / Play / Home row. Source: \`{ artifact_type: 'interactive_story', source_id: sessionId }\`.

## Server-error UX mapping

The modal maps each \`detail.code\` from the backend post endpoint (#449) to the right path:

| code | UI |
|---|---|
| \`ONBOARDING_REQUIRED\` / \`AGENT_REQUIRED\` | Close modal, route to \`/my-agent?return=<current>\` |
| \`NOT_A_MEMBER\` | Inline "you'll need to join this group first" |
| \`UNSAFE_CAPTION\` | Inline error on caption field |
| \`SAFETY_UNAVAILABLE\` | "Our safety checker is taking a break" toast |
| (other) | Generic "couldn't share" |

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Builds on \`hubService\` whose 8 vitest cases (#451) cover the URL/payload contract
- [ ] Page-render tests deferred until \`@testing-library/react\` is a project dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)