### PR TITLE
fix(ui): align logged-out states + soften onboarding gate (#444 follow-up)

### DIFF
--- a/frontend/src/components/common/SignInPrompt.tsx
+++ b/frontend/src/components/common/SignInPrompt.tsx
@@ -1,0 +1,43 @@
+/**
+ * SignInPrompt — shared empty-state for pages that need an auth session.
+ * Used by /my-agent and /content-hub guest views so the experience is
+ * aligned across the app.
+ *
+ * Issue: ui-polish on top of #442 / #444 / #451
+ */
+
+import { Link } from "react-router-dom";
+
+interface Props {
+  icon?: string;
+  title: string;
+  description: string;
+  /** Where to come back to after sign-in. Optional — defaults to current path. */
+  returnPath?: string;
+}
+
+export default function SignInPrompt({
+  icon = "👋",
+  title,
+  description,
+  returnPath,
+}: Props) {
+  const ret =
+    returnPath ?? (typeof window !== "undefined" ? window.location.pathname : "/");
+  const href = `/login?return=${encodeURIComponent(ret)}`;
+  return (
+    <div className="mx-auto flex max-w-2xl flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-gray-200 bg-white px-6 py-10 text-center">
+      <span className="text-4xl" aria-hidden="true">
+        {icon}
+      </span>
+      <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
+      <p className="max-w-md text-sm text-gray-600">{description}</p>
+      <Link
+        to={href}
+        className="mt-2 rounded-md bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500"
+      >
+        Sign in
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/PageContainer/requireOnboarded.test.ts
+++ b/frontend/src/components/layout/PageContainer/requireOnboarded.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { shouldRedirectToOnboarding } from "./requireOnboarded";
 
-describe("shouldRedirectToOnboarding", () => {
+describe("shouldRedirectToOnboarding (soft gate per PRD §3.11.2)", () => {
   it("does NOT redirect anonymous users", () => {
     expect(
       shouldRedirectToOnboarding({
         isAuthenticated: false,
         onboardedAt: null,
-        pathname: "/library",
+        pathname: "/content-hub",
       }),
     ).toBe(false);
   });
@@ -17,19 +17,48 @@ describe("shouldRedirectToOnboarding", () => {
       shouldRedirectToOnboarding({
         isAuthenticated: true,
         onboardedAt: "2026-01-01T00:00:00",
-        pathname: "/library",
+        pathname: "/content-hub",
       }),
     ).toBe(false);
   });
 
-  it("redirects authenticated, not-yet-onboarded users on a guarded path", () => {
+  it("redirects only when an authenticated, not-yet-onboarded user hits Content Hub", () => {
     expect(
       shouldRedirectToOnboarding({
         isAuthenticated: true,
         onboardedAt: null,
-        pathname: "/library",
+        pathname: "/content-hub",
       }),
     ).toBe(true);
+    expect(
+      shouldRedirectToOnboarding({
+        isAuthenticated: true,
+        onboardedAt: null,
+        pathname: "/content-hub/dragons",
+      }),
+    ).toBe(true);
+  });
+
+  it("does NOT redirect on Library, Upload, Story, Interactive, Profile, Kids Daily, Home", () => {
+    const openPaths = [
+      "/library",
+      "/upload",
+      "/story/abc",
+      "/interactive",
+      "/profile",
+      "/kids-daily",
+      "/kids-daily/episode-1",
+      "/",
+    ];
+    for (const p of openPaths) {
+      expect(
+        shouldRedirectToOnboarding({
+          isAuthenticated: true,
+          onboardedAt: null,
+          pathname: p,
+        }),
+      ).toBe(false);
+    }
   });
 
   it("does NOT redirect when already on /my-agent (avoids loops)", () => {
@@ -42,7 +71,7 @@ describe("shouldRedirectToOnboarding", () => {
     ).toBe(false);
   });
 
-  it("does NOT redirect on /login or /register so the user can sign in / out", () => {
+  it("does NOT redirect on /login or /register", () => {
     expect(
       shouldRedirectToOnboarding({
         isAuthenticated: true,
@@ -64,7 +93,7 @@ describe("shouldRedirectToOnboarding", () => {
       shouldRedirectToOnboarding({
         isAuthenticated: true,
         onboardedAt: undefined,
-        pathname: "/upload",
+        pathname: "/content-hub",
       }),
     ).toBe(true);
   });

--- a/frontend/src/components/layout/PageContainer/requireOnboarded.ts
+++ b/frontend/src/components/layout/PageContainer/requireOnboarded.ts
@@ -5,6 +5,12 @@
  * Extracted so it's unit-testable without mounting the page tree
  * (the project does not depend on @testing-library/react).
  *
+ * Per PRD §3.11.2: onboarding is a SOFT gate. The "Not now" path lets
+ * the child use the rest of the app but blocks Content Hub posting
+ * until consent is given. So this helper only fires on /content-hub
+ * paths (and the share-to-hub flow that lives there) — never on the
+ * entire app.
+ *
  * Issue: #444 | Parent epic: #436
  */
 
@@ -12,6 +18,18 @@ export interface OnboardingGateInput {
   isAuthenticated: boolean;
   onboardedAt: string | null | undefined;
   pathname: string;
+}
+
+/**
+ * Paths that REQUIRE onboarding to access. Everything else is open
+ * to authenticated users regardless of onboarding state.
+ */
+function requiresOnboarding(pathname: string): boolean {
+  // Content Hub is the public-sharing surface; posting / browsing
+  // private groups requires the buddy persona to exist. Public
+  // landing reads are still open to onboarded-or-not via the page's
+  // own guest-empty state, but the gate itself only fires here.
+  return pathname.startsWith("/content-hub");
 }
 
 export function shouldRedirectToOnboarding(
@@ -23,5 +41,7 @@ export function shouldRedirectToOnboarding(
   if (pathname === "/my-agent") return false;
   if (pathname.startsWith("/login")) return false;
   if (pathname.startsWith("/register")) return false;
+  // Soft gate: only block paths that genuinely need a buddy persona.
+  if (!requiresOnboarding(pathname)) return false;
   return true;
 }

--- a/frontend/src/hooks/useAgent.ts
+++ b/frontend/src/hooks/useAgent.ts
@@ -3,22 +3,40 @@
  *
  * Mirrors the style of useMemoryApi.ts: a useQuery for the read path,
  * a useMutation that invalidates the read query on success.
+ *
+ * Auth gate: the query is disabled when the user is not authenticated
+ * so we never storm /api/v1/me/agent with 401s. Without this gate, a
+ * logged-out visit to /my-agent fired hundreds of requests per second
+ * (each with a freshly-generated child_id) — see commit message for
+ * the runaway-loop fix.
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import { agentService } from "@/api/services/agentService";
+import useAuthStore from "@/store/useAuthStore";
 import type { Agent, UpsertAgentPayload } from "@/types/agent";
 
 const AGENT_QUERY_KEY = (childId: string | undefined) =>
   ["agent", childId ?? null] as const;
 
 export function useAgent(childId: string | undefined | null) {
-  const enabled = Boolean(childId);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const enabled = Boolean(childId) && isAuthenticated;
   return useQuery<Agent | null>({
     queryKey: AGENT_QUERY_KEY(childId ?? undefined),
     queryFn: () => agentService.getAgent(childId as string),
     enabled,
     staleTime: 60_000,
+    // Don't retry on 401 — the request will keep failing until the user
+    // signs in. Retrying just multiplies the noise (and on a network
+    // error, our existing service already throws cleanly).
+    retry: (failureCount, error) => {
+      if (error instanceof AxiosError && error.response?.status === 401) {
+        return false;
+      }
+      return failureCount < 2;
+    },
   });
 }
 

--- a/frontend/src/pages/ContentHubPage/index.tsx
+++ b/frontend/src/pages/ContentHubPage/index.tsx
@@ -19,6 +19,8 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { hubService } from "@/api/services/hubService";
+import useAuthStore from "@/store/useAuthStore";
+import SignInPrompt from "@/components/common/SignInPrompt";
 import type {
   CreateGroupPayload,
   Group,
@@ -32,12 +34,15 @@ const HUB_GROUPS_KEY = ["hub-groups"] as const;
 export default function ContentHubPage() {
   const navigate = useNavigate();
   const qc = useQueryClient();
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const onboardedAt = useAuthStore((s) => s.user?.onboarded_at);
   const [createOpen, setCreateOpen] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
 
   const { data, isLoading } = useQuery<ListGroupsResponse>({
     queryKey: HUB_GROUPS_KEY,
     queryFn: () => hubService.listGroups(),
+    enabled: isAuthenticated,
   });
 
   const createMutation = useMutation({
@@ -82,6 +87,26 @@ export default function ContentHubPage() {
   const items = data?.items ?? [];
   const myGroups = items.filter((g) => g.visibility === "private");
   const publicGroups = items.filter((g) => g.visibility === "public");
+  const canCreate = isAuthenticated && Boolean(onboardedAt);
+
+  if (!isAuthenticated) {
+    return (
+      <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8">
+        <header>
+          <h1 className="text-2xl font-semibold text-gray-900">Content Hub</h1>
+          <p className="text-sm text-gray-600">
+            Browse stories from other kids and start groups around the themes
+            you love.
+          </p>
+        </header>
+        <SignInPrompt
+          icon="🌐"
+          title="Sign in to join the Hub"
+          description="The Hub is where kids share stories with each other. Sign in to browse public groups, post your own creations under your buddy's name, and react to others'."
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8">
@@ -94,13 +119,26 @@ export default function ContentHubPage() {
             animal — never your real name.
           </p>
         </div>
-        <button
-          type="button"
-          className="shrink-0 rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
-          onClick={() => setCreateOpen(true)}
-        >
-          + New group
-        </button>
+        {canCreate ? (
+          <button
+            type="button"
+            className="shrink-0 rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+            onClick={() => setCreateOpen(true)}
+          >
+            + New group
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="shrink-0 rounded-md border border-violet-300 bg-white px-4 py-2 text-sm font-medium text-violet-700 hover:bg-violet-50"
+            onClick={() =>
+              navigate(`/my-agent?return=${encodeURIComponent("/content-hub")}`)
+            }
+            title="Meet your buddy first to create a group"
+          >
+            Meet buddy → New group
+          </button>
+        )}
       </header>
 
       {joinError && (
@@ -117,14 +155,22 @@ export default function ContentHubPage() {
             No groups yet — be the first!
           </p>
           <p className="mt-1 text-sm text-gray-500">
-            Create a group around a theme you love and invite friends.
+            {canCreate
+              ? "Create a group around a theme you love and invite friends."
+              : "Meet your buddy first, then come back to start your own group."}
           </p>
           <button
             type="button"
             className="mt-4 rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
-            onClick={() => setCreateOpen(true)}
+            onClick={() =>
+              canCreate
+                ? setCreateOpen(true)
+                : navigate(
+                    `/my-agent?return=${encodeURIComponent("/content-hub")}`,
+                  )
+            }
           >
-            Create the first group
+            {canCreate ? "Create the first group" : "Meet your buddy first"}
           </button>
         </div>
       )}

--- a/frontend/src/pages/MyAgentPage/index.tsx
+++ b/frontend/src/pages/MyAgentPage/index.tsx
@@ -25,6 +25,7 @@ import { useAgent, useUpsertAgent } from "@/hooks/useAgent";
 import AgentTitlePicker from "./AgentTitlePicker";
 import OnboardingModal from "./OnboardingModal";
 import { shouldAutoOpenOnboarding } from "./onboardingState";
+import SignInPrompt from "@/components/common/SignInPrompt";
 import type { AgentErrorDetail } from "@/types/agent";
 
 const MAX_NAME = 32;
@@ -58,14 +59,17 @@ export default function MyAgentPage() {
   const childId = currentChild?.child_id ?? defaultChildId;
   const ageGroup = currentChild?.age_group;
 
-  const { data: existing, isLoading } = useAgent(childId);
-  const upsert = useUpsertAgent();
-
   // First-login modal: auto-opens when authenticated user has not yet
   // completed onboarding (#443). The modal walks through name/avatar/title
   // + parent consent and calls POST /me/onboarding/complete on submit.
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
   const onboardedAt = useAuthStore((s) => s.user?.onboarded_at);
+
+  // Guard: useAgent is gated on isAuthenticated, but we also short-circuit
+  // the page tree entirely so guests see a clean sign-in prompt instead of
+  // a half-rendered editor that can't possibly save.
+  const { data: existing, isLoading } = useAgent(childId);
+  const upsert = useUpsertAgent();
   const [modalOpen, setModalOpen] = useState(false);
   useEffect(() => {
     if (isLoading) return;
@@ -163,6 +167,27 @@ export default function MyAgentPage() {
       }
     }
   };
+
+  if (!isAuthenticated) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8">
+        <header className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold text-gray-900">
+            Meet your creative buddy
+          </h1>
+          <p className="text-sm text-gray-600">
+            Your buddy is the name and animal we'll show whenever you share a
+            story to Content Hub. Sign in to set yours up.
+          </p>
+        </header>
+        <SignInPrompt
+          icon="🦊"
+          title="Sign in to meet your buddy"
+          description="Once you sign in, we'll walk you through naming your creative buddy and picking its animal — takes under a minute."
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8">


### PR DESCRIPTION
Follow-up to #436 / #437. Fixes two UX bugs surfaced when smoke-testing the new pages in the browser.

## Bug 1 — Hard onboarding gate violated PRD §3.11.2

The RequireOnboarded gate in #444 was redirecting **every** authenticated path to \`/my-agent\` when \`users.onboarded_at\` was null. PRD §3.11.2 says onboarding is a **soft gate** — the *"Not now"* path lets the child use the rest of the app and only blocks Content Hub posting until consent is given.

**Fix:** the gate now only fires on \`/content-hub*\` paths. Library, Upload, Story, Interactive, Profile, Kids Daily, Home all stay open to authenticated-but-not-onboarded users.

## Bug 2 — Logged-out states were broken on the new pages

\`/my-agent\` and \`/content-hub\` had no guest empty-state. Visiting them as a guest:
- Fired hundreds of \`/api/v1/me/agent?child_id=...\` requests per second (200+ console errors per page-load) because \`useAgent\` had no auth gate and TanStack Query was retrying 401s.
- Rendered a half-built editor that couldn't save.

**Fix:**
- \`useAgent\` is now gated on \`isAuthenticated\` and \`retry: false\` on 401.
- New shared \`SignInPrompt\` component used by both pages.
- \`MyAgentPage\` short-circuits to the prompt when guest.
- \`ContentHubPage\` shows the prompt when guest, and a "Meet buddy → New group" CTA when authenticated-but-not-onboarded.

## Test plan

- [x] 7/7 vitest cases on \`shouldRedirectToOnboarding\` pass (expanded test asserts the open-paths list)
- [x] \`tsc --noEmit\` clean
- [x] Manual smoke at \`/my-agent\` and \`/content-hub\` as guest: zero console errors, aligned guest UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)