### PR TITLE
fix(ui): stop redirecting /content-hub to /my-agent for not-onboarded users

### DIFF
--- a/frontend/src/components/layout/PageContainer/requireOnboarded.test.ts
+++ b/frontend/src/components/layout/PageContainer/requireOnboarded.test.ts
@@ -1,100 +1,37 @@
 import { describe, expect, it } from "vitest";
 import { shouldRedirectToOnboarding } from "./requireOnboarded";
 
-describe("shouldRedirectToOnboarding (soft gate per PRD §3.11.2)", () => {
-  it("does NOT redirect anonymous users", () => {
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: false,
-        onboardedAt: null,
-        pathname: "/content-hub",
-      }),
-    ).toBe(false);
-  });
+/**
+ * Per PRD §3.11.2 onboarding is a soft gate. The route-level helper
+ * never redirects; per-action affordances inside Content Hub and the
+ * Share-to-Hub modal do the actual gating.
+ *
+ * These cases lock that contract so a future regression that re-enables
+ * the redirect (e.g. by adding paths back) flips the test red.
+ */
+describe("shouldRedirectToOnboarding (soft gate, no route redirect)", () => {
+  const matrix = [
+    { isAuthenticated: false, onboardedAt: null, pathname: "/content-hub" },
+    { isAuthenticated: true, onboardedAt: null, pathname: "/content-hub" },
+    {
+      isAuthenticated: true,
+      onboardedAt: null,
+      pathname: "/content-hub/dragons",
+    },
+    {
+      isAuthenticated: true,
+      onboardedAt: "2026-01-01T00:00:00",
+      pathname: "/content-hub",
+    },
+    { isAuthenticated: true, onboardedAt: null, pathname: "/library" },
+    { isAuthenticated: true, onboardedAt: null, pathname: "/upload" },
+    { isAuthenticated: true, onboardedAt: null, pathname: "/my-agent" },
+    { isAuthenticated: true, onboardedAt: null, pathname: "/login" },
+  ];
 
-  it("does NOT redirect users who have already onboarded", () => {
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: true,
-        onboardedAt: "2026-01-01T00:00:00",
-        pathname: "/content-hub",
-      }),
-    ).toBe(false);
-  });
-
-  it("redirects only when an authenticated, not-yet-onboarded user hits Content Hub", () => {
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: true,
-        onboardedAt: null,
-        pathname: "/content-hub",
-      }),
-    ).toBe(true);
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: true,
-        onboardedAt: null,
-        pathname: "/content-hub/dragons",
-      }),
-    ).toBe(true);
-  });
-
-  it("does NOT redirect on Library, Upload, Story, Interactive, Profile, Kids Daily, Home", () => {
-    const openPaths = [
-      "/library",
-      "/upload",
-      "/story/abc",
-      "/interactive",
-      "/profile",
-      "/kids-daily",
-      "/kids-daily/episode-1",
-      "/",
-    ];
-    for (const p of openPaths) {
-      expect(
-        shouldRedirectToOnboarding({
-          isAuthenticated: true,
-          onboardedAt: null,
-          pathname: p,
-        }),
-      ).toBe(false);
-    }
-  });
-
-  it("does NOT redirect when already on /my-agent (avoids loops)", () => {
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: true,
-        onboardedAt: null,
-        pathname: "/my-agent",
-      }),
-    ).toBe(false);
-  });
-
-  it("does NOT redirect on /login or /register", () => {
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: true,
-        onboardedAt: null,
-        pathname: "/login",
-      }),
-    ).toBe(false);
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: true,
-        onboardedAt: null,
-        pathname: "/register",
-      }),
-    ).toBe(false);
-  });
-
-  it("treats undefined onboardedAt the same as null (fresh user)", () => {
-    expect(
-      shouldRedirectToOnboarding({
-        isAuthenticated: true,
-        onboardedAt: undefined,
-        pathname: "/content-hub",
-      }),
-    ).toBe(true);
-  });
+  for (const input of matrix) {
+    it(`does NOT redirect: ${JSON.stringify(input)}`, () => {
+      expect(shouldRedirectToOnboarding(input)).toBe(false);
+    });
+  }
 });

--- a/frontend/src/components/layout/PageContainer/requireOnboarded.ts
+++ b/frontend/src/components/layout/PageContainer/requireOnboarded.ts
@@ -2,14 +2,15 @@
  * Pure helper that decides whether the RequireOnboarded effect in
  * PageContainer should redirect the current request to /my-agent.
  *
- * Extracted so it's unit-testable without mounting the page tree
- * (the project does not depend on @testing-library/react).
+ * Per PRD §3.11.2 onboarding is a SOFT gate. We do NOT redirect on
+ * route navigation — that was annoying users who wanted to browse
+ * Content Hub before crafting a buddy. Per-action affordances inside
+ * /content-hub and the Share-to-Hub modal handle the actual gating
+ * (create / join / post require an onboarded buddy; browsing does not).
  *
- * Per PRD §3.11.2: onboarding is a SOFT gate. The "Not now" path lets
- * the child use the rest of the app but blocks Content Hub posting
- * until consent is given. So this helper only fires on /content-hub
- * paths (and the share-to-hub flow that lives there) — never on the
- * entire app.
+ * The function is kept (instead of being deleted outright) so that
+ * future paths which truly REQUIRE onboarding can opt in by extending
+ * the inner allowlist. Today no path requires it.
  *
  * Issue: #444 | Parent epic: #436
  */
@@ -20,28 +21,9 @@ export interface OnboardingGateInput {
   pathname: string;
 }
 
-/**
- * Paths that REQUIRE onboarding to access. Everything else is open
- * to authenticated users regardless of onboarding state.
- */
-function requiresOnboarding(pathname: string): boolean {
-  // Content Hub is the public-sharing surface; posting / browsing
-  // private groups requires the buddy persona to exist. Public
-  // landing reads are still open to onboarded-or-not via the page's
-  // own guest-empty state, but the gate itself only fires here.
-  return pathname.startsWith("/content-hub");
-}
-
 export function shouldRedirectToOnboarding(
-  input: OnboardingGateInput,
+  _input: OnboardingGateInput,
 ): boolean {
-  const { isAuthenticated, onboardedAt, pathname } = input;
-  if (!isAuthenticated) return false;
-  if (onboardedAt) return false;
-  if (pathname === "/my-agent") return false;
-  if (pathname.startsWith("/login")) return false;
-  if (pathname.startsWith("/register")) return false;
-  // Soft gate: only block paths that genuinely need a buddy persona.
-  if (!requiresOnboarding(pathname)) return false;
-  return true;
+  // Intentionally always returns false. See header comment.
+  return false;
 }


### PR DESCRIPTION
Follow-up to #481.

## What was broken

A logged-in user with \`onboarded_at = null\` clicking **Content Hub** in the nav got bounced to \`/my-agent?return=%2Fcontent-hub\`. They couldn't even **see** the hub before being forced into onboarding.

## Why redirect at all is wrong here

Per-action affordances already gate the things that genuinely require a buddy:

- "+ New group" button becomes **"Meet buddy → New group"** for not-onboarded users (#481).
- The Share-to-Hub modal routes through \`/my-agent\` on \`AGENT_REQUIRED\` / \`ONBOARDING_REQUIRED\` 412 responses (#453).
- The backend POST endpoints (#449, #454, etc.) enforce the 412 gates server-side regardless of what the client does.

So the route-level redirect was **redundant** and **harmful UX**.

## Fix

\`shouldRedirectToOnboarding\` now always returns false. The function is kept (rather than deleted) so a future path that truly needs onboarding can opt in by extending it — but today no path requires it.

## Test plan

- [x] 8/8 vitest cases on the no-redirect contract
- [x] \`tsc --noEmit\` clean
- [x] Browser smoke: a logged-in user can hit \`/content-hub\` and see the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)