### PR TITLE
fix(safety): call check_content_safety via .handler + pin httpx<0.28

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -25,7 +25,12 @@ pgvector>=0.2.0
 pillow>=10.2.0
 
 # HTTP Client
-httpx>=0.27.0,<1
+# Pinned <0.28 because httpx 0.28 removed the `proxies=` kwarg that
+# anthropic 0.18.1's Client.__init__ still passes internally. Symptom:
+# every safety_check_server call raises:
+#   "Client.__init__() got an unexpected keyword argument 'proxies'"
+# which surfaces as HTTP 503 SAFETY_UNAVAILABLE on the buddy save flow.
+httpx>=0.27.0,<0.28
 
 # Web Search (News fetching for Daily Drop)
 tavily-python>=0.5.0

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -57,9 +57,16 @@ async def _run_safety_check(text: str) -> float:
     the MCP server is unreachable or returned an error envelope so the
     caller can fail closed (HTTP 503) — we never silently let unchecked
     text through.
+
+    Note: ``check_content_safety`` is decorated with the SDK's ``@tool``,
+    which wraps it in an ``SdkMcpTool`` registration object that is NOT
+    itself callable. The raw async handler lives at ``.handler``. Without
+    this we'd get ``TypeError: 'SdkMcpTool' object is not callable``,
+    which the outer ``except Exception`` catches and surfaces to the
+    user as ``Our safety checker is taking a break.`` (HTTP 503).
     """
     try:
-        result = await check_content_safety({
+        result = await check_content_safety.handler({
             "content_text": text,
             "content_type": "agent_persona",
             "target_age": _AGENT_SAFETY_TARGET_AGE,

--- a/backend/src/api/routes/hub/posts.py
+++ b/backend/src/api/routes/hub/posts.py
@@ -57,9 +57,13 @@ async def _run_caption_safety(text: str) -> float:
 
     We treat the youngest tier as the target age so the strictest filter
     applies — captions are read by all child age groups.
+
+    Note: ``check_content_safety`` is decorated with the SDK's ``@tool``
+    which wraps it in an ``SdkMcpTool`` registration object that is NOT
+    itself callable. The raw async handler lives at ``.handler``.
     """
     try:
-        result = await check_content_safety({
+        result = await check_content_safety.handler({
             "content_text": text,
             "content_type": "hub_caption",
             "target_age": _AGENT_SAFETY_TARGET_AGE,

--- a/backend/tests/contracts/test_admin_hub_endpoint_contract.py
+++ b/backend/tests/contracts/test_admin_hub_endpoint_contract.py
@@ -178,7 +178,7 @@ async def _create_post(client: AsyncClient) -> str:
     assert r1.status_code == 201, r1.text
     gid = r1.json()["group_id"]
     with patch(
-        "backend.src.api.routes.hub.posts.check_content_safety",
+        "backend.src.api.routes.hub.posts.check_content_safety.handler",
         new=AsyncMock(return_value=_safety(0.99)),
     ):
         r2 = await client.post(

--- a/backend/tests/contracts/test_agent_endpoint_contract.py
+++ b/backend/tests/contracts/test_agent_endpoint_contract.py
@@ -158,7 +158,7 @@ class TestAvatarWhitelist:
         body = _valid_body(agent_avatar_id="emoji:🦖")
         # Even though we hit the avatar branch first, mock safety to be safe.
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -169,7 +169,7 @@ class TestAvatarWhitelist:
     async def test_accepts_avatar_in_whitelist(self, client):
         body = _valid_body(agent_avatar_id="emoji:🐶")
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -189,7 +189,7 @@ class TestNameSafety:
         # Mock returns safety_score below 0.85 -> route must reject.
         body = _valid_body(agent_name="something_unsafe")
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.50)),
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -200,7 +200,7 @@ class TestNameSafety:
     async def test_safe_name_accepted(self, client):
         body = _valid_body(agent_name="Sparkle")
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -221,7 +221,7 @@ class TestCuratedTitleBypass:
         body = _valid_body(agent_title="Brave Lion")
         mock_safety = AsyncMock(return_value=_safety_response(0.99))
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=mock_safety,
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -235,7 +235,7 @@ class TestCuratedTitleBypass:
         body = _valid_body(agent_title="My Cool Title")
         mock_safety = AsyncMock(return_value=_safety_response(0.99))
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=mock_safety,
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -257,7 +257,7 @@ class TestSafetyFailClosed:
         """When the MCP tool raises, the route must return 503 with SAFETY_UNAVAILABLE."""
         body = _valid_body()  # curated title, so only name is safety-checked
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(side_effect=RuntimeError("boom")),
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -274,7 +274,7 @@ class TestSafetyFailClosed:
             ]
         }
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=bad),
         ):
             r = await client.put("/api/v1/me/agent", json=body)
@@ -294,7 +294,7 @@ class TestUpsertIdempotency:
     async def test_repeated_put_same_body_same_agent_id(self, client):
         body = _valid_body(child_id="child_idempotent")
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r1 = await client.put("/api/v1/me/agent", json=body)
@@ -306,7 +306,7 @@ class TestUpsertIdempotency:
     @pytest.mark.asyncio
     async def test_different_child_id_yields_distinct_agent(self, client):
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r1 = await client.put(
@@ -340,7 +340,7 @@ class TestGetAgent:
     async def test_returns_agent_after_upsert(self, client):
         body = _valid_body(child_id="child_get_test")
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             put = await client.put("/api/v1/me/agent", json=body)

--- a/backend/tests/contracts/test_default_child_id_contract.py
+++ b/backend/tests/contracts/test_default_child_id_contract.py
@@ -132,7 +132,7 @@ class TestSetsOnFirstPut:
         assert before.default_child_id is None
 
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r = await client.put("/api/v1/me/agent", json=_valid_body("child_first"))
@@ -154,7 +154,7 @@ class TestNeverOverwrites:
     ):
         # Pre-set default_child_id to child-A by the first PUT.
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r1 = await client.put("/api/v1/me/agent", json=_valid_body("child-A"))
@@ -165,7 +165,7 @@ class TestNeverOverwrites:
 
         # Now PUT a SECOND agent for a DIFFERENT child profile.
         with patch(
-            "backend.src.api.routes.agents.check_content_safety",
+            "backend.src.api.routes.agents.check_content_safety.handler",
             new=AsyncMock(return_value=_safety_response(0.99)),
         ):
             r2 = await client.put("/api/v1/me/agent", json=_valid_body("child-B"))

--- a/backend/tests/contracts/test_hub_coppa_invariant.py
+++ b/backend/tests/contracts/test_hub_coppa_invariant.py
@@ -210,7 +210,7 @@ async def test_get_group_posts_response_contains_no_user_pii(client) -> None:
     group_id = r1.json()["group_id"]
 
     with patch(
-        "backend.src.api.routes.hub.posts.check_content_safety",
+        "backend.src.api.routes.hub.posts.check_content_safety.handler",
         new=AsyncMock(return_value=_safety_response(0.99)),
     ):
         r2 = await client.post(

--- a/backend/tests/contracts/test_hub_posts_endpoint_contract.py
+++ b/backend/tests/contracts/test_hub_posts_endpoint_contract.py
@@ -223,7 +223,7 @@ class TestCreateGates:
         gid = await _create_public_group(client)
         # No _seed_buddy(_OWNER) call.
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(return_value=_safety(0.99)),
         ):
             r = await client.post(
@@ -272,7 +272,7 @@ class TestCaptionSafety:
         await _seed_buddy(_OWNER)
         gid = await _create_public_group(client)
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(return_value=_safety(0.5)),
         ):
             r = await client.post(
@@ -291,7 +291,7 @@ class TestCaptionSafety:
         await _seed_buddy(_OWNER)
         gid = await _create_public_group(client)
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(side_effect=Exception("mcp down")),
         ):
             r = await client.post(
@@ -312,7 +312,7 @@ class TestCaptionSafety:
         # Patch raises on call; should not be called when caption is None.
         mock = AsyncMock(side_effect=Exception("should not be called"))
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=mock,
         ):
             r = await client.post(
@@ -334,7 +334,7 @@ class TestHappyPath:
         await _seed_buddy(_OWNER)
         gid = await _create_public_group(client)
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(return_value=_safety(0.95)),
         ):
             r = await client.post(
@@ -372,7 +372,7 @@ class TestHappyPath:
         await _seed_buddy(_OWNER)
         gid = await _create_public_group(client)
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(return_value=_safety(0.99)),
         ):
             await client.post(
@@ -410,7 +410,7 @@ class TestPrivateGroupReadAccess:
         assert r1.status_code == 201, r1.text
         gid = r1.json()["group_id"]
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(return_value=_safety(0.99)),
         ):
             await client.post(
@@ -436,7 +436,7 @@ class TestPagination:
         await _seed_buddy(_OWNER)
         gid = await _create_public_group(client)
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(return_value=_safety(0.99)),
         ):
             for i in range(3):

--- a/backend/tests/contracts/test_hub_reactions_endpoint_contract.py
+++ b/backend/tests/contracts/test_hub_reactions_endpoint_contract.py
@@ -166,7 +166,7 @@ async def _make_public_post(client: AsyncClient) -> str:
     )
     gid = r1.json()["group_id"]
     with patch(
-        "backend.src.api.routes.hub.posts.check_content_safety",
+        "backend.src.api.routes.hub.posts.check_content_safety.handler",
         new=AsyncMock(return_value=_safety(0.99)),
     ):
         r2 = await client.post(
@@ -246,7 +246,7 @@ class TestVisibilityGate:
         )
         gid = r1.json()["group_id"]
         with patch(
-            "backend.src.api.routes.hub.posts.check_content_safety",
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
             new=AsyncMock(return_value=_safety(0.99)),
         ):
             r2 = await client.post(


### PR DESCRIPTION
Reported by the user: clicking "I'm a parent and I'm OK with this" on the OnboardingModal failed with **"Our safety checker is taking a break"** and HTTP 503 in the network tab.

## Root causes

### 1. \`SdkMcpTool\` is not callable

\`check_content_safety\` is decorated with the SDK's \`@tool\`, which replaces the function with an \`SdkMcpTool\` registration object. The raw async function lives at \`.handler\`. The agent + hub-post routes called it as \`await check_content_safety({...})\`, which raises \`TypeError: 'SdkMcpTool' object is not callable\` — caught by the outer \`except Exception\`, surfaced as 503 \`SAFETY_UNAVAILABLE\`. So no buddy ever saved with a real backend.

### 2. anthropic 0.18 + httpx 0.28 incompatibility

With (1) fixed, the underlying call still failed:

\`\`\`
Client.__init__() got an unexpected keyword argument 'proxies'
\`\`\`

\`anthropic\` 0.18.1's \`Client.__init__\` passes \`proxies=\` to httpx internally, but httpx 0.28 **removed** that parameter. The existing pin (\`httpx>=0.27.0,<1\`) allowed 0.28.x to install. Tightened to \`<0.28\`.

## Test plan

- [x] **41/41** contract tests across 6 impacted suites green (mocks updated to patch \`.handler\` instead of the wrapper)
- [x] Live verification via the safety server directly:
  - Before fix: \`TypeError: 'SdkMcpTool' object is not callable\`
  - After pin: succeeds, real Anthropic API returns a \`safety_score\`

## Out of scope

\`interactive_story._check_story_safety\` has the same wrapper-pattern bug but isn't on the reported path. Left for a follow-up to keep blast radius small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)