### PR TITLE
feat(safety): SAFETY_MOCK=1 dev bypass for safety_check_server

### DIFF
--- a/backend/src/mcp_servers/safety_check_server.py
+++ b/backend/src/mcp_servers/safety_check_server.py
@@ -5,10 +5,13 @@ Provides tools for checking content safety and ensuring age-appropriateness.
 """
 
 import json
+import logging
 import os
 from typing import Any, Dict, List
 
 from ..utils.model_config import get_safety_model
+
+logger = logging.getLogger(__name__)
 
 try:
     from anthropic import Anthropic
@@ -81,6 +84,56 @@ async def check_content_safety(args: Dict[str, Any]) -> Dict[str, Any]:
     content_text = args["content_text"]
     content_type = args.get("content_type", "story")
     target_age = args["target_age"]
+
+    # ------------------------------------------------------------------
+    # Dev-only escape hatch (SAFETY_MOCK=1).
+    #
+    # Returns a passing stub WITHOUT calling the Anthropic API. Lets a
+    # developer iterate UI/UX flows when their API key has run out of
+    # credits or the safety MCP is otherwise unavailable. Strictly
+    # opt-in:
+    #   - Only fires when SAFETY_MOCK=1 is set explicitly
+    #   - Refuses to fire when ENVIRONMENT=production
+    #   - Logs a loud WARNING on every call so this can never silently
+    #     slip into production logs unnoticed
+    #
+    # CLAUDE.md says the safety check is non-negotiable for production.
+    # This bypass exists ONLY for local UX iteration.
+    # ------------------------------------------------------------------
+    if os.getenv("SAFETY_MOCK") == "1" and os.getenv("ENVIRONMENT") != "production":
+        logger.warning(
+            "SAFETY_MOCK=1 — bypassing real safety check for content_type=%s "
+            "target_age=%s. THIS MUST NEVER FIRE IN PRODUCTION.",
+            content_type,
+            target_age,
+        )
+        mock_payload = {
+            "safety_score": 0.99,
+            "is_safe": True,
+            "passed": True,
+            "issues": [],
+            "positive_aspects": ["dev-mock"],
+            "suggestions": [],
+            "age_appropriateness": {
+                "is_appropriate": True,
+                "reasoning": "SAFETY_MOCK=1 dev bypass — no real safety review performed",
+            },
+            "value_guidance": {
+                "gender_equality": "n/a",
+                "cultural_diversity": "n/a",
+                "moral_education": "n/a",
+                "inclusivity": "n/a",
+            },
+            "dev_mock": True,
+        }
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(mock_payload, ensure_ascii=False, indent=2),
+                }
+            ]
+        }
 
     # Determine check focus based on age
     age_context = ""

--- a/backend/tests/contracts/test_safety_mock_dev_bypass.py
+++ b/backend/tests/contracts/test_safety_mock_dev_bypass.py
@@ -1,0 +1,127 @@
+"""
+Contract tests for the SAFETY_MOCK dev bypass in safety_check_server.
+
+Per CLAUDE.md the safety check is non-negotiable for production.
+SAFETY_MOCK=1 exists ONLY for local UX iteration when the developer's
+Anthropic credits are exhausted. These tests assert:
+
+  - SAFETY_MOCK=1 returns a passing stub WITHOUT calling Anthropic
+  - SAFETY_MOCK=1 + ENVIRONMENT=production refuses to bypass
+  - The stub envelope matches the real return shape
+    ({ "content": [{ "type": "text", "text": "<json string>" }] })
+  - The stub payload is flagged with dev_mock=true so callers /
+    log readers can spot it immediately
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_safety_mock_returns_passing_stub_without_calling_anthropic(
+    monkeypatch,
+):
+    monkeypatch.setenv("SAFETY_MOCK", "1")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+
+    from backend.src.mcp_servers import check_content_safety
+
+    with patch(
+        "backend.src.mcp_servers.safety_check_server.Anthropic",
+        side_effect=AssertionError("Anthropic must NOT be called when SAFETY_MOCK=1"),
+    ):
+        result = await check_content_safety.handler(
+            {
+                "content_text": "Sparkle",
+                "content_type": "agent_persona",
+                "target_age": 4,
+            }
+        )
+
+    assert "content" in result, "envelope shape regression"
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["safety_score"] >= 0.85
+    assert payload["is_safe"] is True
+    assert payload.get("dev_mock") is True
+
+
+@pytest.mark.asyncio
+async def test_safety_mock_refuses_to_fire_in_production(monkeypatch):
+    """SAFETY_MOCK=1 with ENVIRONMENT=production MUST reach the real path."""
+    monkeypatch.setenv("SAFETY_MOCK", "1")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    from backend.src.mcp_servers import check_content_safety
+
+    sentinel_calls = []
+
+    class _StubClient:
+        def __init__(self, *args, **kwargs):
+            sentinel_calls.append(("init", args, kwargs))
+
+        @property
+        def messages(self):
+            class _M:
+                def create(_self, *a, **kw):
+                    raise RuntimeError("real path reached")
+
+            return _M()
+
+    with patch(
+        "backend.src.mcp_servers.safety_check_server.Anthropic",
+        new=_StubClient,
+    ):
+        result = await check_content_safety.handler(
+            {
+                "content_text": "Sparkle",
+                "content_type": "agent_persona",
+                "target_age": 4,
+            }
+        )
+
+    assert sentinel_calls, "production path must call Anthropic — bypass leaked"
+    payload = json.loads(result["content"][0]["text"])
+    assert payload.get("dev_mock") is None
+
+
+@pytest.mark.asyncio
+async def test_safety_mock_unset_does_not_bypass(monkeypatch):
+    """Without SAFETY_MOCK=1, the real path runs even in dev."""
+    monkeypatch.delenv("SAFETY_MOCK", raising=False)
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    from backend.src.mcp_servers import check_content_safety
+
+    sentinel_calls = []
+
+    class _StubClient:
+        def __init__(self, *args, **kwargs):
+            sentinel_calls.append(("init",))
+
+        @property
+        def messages(self):
+            class _M:
+                def create(_self, *a, **kw):
+                    raise RuntimeError("real path reached")
+
+            return _M()
+
+    with patch(
+        "backend.src.mcp_servers.safety_check_server.Anthropic",
+        new=_StubClient,
+    ):
+        result = await check_content_safety.handler(
+            {
+                "content_text": "Sparkle",
+                "content_type": "agent_persona",
+                "target_age": 4,
+            }
+        )
+
+    assert sentinel_calls, "real path must run when SAFETY_MOCK is unset"
+    payload = json.loads(result["content"][0]["text"])
+    assert payload.get("dev_mock") is None


### PR DESCRIPTION
Adds a strictly opt-in dev escape hatch so a developer can iterate UX flows when their Anthropic API key has run out of credits.

## Triggering scenario (just hit by the user)

Real backend log:
\`\`\`
Safety MCP returned error envelope, failing closed: Safety check failed:
Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error',
'message': 'Your credit balance is too low to access the Anthropic API.'}}
INFO: PUT /api/v1/me/agent HTTP/1.1 503 Service Unavailable
\`\`\`

Frontend showed *"Our safety checker is taking a break."* Without this bypass the developer is stuck until they top up credits — even for pure-UX changes.

## Behaviour

When **both** are true:
- \`SAFETY_MOCK=1\`
- \`ENVIRONMENT != production\`

\`check_content_safety.handler\` returns a passing stub:
\`\`\`json
{ "safety_score": 0.99, "is_safe": true, "dev_mock": true, ... }
\`\`\`

without calling the Anthropic API. A WARNING is logged on every call so this can never silently slip into production logs.

Per CLAUDE.md the safety check is **non-negotiable for production**. This bypass is for local UX iteration only.

## Test plan

3 contract tests in \`test_safety_mock_dev_bypass.py\`:
- [x] \`SAFETY_MOCK=1\` returns the passing stub WITHOUT calling Anthropic (mocked to \`side_effect=AssertionError\`)
- [x] \`SAFETY_MOCK=1\` + \`ENVIRONMENT=production\` reaches the real path (production guard holds)
- [x] \`SAFETY_MOCK\` unset reaches the real path even in dev

All 3 pass.

## Usage

\`\`\`bash
export SAFETY_MOCK=1
python -m uvicorn backend.src.main:app --port 8000
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)