### PR TITLE
fix(hub): GET /hub/groups/{ident} accepts both id and slug

### DIFF
--- a/backend/src/api/routes/hub/groups.py
+++ b/backend/src/api/routes/hub/groups.py
@@ -136,15 +136,25 @@ async def create_group(
 
 
 @router.get(
-    "/{group_id}",
+    "/{ident}",
     response_model=GroupResponse,
-    summary="Get a group by id",
+    summary="Get a group by id or slug",
 )
 async def get_group(
-    group_id: str,
+    ident: str,
     user: UserData = Depends(get_current_user),
 ):
-    group = await group_repo.get_by_id(group_id)
+    """Look up a group by either its UUID hex id OR its kebab-case slug.
+
+    The frontend GroupPage routes by slug (/content-hub/:slug), so the
+    by-slug path is what matters in practice. The id path is kept so
+    consumers that already have the id (e.g. server-side tests or the
+    create-response payload) can use it directly without an extra hop.
+    """
+    group = await group_repo.get_by_id(ident)
+    if group is None:
+        # Fall through: maybe the caller passed a slug.
+        group = await group_repo.get_by_slug(ident)
     if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/tests/contracts/test_hub_groups_endpoint_contract.py
+++ b/backend/tests/contracts/test_hub_groups_endpoint_contract.py
@@ -247,6 +247,23 @@ class TestGetGroup:
         assert r.status_code == 404
         assert r.json()["detail"]["code"] == "GROUP_NOT_FOUND"
 
+    @pytest.mark.asyncio
+    async def test_get_by_slug_returns_same_group_as_by_id(self, client):
+        r1 = await client.post(
+            "/api/v1/hub/groups",
+            json={"name": "SlugLookup", "visibility": "public"},
+        )
+        assert r1.status_code == 201, r1.text
+        gid = r1.json()["group_id"]
+        slug = r1.json()["slug"]
+        assert slug == "sluglookup"
+
+        r_by_id = await client.get(f"/api/v1/hub/groups/{gid}")
+        r_by_slug = await client.get(f"/api/v1/hub/groups/{slug}")
+        assert r_by_id.status_code == 200, r_by_id.text
+        assert r_by_slug.status_code == 200, r_by_slug.text
+        assert r_by_id.json()["group_id"] == r_by_slug.json()["group_id"]
+
 
 # ---------------------------------------------------------------------------
 # Join


### PR DESCRIPTION
Fixes the user-reported bug: clicking "Open" on a freshly-created group on the ContentHubPage 404s.

## Root cause

The frontend \`GroupPage\` routes by slug (\`/content-hub/:slug\`) and \`hubService.getGroup(slug)\` calls \`GET /hub/groups/{slug}\`. But the backend's \`GET /hub/groups/{group_id}\` only looked up by the UUID hex id, never by slug. Every "Open" action 404'd.

## Fix

Rename the path param to \`{ident}\` and try id first, then slug. Frontend stays as-is. Backwards-compatible for any consumer that already has the id.

## Test plan

- [x] 14/14 contract tests pass, including a new \`test_get_by_slug_returns_same_group_as_by_id\` that round-trips both lookup forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)