### PR TITLE
feat(hub): magazine-spread redesign of GroupPage + PostCard

### DIFF
--- a/frontend/src/pages/GroupPage/PostCard.tsx
+++ b/frontend/src/pages/GroupPage/PostCard.tsx
@@ -1,20 +1,24 @@
 /**
- * PostCard — single hub-post tile for the group feed (#452).
+ * PostCard — magazine-spread tile for a hub-post (Option A redesign).
  *
- * Renders the agent persona byline (reused AgentBylineChip from #445),
- * caption (if any), and the ReactionBar from #454. The card is clickable
- * — tapping the title navigates to the source artifact (story / interactive
- * session) so the reader can experience what the buddy made.
+ * Layout (top → bottom):
+ *   - 16:9 cover band (gradient + emoji icon based on source_artifact_type)
+ *     with the agent persona byline floating top-right
+ *   - Type chip + relative timestamp row
+ *   - Caption (line-clamped to 3) — or a styled placeholder if absent
+ *   - Reactions + "Read story →" pill on the same row at the bottom
  *
- * Privacy: this component reads ONLY from `HubPost` snapshot fields. No
- * users-table data is referenced here, matching the COPPA invariant
- * locked by the contract test in #450.
+ * Privacy: still reads ONLY from `HubPost` snapshot fields. The COPPA
+ * contract test in #450 stays green.
+ *
+ * Issue: GroupPage magazine redesign | Parent epic: #437
  */
 
 import { useNavigate } from "react-router-dom";
 import AgentBylineChip from "@/components/common/AgentBylineChip";
 import ReactionBar from "@/components/hub/ReactionBar";
 import type { HubPost } from "@/types/hub";
+import { coverFor } from "./groupTheme";
 
 interface Props {
   post: HubPost;
@@ -24,17 +28,28 @@ function destinationFor(post: HubPost): string {
   if (post.source_artifact_type === "art_story") {
     return `/story/${post.source_id}`;
   }
-  // interactive_story stories live behind the InteractiveStoryPage with
-  // a session id — the source_id IS the session id.
   return `/interactive?session=${encodeURIComponent(post.source_id)}`;
+}
+
+function relativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const seconds = Math.max(0, Math.floor((now - then) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
 }
 
 export default function PostCard({ post }: Props) {
   const navigate = useNavigate();
   const destination = destinationFor(post);
+  const cover = coverFor(post.source_artifact_type);
 
-  // Adapt HubPost.byline-shaped fields to the AgentBylineChip's `Agent`
-  // contract. We only use the fields the chip actually reads.
   const bylineAgent = {
     agent_id: "snapshot",
     user_id: "snapshot",
@@ -47,34 +62,62 @@ export default function PostCard({ post }: Props) {
   };
 
   return (
-    <article className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm transition-shadow hover:shadow-md">
-      <header className="flex flex-col gap-2">
-        <AgentBylineChip agent={bylineAgent} />
-        <h3 className="text-base font-semibold text-gray-900">
-          {post.source_artifact_type === "interactive_story"
-            ? "Interactive story"
-            : "Art story"}
-        </h3>
-      </header>
-
-      {post.caption && (
-        <p className="text-sm text-gray-700 line-clamp-3">{post.caption}</p>
-      )}
-
-      <div className="flex items-center justify-between gap-2">
-        <ReactionBar postId={post.post_id} />
-        <button
-          type="button"
-          className="rounded-md bg-violet-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-700"
-          onClick={() => navigate(destination)}
+    <article className="group flex flex-col overflow-hidden rounded-3xl border border-gray-200 bg-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-lg">
+      {/* Cover band */}
+      <button
+        type="button"
+        aria-label={`Open ${cover.label}`}
+        onClick={() => navigate(destination)}
+        className={`relative aspect-video w-full overflow-hidden bg-gradient-to-br ${cover.gradient} text-white`}
+      >
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0 flex items-center justify-center text-7xl drop-shadow-md transition-transform duration-300 group-hover:scale-110"
         >
-          Read story →
-        </button>
-      </div>
+          {cover.icon}
+        </span>
+        {/* Byline chip floats over the cover */}
+        <div className="absolute right-3 top-3 max-w-[80%] rounded-full bg-white/90 px-2 py-1 shadow-sm backdrop-blur-sm">
+          <AgentBylineChip agent={bylineAgent} />
+        </div>
+      </button>
 
-      <p className="text-xs text-gray-400">
-        Posted {new Date(post.created_at).toLocaleDateString()}
-      </p>
+      {/* Body */}
+      <div className="flex flex-1 flex-col gap-3 p-5">
+        <div className="flex items-center justify-between gap-2 text-xs">
+          <span
+            className={
+              post.source_artifact_type === "art_story"
+                ? "rounded-full bg-rose-100 px-2 py-0.5 font-semibold text-rose-700"
+                : "rounded-full bg-violet-100 px-2 py-0.5 font-semibold text-violet-700"
+            }
+          >
+            {cover.label}
+          </span>
+          <span className="text-gray-400">{relativeTime(post.created_at)}</span>
+        </div>
+
+        {post.caption ? (
+          <p className="text-sm leading-relaxed text-gray-800 line-clamp-3">
+            {post.caption}
+          </p>
+        ) : (
+          <p className="text-sm italic text-gray-400">
+            Tap to read what {post.agent_name} made.
+          </p>
+        )}
+
+        <div className="mt-auto flex items-center justify-between gap-3 pt-2">
+          <ReactionBar postId={post.post_id} />
+          <button
+            type="button"
+            onClick={() => navigate(destination)}
+            className="shrink-0 rounded-full bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500"
+          >
+            Read →
+          </button>
+        </div>
+      </div>
     </article>
   );
 }

--- a/frontend/src/pages/GroupPage/groupTheme.test.ts
+++ b/frontend/src/pages/GroupPage/groupTheme.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { accentForSlug, coverFor, emojiForTheme } from "./groupTheme";
+
+describe("accentForSlug", () => {
+  it("is deterministic — same slug -> same accent", () => {
+    const a = accentForSlug("dragons");
+    const b = accentForSlug("dragons");
+    expect(a).toEqual(b);
+  });
+
+  it("different slugs MAY map to different accents", () => {
+    // Not strictly required (the palette is small) — but at least one
+    // pair across a sample should differ to prove the hash isn't a
+    // constant.
+    const slugs = ["dragons", "space-adventures", "kindness-club", "music"];
+    const accents = slugs.map(accentForSlug);
+    const unique = new Set(accents.map((a) => a.bannerGradient));
+    expect(unique.size).toBeGreaterThan(1);
+  });
+
+  it("returns a sane default when slug is empty", () => {
+    expect(accentForSlug(null)).toBeDefined();
+    expect(accentForSlug(undefined)).toBeDefined();
+    expect(accentForSlug("")).toBeDefined();
+  });
+});
+
+describe("emojiForTheme", () => {
+  it("known themes get their canonical emoji", () => {
+    expect(emojiForTheme("dragons")).toBe("🐉");
+    expect(emojiForTheme("Space")).toBe("🚀");
+    expect(emojiForTheme("  ocean  ")).toBe("🌊");
+  });
+
+  it("unknown themes fall back to sparkle", () => {
+    expect(emojiForTheme("blarg")).toBe("✨");
+    expect(emojiForTheme(null)).toBe("✨");
+  });
+});
+
+describe("coverFor", () => {
+  it("art_story uses the warm bookish gradient", () => {
+    const c = coverFor("art_story");
+    expect(c.icon).toBe("📖");
+    expect(c.label).toBe("Art story");
+  });
+  it("interactive_story uses the playful violet gradient", () => {
+    const c = coverFor("interactive_story");
+    expect(c.icon).toBe("🌟");
+    expect(c.label).toBe("Interactive story");
+  });
+});

--- a/frontend/src/pages/GroupPage/groupTheme.ts
+++ b/frontend/src/pages/GroupPage/groupTheme.ts
@@ -1,0 +1,126 @@
+/**
+ * groupTheme — deterministic visual accents for a Content Hub group.
+ *
+ * Picks a palette index by hashing the group's slug, so the same group
+ * always renders with the same color story across sessions and devices.
+ *
+ * Issue: GroupPage magazine redesign | Parent epic: #437
+ */
+
+import type { HubPost } from "@/types/hub";
+
+export interface GroupAccent {
+  /** Tailwind gradient classes for the page banner background. */
+  bannerGradient: string;
+  /** Tailwind gradient classes for the post-cover placeholder. */
+  coverGradient: string;
+  /** Tailwind text color for theme-tinted accents (chips, dividers). */
+  accentText: string;
+  /** Tailwind background for chip pills. */
+  chipBg: string;
+}
+
+const PALETTE: GroupAccent[] = [
+  {
+    bannerGradient: "from-pink-200 via-rose-100 to-orange-100",
+    coverGradient: "from-pink-300 via-rose-200 to-orange-200",
+    accentText: "text-rose-700",
+    chipBg: "bg-rose-100 text-rose-700",
+  },
+  {
+    bannerGradient: "from-violet-200 via-purple-100 to-fuchsia-100",
+    coverGradient: "from-violet-300 via-purple-200 to-fuchsia-200",
+    accentText: "text-violet-700",
+    chipBg: "bg-violet-100 text-violet-700",
+  },
+  {
+    bannerGradient: "from-sky-200 via-cyan-100 to-emerald-100",
+    coverGradient: "from-sky-300 via-cyan-200 to-emerald-200",
+    accentText: "text-sky-700",
+    chipBg: "bg-sky-100 text-sky-700",
+  },
+  {
+    bannerGradient: "from-amber-200 via-yellow-100 to-lime-100",
+    coverGradient: "from-amber-300 via-yellow-200 to-lime-200",
+    accentText: "text-amber-700",
+    chipBg: "bg-amber-100 text-amber-700",
+  },
+  {
+    bannerGradient: "from-emerald-200 via-teal-100 to-sky-100",
+    coverGradient: "from-emerald-300 via-teal-200 to-sky-200",
+    accentText: "text-emerald-700",
+    chipBg: "bg-emerald-100 text-emerald-700",
+  },
+  {
+    bannerGradient: "from-indigo-200 via-blue-100 to-cyan-100",
+    coverGradient: "from-indigo-300 via-blue-200 to-cyan-200",
+    accentText: "text-indigo-700",
+    chipBg: "bg-indigo-100 text-indigo-700",
+  },
+];
+
+/**
+ * Stable string hash (djb2). Browser/server agnostic, no deps.
+ */
+function hashStr(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 33) ^ s.charCodeAt(i);
+  }
+  return h >>> 0;
+}
+
+export function accentForSlug(slug: string | undefined | null): GroupAccent {
+  if (!slug) return PALETTE[0];
+  return PALETTE[hashStr(slug) % PALETTE.length];
+}
+
+/**
+ * Deterministic emoji for a theme tag. Falls back to a sparkle if the
+ * theme is empty or unknown.
+ */
+const THEME_EMOJI: Record<string, string> = {
+  fantasy: "🧙",
+  dragons: "🐉",
+  space: "🚀",
+  ocean: "🌊",
+  animals: "🦁",
+  forest: "🌳",
+  science: "🔬",
+  music: "🎵",
+  art: "🎨",
+  invention: "💡",
+  food: "🍰",
+  sports: "⚽",
+  heroes: "🦸",
+  robots: "🤖",
+  magic: "✨",
+};
+
+export function emojiForTheme(theme: string | null | undefined): string {
+  if (!theme) return "✨";
+  const key = theme.trim().toLowerCase();
+  return THEME_EMOJI[key] ?? "✨";
+}
+
+/**
+ * Per-source-type cover treatment. Art stories get a warm bookish
+ * gradient, interactive stories a playful violet — both override the
+ * group's accent so individual posts read differently at a glance.
+ */
+export function coverFor(
+  type: HubPost["source_artifact_type"],
+): { gradient: string; icon: string; label: string } {
+  if (type === "art_story") {
+    return {
+      gradient: "from-pink-300 via-orange-200 to-amber-200",
+      icon: "📖",
+      label: "Art story",
+    };
+  }
+  return {
+    gradient: "from-violet-400 via-fuchsia-300 to-sky-300",
+    icon: "🌟",
+    label: "Interactive story",
+  };
+}

--- a/frontend/src/pages/GroupPage/index.tsx
+++ b/frontend/src/pages/GroupPage/index.tsx
@@ -1,22 +1,21 @@
 /**
- * GroupPage — per-group feed at /content-hub/:slug.
+ * GroupPage — magazine-spread per-group feed (Option A redesign).
  *
- * Resolves the slug to a group id, then paginates through hub_posts
- * via the cursor returned by listGroupPosts. Renders an empty state
- * with a "Be the first to share!" CTA pointing at /upload (or the
- * relevant creation flow) when the group has no posts.
+ * Layout:
+ *   - Hero banner with deterministic theme gradient, theme emoji, group
+ *     name in display font, member + visibility chips, and an italic
+ *     description line
+ *   - 1/2/3-column responsive grid of magazine-style PostCards
+ *   - Animated empty state with the shared rainbow + balloon set
+ *   - Cursor-paginated load-more button
  *
- * Visibility:
- *   - Public groups: any authenticated user can read.
- *   - Private groups: members only — the backend returns 403 NOT_A_MEMBER
- *     and we surface a join CTA pointing at the invite-link flow.
- *
- * Issue: #452 | Parent epic: #437
+ * Issue: GroupPage magazine redesign | Parent epic: #437
  */
 
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { AxiosError } from "axios";
+import { motion } from "framer-motion";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import { hubService } from "@/api/services/hubService";
 import type {
@@ -26,6 +25,7 @@ import type {
   ListHubPostsResponse,
 } from "@/types/hub";
 import PostCard from "./PostCard";
+import { accentForSlug, emojiForTheme } from "./groupTheme";
 
 const PAGE_SIZE = 10;
 
@@ -37,13 +37,15 @@ export default function GroupPage() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
   const [forbidden, setForbidden] = useState(false);
+  const accent = accentForSlug(slug);
 
-  // Resolve slug -> group_id (the post-feed endpoint uses ids).
   const { data: group, isLoading: groupLoading } = useQuery<Group | null>({
     queryKey: ["hub-group", slug],
     queryFn: () => hubService.getGroup(slug as string),
     enabled: Boolean(slug),
   });
+
+  const themeEmoji = emojiForTheme(group?.theme ?? group?.name);
 
   const {
     data,
@@ -68,23 +70,43 @@ export default function GroupPage() {
     if (isAxios403(error)) setForbidden(true);
   }, [error]);
 
-  if (groupLoading || (!group && !groupLoading)) {
+  if (groupLoading) {
     return (
       <div className="mx-auto max-w-3xl px-4 py-8 text-gray-500">
-        {groupLoading ? "Loading group…" : "Group not found."}
+        Loading group…
       </div>
     );
   }
 
-  const posts: HubPost[] = (data?.pages ?? []).flatMap((p) => p.items);
+  if (!group) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-12 text-center">
+        <span className="text-5xl">🔭</span>
+        <p className="text-lg font-medium text-gray-700">
+          Couldn't find that group.
+        </p>
+        <Link
+          to="/content-hub"
+          className="text-sm font-medium text-violet-700 underline"
+        >
+          Back to Content Hub
+        </Link>
+      </div>
+    );
+  }
 
   if (forbidden) {
     return (
-      <div className="mx-auto flex max-w-3xl flex-col gap-4 px-4 py-8">
-        <h1 className="text-2xl font-semibold text-gray-900">{group!.name}</h1>
+      <div className="mx-auto flex max-w-4xl flex-col gap-6 px-4 py-8">
+        <div
+          className={`overflow-hidden rounded-3xl bg-gradient-to-br ${accent.bannerGradient} px-8 py-10 shadow-sm`}
+        >
+          <h1 className="text-3xl font-bold text-gray-900">{group.name}</h1>
+          <p className="mt-2 text-sm text-gray-700">Private group</p>
+        </div>
         <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6">
           <p className="text-base font-medium text-amber-900">
-            This is a private group.
+            🔒 This is a private group.
           </p>
           <p className="mt-1 text-sm text-amber-800">
             Open the invite link a friend sent you to join, then come back to
@@ -92,7 +114,7 @@ export default function GroupPage() {
           </p>
           <Link
             to="/content-hub"
-            className="mt-3 inline-block text-sm font-medium text-violet-700 underline"
+            className="mt-3 inline-block text-sm font-semibold text-violet-700 underline"
           >
             Back to Content Hub
           </Link>
@@ -101,37 +123,97 @@ export default function GroupPage() {
     );
   }
 
+  const posts: HubPost[] = (data?.pages ?? []).flatMap((p) => p.items);
+  const memberLabel =
+    group.member_count === 1 ? "1 member" : `${group.member_count} members`;
+
   return (
-    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-8">
-      <header className="flex flex-col gap-1">
-        <p className="text-xs font-medium uppercase tracking-wide text-violet-600">
-          Content Hub
-        </p>
-        <h1 className="text-2xl font-semibold text-gray-900">{group!.name}</h1>
-        <p className="text-sm text-gray-600">
-          {group!.member_count}{" "}
-          {group!.member_count === 1 ? "member" : "members"} ·{" "}
-          {group!.visibility === "private" ? "Private" : "Public"}
-          {group!.theme ? ` · ${group!.theme}` : ""}
-        </p>
-        {group!.description && (
-          <p className="mt-1 text-sm text-gray-700">{group!.description}</p>
-        )}
+    <div className="mx-auto flex max-w-6xl flex-col gap-6 px-4 py-8">
+      {/* Hero banner */}
+      <header
+        className={`relative overflow-hidden rounded-3xl bg-gradient-to-br ${accent.bannerGradient} px-6 py-8 shadow-sm sm:px-10 sm:py-12`}
+      >
+        {/* Decorative floating emoji on the right */}
+        <motion.span
+          aria-hidden="true"
+          className="pointer-events-none absolute right-4 top-4 text-7xl opacity-90 sm:right-10 sm:top-6 sm:text-8xl"
+          animate={{ y: [0, -6, 0] }}
+          transition={{ duration: 4, repeat: Infinity, ease: "easeInOut" }}
+        >
+          {themeEmoji}
+        </motion.span>
+
+        <div className="relative flex flex-col gap-2">
+          <Link
+            to="/content-hub"
+            className={`text-xs font-semibold uppercase tracking-wider ${accent.accentText} hover:underline`}
+          >
+            ← Content Hub
+          </Link>
+          <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl">
+            {group.name}
+          </h1>
+          <div className="flex flex-wrap items-center gap-2 text-xs">
+            <span
+              className={`rounded-full px-2.5 py-0.5 font-semibold ${accent.chipBg}`}
+            >
+              {group.visibility === "private" ? "🔒 Private" : "🌐 Public"}
+            </span>
+            <span className="rounded-full bg-white/70 px-2.5 py-0.5 font-medium text-gray-700">
+              {memberLabel}
+            </span>
+            {group.theme && (
+              <span
+                className={`rounded-full px-2.5 py-0.5 font-medium ${accent.chipBg}`}
+              >
+                #{group.theme}
+              </span>
+            )}
+          </div>
+          {group.description && (
+            <p className="mt-2 max-w-2xl text-sm italic text-gray-700">
+              {group.description}
+            </p>
+          )}
+        </div>
       </header>
 
-      {postsLoading && <p className="text-gray-500">Loading posts…</p>}
+      {/* Posts */}
+      {postsLoading && <p className="text-gray-500">Loading stories…</p>}
 
       {!postsLoading && posts.length === 0 && (
-        <div className="rounded-2xl border-2 border-dashed border-gray-200 bg-white p-8 text-center">
-          <p className="text-base font-medium text-gray-700">
-            Be the first to share!
-          </p>
-          <p className="mt-1 text-sm text-gray-500">
-            Make a story and tap "Share to Content Hub" to drop it here.
-          </p>
+        <div className="flex flex-col items-center gap-4 rounded-3xl border-2 border-dashed border-gray-200 bg-white px-6 py-12 text-center shadow-sm">
+          <div className="flex justify-center gap-3 text-5xl">
+            <motion.span
+              animate={{ y: [0, -8, 0] }}
+              transition={{ duration: 2.4, repeat: Infinity, delay: 0 }}
+            >
+              🌟
+            </motion.span>
+            <motion.span
+              animate={{ y: [0, -8, 0] }}
+              transition={{ duration: 2.4, repeat: Infinity, delay: 0.4 }}
+            >
+              🎈
+            </motion.span>
+            <motion.span
+              animate={{ y: [0, -8, 0] }}
+              transition={{ duration: 2.4, repeat: Infinity, delay: 0.8 }}
+            >
+              🌈
+            </motion.span>
+          </div>
+          <div>
+            <p className="text-lg font-semibold text-gray-800">
+              The first story here gets the spotlight!
+            </p>
+            <p className="mt-1 text-sm text-gray-600">
+              Make a story and tap "Share to Content Hub" to drop it in.
+            </p>
+          </div>
           <button
             type="button"
-            className="mt-4 rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+            className="rounded-full bg-violet-600 px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-violet-700"
             onClick={() => navigate("/upload")}
           >
             Make a story
@@ -140,7 +222,7 @@ export default function GroupPage() {
       )}
 
       {posts.length > 0 && (
-        <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <section className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3">
           {posts.map((p) => (
             <PostCard key={p.post_id} post={p} />
           ))}
@@ -151,11 +233,11 @@ export default function GroupPage() {
         <div className="flex justify-center">
           <button
             type="button"
-            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+            className="rounded-full border border-gray-300 bg-white px-5 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-50"
             onClick={() => fetchNextPage()}
             disabled={isFetchingNextPage}
           >
-            {isFetchingNextPage ? "Loading…" : "Load more"}
+            {isFetchingNextPage ? "Loading…" : "Load more stories"}
           </button>
         </div>
       )}


### PR DESCRIPTION
User-driven UI fix. After #485 landed, the user reported: *"in the content Hub when I goes into the club I just formed, the UI is real ugly"*. They picked **Option A — magazine spread** from the three design options.

## What's new

| Surface | Before | After |
|---|---|---|
| Hero | Plain text on the gradient bg | Theme-tinted gradient banner with floating themed emoji, group name in display weight, visibility / member / theme chips |
| PostCard cover | None — text only | 16:9 gradient cover with big emoji icon (📖 art / 🌟 interactive), hover-zoom |
| Byline | Above title | Chip floats top-right over the cover, backdrop-blurred white pill |
| Body | "Art story" h3 | Type pill + relative timestamp; caption or styled placeholder |
| Reactions / Read | Cramped row | Reactions left, chunky "Read →" pill right, generous spacing |
| Empty state | Dashed-border placeholder | Animated rainbow + balloon set with "First story here gets the spotlight!" |
| Grid | 1/2 col | 1/2/3 col responsive |

## Theme palette is deterministic

\`accentForSlug(slug)\` runs a djb2 hash over the slug to pick from 6 kid-friendly gradient palettes. Same group always renders with the same color story. \`emojiForTheme(theme)\` looks up a canonical emoji (Dragons → 🐉, Space → 🚀, Music → 🎵, etc.; sparkle fallback).

## Privacy invariant intact

PostCard still reads ONLY \`HubPost\` snapshot fields. The COPPA contract test from #450 stays green. Nothing in this PR touches the API contract.

## Out of scope (follow-up)

Real story cover thumbnails. The source \`GET /stories/:id\` and session reads are owner-gated, so cross-user cover fetching needs either a server-side enrichment of \`list_by_group\` or a \`cover_url\` snapshot column on \`hub_posts\` (matches the existing persona-snapshot pattern). The gradient + emoji placeholder lands the visual redesign now; cover-fetching is its own scoped change.

## Test plan

- [x] 9/9 vitest cases (\`groupTheme.test.ts\` ×6, \`destinationFor.test.ts\` ×3)
- [x] \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)