### PR TITLE
fix: silence audio + kill render loop when landing from a Content Hub share

### DIFF
--- a/frontend/src/components/effects/Confetti.tsx
+++ b/frontend/src/components/effects/Confetti.tsx
@@ -4,7 +4,7 @@
  */
 
 import { motion, AnimatePresence } from 'framer-motion'
-import { useState, useEffect, useCallback, memo } from 'react'
+import { useState, useEffect, useRef, memo } from 'react'
 import { useStreamVisualizationContext, registerEffectCallback } from '@/providers/StreamVisualizationProvider'
 import { colors } from '@/config/animationPresets'
 import type { EffectTrigger } from '@/types/streaming'
@@ -125,23 +125,39 @@ function ConfettiComponent({
   const [confetti, setConfetti] = useState<ConfettiPiece[]>([])
 
   // Trigger confetti
-  const triggerConfetti = useCallback(() => {
-    if (prefersReducedMotion) return
-
-    setConfetti(generateConfetti(count, colorOptions, origin, spread))
-
-    // Clear after duration
-    setTimeout(() => {
-      setConfetti([])
-    }, duration)
-  }, [count, colorOptions, origin, spread, duration, prefersReducedMotion])
+  // Refs over state to keep the props stable inside the effect below
+  // without forcing a render cycle when the parent passes a new
+  // colors / origin object on every render. Without this, the parent
+  // (ConfettiController) spreads a freshly-built `config` object each
+  // time it re-renders, which makes triggerConfetti a new reference,
+  // which fires the effect, which calls setConfetti, which re-renders
+  // the parent — Maximum update depth exceeded.
+  const propsRef = useRef({
+    count,
+    colorOptions,
+    origin,
+    spread,
+    duration,
+    prefersReducedMotion,
+  })
+  propsRef.current = {
+    count,
+    colorOptions,
+    origin,
+    spread,
+    duration,
+    prefersReducedMotion,
+  }
 
   // Handle active prop changes
   useEffect(() => {
-    if (active) {
-      triggerConfetti()
-    }
-  }, [active, triggerConfetti])
+    if (!active) return
+    const p = propsRef.current
+    if (p.prefersReducedMotion) return
+    setConfetti(generateConfetti(p.count, p.colorOptions, p.origin, p.spread))
+    const t = setTimeout(() => setConfetti([]), p.duration)
+    return () => clearTimeout(t)
+  }, [active])
 
   if (prefersReducedMotion || confetti.length === 0) {
     return null

--- a/frontend/src/pages/InteractiveStoryPage/index.tsx
+++ b/frontend/src/pages/InteractiveStoryPage/index.tsx
@@ -147,6 +147,18 @@ function InteractiveStoryPage() {
   );
   const sessionParam = searchParams.get("session");
 
+  // Track whether this mount entered via a deep-link resume URL.
+  // When a user lands here from a Content Hub share they clicked "Read"
+  // — they did NOT ask for audio. Auto-playing TTS at full volume on
+  // cold landing is jarring (and arrived as a real bug report). We
+  // suppress auto-play until the user takes their first in-page
+  // interaction (e.g. tapping a choice). Captured once at mount so
+  // subsequent state changes don't flip it.
+  const [enteredViaResume] = useState<boolean>(() => Boolean(sessionParam));
+  const [userHasInteracted, setUserHasInteracted] = useState<boolean>(false);
+  const audioMaySelfStart =
+    activeAgeGroup === "3-5" && (!enteredViaResume || userHasInteracted);
+
   useEffect(() => {
     // Explicit resume path: /interactive?session=...
     if (sessionParam) {
@@ -252,6 +264,11 @@ function InteractiveStoryPage() {
 
   // Choice handler - uses streaming for real-time progress
   const handleChoice = async (choiceId: string) => {
+    // First in-page interaction unlocks audio auto-play (see
+    // audioMaySelfStart above). Without this, a user who lands here
+    // via a Content Hub share would never get audio even when they
+    // wanted it on subsequent segments.
+    setUserHasInteracted(true);
     try {
       await makeChoiceStream(choiceId);
     } catch {
@@ -640,7 +657,7 @@ function InteractiveStoryPage() {
             audioUrl={currentSegment.audio_url || onDemandAudioUrl}
             onRequestAudio={handleRequestAudio}
             isAudioLoading={isAudioGenerating}
-            autoPlayAudio={activeAgeGroup === "3-5"}
+            autoPlayAudio={audioMaySelfStart}
             textContent={renderStoryTimeline()}
           />
 
@@ -709,7 +726,7 @@ function InteractiveStoryPage() {
               audioUrl={currentSegment.audio_url || onDemandAudioUrl}
               onRequestAudio={handleRequestAudio}
               isAudioLoading={isAudioGenerating}
-              autoPlayAudio={activeAgeGroup === "3-5"}
+              autoPlayAudio={audioMaySelfStart}
               textContent={renderStoryTimeline()}
             />
           )}


### PR DESCRIPTION
User-reported double bug after the magazine redesign #486 landed: clicking "Read" on a shared interactive-story post played TTS at full volume on landing AND threw \`Maximum update depth exceeded\` in the console.

## Bug 1 — audio blasts on share landing

When a viewer lands on \`/interactive?session=<id>\` from a Hub PostCard "Read" tap, \`AgeAwareContent\` for 3–5 year olds auto-played TTS the moment the page mounted. The user never asked for audio — they clicked a card to **read**.

**Fix:** track \`enteredViaResume\` (captured once at mount from the \`?session=\` URL param) + \`userHasInteracted\` (flips on first choice tap). \`autoPlayAudio\` is derived as:

\`\`\`ts
activeAgeGroup === "3-5" && (!enteredViaResume || userHasInteracted)
\`\`\`

A 3–5 viewer who lands on a share gets a silent first segment, but the moment they tap a choice, subsequent segments auto-play as before — preserving the in-session UX for kids who can't operate a play button.

## Bug 2 — Maximum update depth (ConfettiComponent)

\`ConfettiController\` rebuilds a fresh \`config\` object on every render and spreads \`{...config}\` into \`<Confetti>\`. That makes \`colorOptions\` / \`origin\` new references each render → the \`useCallback\` for \`triggerConfetti\` depended on those changing references → the \`useEffect\`'s \`[active, triggerConfetti]\` deps fired every render → \`setConfetti\` → re-render parent → loop.

**Fix:** pin the props inside \`ConfettiComponent\` into a ref and watch ONLY \`[active]\` in the effect. The effect reads the latest props through the ref without re-firing on identity churn.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Existing vitest suite green (no new tests; both fixes are behavioural)
- [ ] Manual: hit a hub-shared link → first segment is silent → tap choice → subsequent segments auto-play; confetti animation on completion fires once cleanly with no console warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)