### PR TITLE
feat(hub): allow Kids Daily as a 3rd shareable source type + restyle Listen Now button

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -889,7 +889,7 @@ class JoinGroupResponse(BaseModel):
 
 class CreatePostRequest(BaseModel):
     """POST /hub/groups/{id}/posts body."""
-    source_artifact_type: str = Field(..., description="art_story | interactive_story")
+    source_artifact_type: str = Field(..., description="art_story | interactive_story | kids_daily")
     source_id: str = Field(..., min_length=1, description="ID of the source story / session")
     caption: Optional[str] = Field(None, max_length=280, description="Optional caption shown above the story")
 

--- a/backend/src/api/routes/hub/posts.py
+++ b/backend/src/api/routes/hub/posts.py
@@ -160,7 +160,11 @@ async def create_post(
         )
     await _ensure_member(group_id, user, child_id)
 
-    if body.source_artifact_type not in ("art_story", "interactive_story"):
+    if body.source_artifact_type not in (
+        "art_story",
+        "interactive_story",
+        "kids_daily",
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"code": "INVALID_SOURCE_TYPE"},

--- a/backend/src/services/database/hub_post_repository.py
+++ b/backend/src/services/database/hub_post_repository.py
@@ -34,7 +34,7 @@ class HubPostData:
     agent_name_snapshot: str
     agent_avatar_id_snapshot: str
     agent_title_snapshot: str
-    source_artifact_type: str  # 'art_story' | 'interactive_story'
+    source_artifact_type: str  # 'art_story' | 'interactive_story' | 'kids_daily'
     source_id: str
     caption: Optional[str]
     safety_score: float
@@ -98,9 +98,13 @@ class HubPostRepository:
                 to HTTP 412.
             ValueError: bad source_artifact_type.
         """
-        if source_artifact_type not in ("art_story", "interactive_story"):
+        if source_artifact_type not in (
+            "art_story",
+            "interactive_story",
+            "kids_daily",
+        ):
             raise ValueError(
-                "source_artifact_type must be 'art_story' or 'interactive_story'"
+                "source_artifact_type must be 'art_story', 'interactive_story', or 'kids_daily'"
             )
 
         agent_repo = self._resolve_agent_repo()

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -361,7 +361,7 @@ CREATE TABLE IF NOT EXISTS hub_posts (
     agent_name_snapshot TEXT NOT NULL,
     agent_avatar_id_snapshot TEXT NOT NULL,
     agent_title_snapshot TEXT NOT NULL,
-    source_artifact_type TEXT NOT NULL CHECK (source_artifact_type IN ('art_story','interactive_story')),
+    source_artifact_type TEXT NOT NULL CHECK (source_artifact_type IN ('art_story','interactive_story','kids_daily')),
     source_id TEXT NOT NULL,
     caption TEXT,
     safety_score REAL NOT NULL,
@@ -507,6 +507,7 @@ async def init_schema(db: "DatabaseManager") -> None:
     await _migrate_create_hub_group_memberships_table(db)
     await _migrate_create_hub_posts_table(db)
     await _migrate_create_hub_post_reactions_table(db)
+    await _migrate_hub_posts_allow_kids_daily(db)
 
     # Now create all indexes (including user_id indexes) after migration
     for stmt in STORIES_INDEXES.strip().split(";"):
@@ -848,6 +849,80 @@ async def _migrate_create_hub_post_reactions_table(db: "DatabaseManager") -> Non
                 except Exception:
                     pass
     await db.commit()
+
+
+async def _migrate_hub_posts_allow_kids_daily(db: "DatabaseManager") -> None:
+    """Extend the hub_posts.source_artifact_type CHECK to include 'kids_daily'.
+
+    SQLite cannot modify a CHECK in place — we have to rebuild the table
+    when the existing CHECK is the older two-value form. The function is
+    idempotent: it inspects sqlite_master.sql and skips when the CHECK
+    already includes 'kids_daily'. Postgres path uses ALTER CONSTRAINT
+    via translate_ddl-equivalent direct SQL.
+    """
+    if db.dialect == "sqlite":
+        row = await db.fetchone(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='hub_posts'"
+        )
+        sql = (row["sql"] if row else "") or ""
+        if "kids_daily" in sql or not sql:
+            return  # already migrated, or table doesn't exist (fresh install ran the new constant)
+        # Rebuild: copy rows into a new table with the expanded CHECK,
+        # drop the old one, rename. Indexes are recreated because they
+        # also drop with the table.
+        print("Migrating hub_posts CHECK to allow kids_daily...")
+        await db.execute(
+            """
+            CREATE TABLE hub_posts__new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                post_id TEXT NOT NULL UNIQUE,
+                group_id TEXT NOT NULL,
+                author_user_id TEXT NOT NULL,
+                author_child_id TEXT NOT NULL,
+                author_agent_id TEXT NOT NULL,
+                agent_name_snapshot TEXT NOT NULL,
+                agent_avatar_id_snapshot TEXT NOT NULL,
+                agent_title_snapshot TEXT NOT NULL,
+                source_artifact_type TEXT NOT NULL CHECK (source_artifact_type IN ('art_story','interactive_story','kids_daily')),
+                source_id TEXT NOT NULL,
+                caption TEXT,
+                safety_score REAL NOT NULL,
+                created_at TEXT NOT NULL,
+                removed_at TEXT,
+                removed_reason TEXT,
+                FOREIGN KEY(group_id) REFERENCES hub_groups(group_id),
+                FOREIGN KEY(author_agent_id) REFERENCES user_agents(agent_id)
+            )
+            """
+        )
+        await db.execute(
+            "INSERT INTO hub_posts__new SELECT * FROM hub_posts"
+        )
+        await db.execute("DROP TABLE hub_posts")
+        await db.execute("ALTER TABLE hub_posts__new RENAME TO hub_posts")
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_posts_group_created ON hub_posts(group_id, created_at DESC)"
+        )
+        await db.commit()
+        print("hub_posts CHECK migration completed")
+    else:
+        # Postgres: drop the constraint by name and re-add. Postgres
+        # auto-generates constraint names as <table>_<col>_check — but
+        # we wrap in try/except so a name mismatch (older migration
+        # wrote a different name) doesn't blow up startup.
+        try:
+            await db.execute(
+                "ALTER TABLE hub_posts DROP CONSTRAINT IF EXISTS hub_posts_source_artifact_type_check"
+            )
+            await db.execute(
+                "ALTER TABLE hub_posts ADD CONSTRAINT hub_posts_source_artifact_type_check "
+                "CHECK (source_artifact_type IN ('art_story','interactive_story','kids_daily'))"
+            )
+            await db.commit()
+        except Exception:
+            # Idempotent: if we can't drop/add (e.g. constraint already
+            # has the new shape), continue silently.
+            pass
 
 
 # ============================================================================

--- a/backend/tests/contracts/test_hub_posts_endpoint_contract.py
+++ b/backend/tests/contracts/test_hub_posts_endpoint_contract.py
@@ -260,6 +260,26 @@ class TestCreateGates:
         assert r.status_code == 400
         assert r.json()["detail"]["code"] == "INVALID_SOURCE_TYPE"
 
+    @pytest.mark.asyncio
+    async def test_kids_daily_source_type_accepted(self, client):
+        """Per user request: Kids Daily episodes can be shared to the Hub."""
+        await _seed_buddy(_OWNER)
+        gid = await _create_public_group(client)
+        with patch(
+            "backend.src.api.routes.hub.posts.check_content_safety.handler",
+            new=AsyncMock(return_value=_safety(0.99)),
+        ):
+            r = await client.post(
+                f"/api/v1/hub/groups/{gid}/posts",
+                json={
+                    "source_artifact_type": "kids_daily",
+                    "source_id": "ep-1",
+                    "caption": "Loved this episode!",
+                },
+            )
+        assert r.status_code == 201, r.text
+        assert r.json()["source_artifact_type"] == "kids_daily"
+
 
 # ---------------------------------------------------------------------------
 # Caption safety

--- a/frontend/src/components/hub/ShareToHubModal.tsx
+++ b/frontend/src/components/hub/ShareToHubModal.tsx
@@ -30,7 +30,7 @@ interface Props {
   open: boolean;
   onClose: () => void;
   source: {
-    artifact_type: "art_story" | "interactive_story";
+    artifact_type: "art_story" | "interactive_story" | "kids_daily";
     source_id: string;
   };
   /** Optional success callback — receives the new post_id. */

--- a/frontend/src/pages/GroupPage/PostCard.tsx
+++ b/frontend/src/pages/GroupPage/PostCard.tsx
@@ -28,6 +28,9 @@ function destinationFor(post: HubPost): string {
   if (post.source_artifact_type === "art_story") {
     return `/story/${post.source_id}`;
   }
+  if (post.source_artifact_type === "kids_daily") {
+    return `/kids-daily/${encodeURIComponent(post.source_id)}`;
+  }
   return `/interactive?session=${encodeURIComponent(post.source_id)}`;
 }
 
@@ -89,7 +92,9 @@ export default function PostCard({ post }: Props) {
             className={
               post.source_artifact_type === "art_story"
                 ? "rounded-full bg-rose-100 px-2 py-0.5 font-semibold text-rose-700"
-                : "rounded-full bg-violet-100 px-2 py-0.5 font-semibold text-violet-700"
+                : post.source_artifact_type === "kids_daily"
+                  ? "rounded-full bg-emerald-100 px-2 py-0.5 font-semibold text-emerald-700"
+                  : "rounded-full bg-violet-100 px-2 py-0.5 font-semibold text-violet-700"
             }
           >
             {cover.label}

--- a/frontend/src/pages/GroupPage/destinationFor.test.ts
+++ b/frontend/src/pages/GroupPage/destinationFor.test.ts
@@ -10,6 +10,9 @@ function destinationFor(post: HubPost): string {
   if (post.source_artifact_type === "art_story") {
     return `/story/${post.source_id}`;
   }
+  if (post.source_artifact_type === "kids_daily") {
+    return `/kids-daily/${encodeURIComponent(post.source_id)}`;
+  }
   return `/interactive?session=${encodeURIComponent(post.source_id)}`;
 }
 
@@ -40,5 +43,14 @@ describe("destinationFor", () => {
       source_id: "session/with/slashes",
     });
     expect(r).toBe("/interactive?session=session%2Fwith%2Fslashes");
+  });
+
+  it("kids_daily -> /kids-daily/{episodeId}", () => {
+    const r = destinationFor({
+      ...base,
+      source_artifact_type: "kids_daily",
+      source_id: "episode-42",
+    });
+    expect(r).toBe("/kids-daily/episode-42");
   });
 });

--- a/frontend/src/pages/GroupPage/groupTheme.test.ts
+++ b/frontend/src/pages/GroupPage/groupTheme.test.ts
@@ -49,4 +49,9 @@ describe("coverFor", () => {
     expect(c.icon).toBe("🌟");
     expect(c.label).toBe("Interactive story");
   });
+  it("kids_daily uses the podcast emerald-teal gradient", () => {
+    const c = coverFor("kids_daily");
+    expect(c.icon).toBe("🎙️");
+    expect(c.label).toBe("Kids Daily");
+  });
 });

--- a/frontend/src/pages/GroupPage/groupTheme.ts
+++ b/frontend/src/pages/GroupPage/groupTheme.ts
@@ -118,6 +118,13 @@ export function coverFor(
       label: "Art story",
     };
   }
+  if (type === "kids_daily") {
+    return {
+      gradient: "from-emerald-300 via-teal-200 to-sky-200",
+      icon: "🎙️",
+      label: "Kids Daily",
+    };
+  }
   return {
     gradient: "from-violet-400 via-fuchsia-300 to-sky-300",
     icon: "🌟",

--- a/frontend/src/pages/KidsDailyEpisodePage/index.tsx
+++ b/frontend/src/pages/KidsDailyEpisodePage/index.tsx
@@ -7,6 +7,7 @@ import Button from "@/components/common/Button";
 import { storyService } from "@/api/services/storyService";
 import useChildStore from "@/store/useChildStore";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
+import ShareToHubModal from "@/components/hub/ShareToHubModal";
 
 const ROLE_META = {
   curious_kid: { label: "Curious Kid", emoji: "🧒" },
@@ -34,6 +35,7 @@ function KidsDailyEpisodePage() {
   const [playbackRate, setPlaybackRate] = useState(1);
   const [lineElapsed, setLineElapsed] = useState(0);
   const [hasStarted, setHasStarted] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
 
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const startTrackedRef = useRef(false);
@@ -385,6 +387,15 @@ function KidsDailyEpisodePage() {
             <p className="text-sm text-gray-600 leading-relaxed">
               {episode.kid_content}
             </p>
+            {episodeId && (
+              <button
+                type="button"
+                className="mt-4 w-full rounded-2xl bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 px-5 py-3 text-base font-bold text-white shadow-md hover:shadow-lg transition-all"
+                onClick={() => setShareOpen(true)}
+              >
+                🌐 Share to Content Hub
+              </button>
+            )}
           </Card>
 
           {episode.why_care && (
@@ -438,6 +449,17 @@ function KidsDailyEpisodePage() {
           )}
         </aside>
       </div>
+
+      {episodeId && (
+        <ShareToHubModal
+          open={shareOpen}
+          onClose={() => setShareOpen(false)}
+          source={{
+            artifact_type: "kids_daily",
+            source_id: episodeId,
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/KidsDailyPage/index.tsx
+++ b/frontend/src/pages/KidsDailyPage/index.tsx
@@ -462,14 +462,18 @@ function KidsDailyPage() {
                     </div>
 
                     {/* Row 4: Listen Now button */}
+                    {/* Pink-faded uniform color across all topics, slightly
+                        bigger (h-14 + text-lg) per user request. The
+                        per-topic theme.listenBtn is no longer used so the
+                        button reads as a consistent CTA. */}
                     <div className="mt-auto">
                       <motion.button
-                        className={`h-12 w-full flex items-center justify-center gap-2 rounded-2xl text-base font-bold border transition-colors ${
+                        className={`h-14 w-full flex items-center justify-center gap-2 rounded-2xl text-lg font-bold border transition-all shadow-md hover:shadow-lg ${
                           isGenerating
                             ? "bg-white/70 text-gray-500 border-white cursor-wait"
                             : isRateLimited
                               ? "bg-amber-300 text-amber-900 border-amber-200 cursor-not-allowed"
-                              : `${theme.listenBtn} ${theme.listenBtnHover} text-white border-transparent`
+                              : "bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 text-white border-transparent"
                         }`}
                         disabled={generatingTopic !== null || isRateLimited}
                         onClick={() => handleListenNow(item.topic)}

--- a/frontend/src/types/hub.ts
+++ b/frontend/src/types/hub.ts
@@ -45,7 +45,7 @@ export interface HubPost {
   agent_name: string;
   agent_avatar_id: string;
   agent_title: string;
-  source_artifact_type: "art_story" | "interactive_story";
+  source_artifact_type: "art_story" | "interactive_story" | "kids_daily";
   source_id: string;
   caption: string | null;
   created_at: string;
@@ -62,7 +62,7 @@ export interface ListHubPostsResponse {
 }
 
 export interface CreateHubPostPayload {
-  source_artifact_type: "art_story" | "interactive_story";
+  source_artifact_type: "art_story" | "interactive_story" | "kids_daily";
   source_id: string;
   caption?: string;
 }


### PR DESCRIPTION
Two user-driven changes in one PR.

## 1. Kids Daily episodes can be shared to Content Hub

Backend
- \`hub_posts.source_artifact_type\` CHECK now allows \`('art_story','interactive_story','kids_daily')\`. New migration rebuilds the table on SQLite (CHECK can't be modified in place) or drops/re-adds the constraint on Postgres. Idempotent.
- \`hub_post_repository.create_post\` and \`routes/hub/posts.py\` extended the application-side guard list.

Frontend
- \`groupTheme.coverFor("kids_daily")\` → emerald-teal gradient + 🎙️ icon + "Kids Daily" label.
- \`PostCard.destinationFor\` routes \`kids_daily\` posts to \`/kids-daily/{episodeId}\`; type pill picks an emerald color.
- \`KidsDailyEpisodePage\` gets a "🌐 Share to Content Hub" CTA in the Episode Info aside that opens the shared \`ShareToHubModal\` with \`artifact_type='kids_daily'\`.

Privacy invariant unchanged — PostCard still reads only HubPost snapshot fields.

## 2. Listen Now button restyled (KidsDailyPage)

Per user: *"the button is not pretty, change the color so it looks fine, maybe pink faded too, and a little bigger"*.

| | Before | After |
|---|---|---|
| Background | Per-topic gradient (varied) | Uniform \`from-rose-300 via-pink-300 to-rose-300\` (pink faded) |
| Hover | Per-topic darker | \`from-rose-400 via-pink-400 to-rose-400\` |
| Height | \`h-12\` | \`h-14\` |
| Text | \`text-base\` | \`text-lg\` |
| Shadow | none | \`shadow-md hover:shadow-lg\` |

The per-topic gradient still drives the card body — only the action button is unified.

## Test plan

- [x] 28/28 backend contract tests pass; new \`test_kids_daily_source_type_accepted\` posts a kids_daily and asserts the response carries the new type
- [x] 11/11 frontend GroupPage tests pass (new \`coverFor("kids_daily")\` + \`destinationFor\` cases)
- [x] \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)