### PR TITLE
fix(ui): apply pink-faded style to Share-to-Hub buttons; revert Listen Now to per-topic

### DIFF
--- a/frontend/src/pages/InteractiveStoryPage/index.tsx
+++ b/frontend/src/pages/InteractiveStoryPage/index.tsx
@@ -792,17 +792,16 @@ function InteractiveStoryPage() {
             </Button>
           </div>
 
-          {/* Share-to-Content-Hub CTA (#453) */}
+          {/* Share-to-Content-Hub CTA (#453) — pink-faded shared style */}
           {sessionId && (
             <div className="flex justify-center pt-2">
-              <Button
-                variant="primary"
-                size="lg"
+              <button
+                type="button"
+                className="rounded-2xl bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 px-6 py-3 text-base font-bold text-white shadow-md hover:shadow-lg transition-all"
                 onClick={() => setShareOpen(true)}
-                leftIcon={<span>🌐</span>}
               >
-                Share to Content Hub
-              </Button>
+                🌐 Share to Content Hub
+              </button>
             </div>
           )}
         </motion.div>

--- a/frontend/src/pages/KidsDailyPage/index.tsx
+++ b/frontend/src/pages/KidsDailyPage/index.tsx
@@ -461,19 +461,15 @@ function KidsDailyPage() {
                       )}
                     </div>
 
-                    {/* Row 4: Listen Now button */}
-                    {/* Pink-faded uniform color across all topics, slightly
-                        bigger (h-14 + text-lg) per user request. The
-                        per-topic theme.listenBtn is no longer used so the
-                        button reads as a consistent CTA. */}
+                    {/* Row 4: Listen Now button — per-topic gradient */}
                     <div className="mt-auto">
                       <motion.button
-                        className={`h-14 w-full flex items-center justify-center gap-2 rounded-2xl text-lg font-bold border transition-all shadow-md hover:shadow-lg ${
+                        className={`h-12 w-full flex items-center justify-center gap-2 rounded-2xl text-base font-bold border transition-colors ${
                           isGenerating
                             ? "bg-white/70 text-gray-500 border-white cursor-wait"
                             : isRateLimited
                               ? "bg-amber-300 text-amber-900 border-amber-200 cursor-not-allowed"
-                              : "bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 text-white border-transparent"
+                              : `${theme.listenBtn} ${theme.listenBtnHover} text-white border-transparent`
                         }`}
                         disabled={generatingTopic !== null || isRateLimited}
                         onClick={() => handleListenNow(item.topic)}

--- a/frontend/src/pages/StoryPage/index.tsx
+++ b/frontend/src/pages/StoryPage/index.tsx
@@ -278,7 +278,7 @@ function StoryPage() {
         {storyId && (
           <button
             type="button"
-            className="rounded-md bg-violet-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-violet-700"
+            className="rounded-2xl bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 px-6 py-3 text-base font-bold text-white shadow-md hover:shadow-lg transition-all"
             onClick={() => setShareOpen(true)}
           >
             🌐 Share to Content Hub


### PR DESCRIPTION
Misread of the previous ask. The user wanted **every "Share to Content Hub" button** to share one pink-faded look. The previous PR (#489) instead repainted the per-topic "Listen Now" buttons on KidsDailyPage. Swap.

## Changes

| Surface | Before | After |
|---|---|---|
| **KidsDailyPage** Listen Now | Pink-faded gradient (#489) | Reverted to per-topic gradient (\`theme.listenBtn\`) |
| **StoryPage** Share to Hub | \`bg-violet-600\` | Pink-faded shared style |
| **InteractiveStoryPage** Share to Hub | \`<Button variant="primary">\` | Pink-faded bare button |
| **KidsDailyEpisodePage** Share to Hub | Already pink-faded from #489 | Unchanged |

The shared style is now:

\`\`\`
rounded-2xl
bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300
hover:from-rose-400 hover:via-pink-400 hover:to-rose-400
px-6 py-3 text-base font-bold text-white
shadow-md hover:shadow-lg transition-all
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Manual: visit /story/:id, /interactive (after completion), and /kids-daily/:episodeId — every Share to Hub button looks identical and pink-faded; KidsDailyPage's Listen Now buttons are back to their per-topic colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)