### PR TITLE
chore(ui): change My Agent nav icon from 🦊 to 🤖

### DIFF
--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -93,7 +93,7 @@ function PageContainerInner() {
             {/* Navigation links */}
             <div className="flex items-center gap-4">
               <NavLink to="/library" icon="📚" label="My Library" />
-              <NavLink to="/my-agent" icon="🦊" label="My Agent" />
+              <NavLink to="/my-agent" icon="🤖" label="My Agent" />
               <NavLink to="/content-hub" icon="🌐" label="Content Hub" />
 
               {/* Auth section */}


### PR DESCRIPTION
Per user feedback: *"I Think the '🦊My Agent' sign need to be change to something like '🤖My Agent', or a pretty looking robot sign then 'My Agent'"*.

The fox felt too animal-themed (and overlapped with the buddy animal avatars). The robot face reads more clearly as "AI assistant" which is what My Agent is.

Single-line change in \`PageContainer\`'s NavLink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)