### PR TITLE
fix(hub): use 🎭 for interactive_story cover + drop the icon hover-scale

### DIFF
--- a/frontend/src/pages/GroupPage/PostCard.tsx
+++ b/frontend/src/pages/GroupPage/PostCard.tsx
@@ -75,7 +75,7 @@ export default function PostCard({ post }: Props) {
       >
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute inset-0 flex items-center justify-center text-7xl drop-shadow-md transition-transform duration-300 group-hover:scale-110"
+          className="pointer-events-none absolute inset-0 flex items-center justify-center text-7xl drop-shadow-md"
         >
           {cover.icon}
         </span>


### PR DESCRIPTION
Per user feedback: *"the interactive story sign in the content hub others post is a emoji of '🎭', and I don't need the flowers pop out of it for no reason, same as the story I posted"*.

| Surface | Before | After |
|---|---|---|
| \`coverFor("interactive_story").icon\` | 🌟 | 🎭 (theatre masks — matches branching/role-play feel) |
| Cover icon hover | \`group-hover:scale-110\` (popped out) | static |
| Card hover lift | (preserved — \`hover:-translate-y-0.5\`) | unchanged |

The card itself still lifts subtly on hover so it reads as clickable. Only the icon scaling is removed.

## Test plan

- [x] 11/11 GroupPage vitest cases pass (icon assertion updated)
- [x] \`tsc --noEmit\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)