### PR TITLE
fix(hub): land 🎭 emoji for interactive_story cover (followup to #492)

### DIFF
--- a/frontend/src/pages/GroupPage/groupTheme.test.ts
+++ b/frontend/src/pages/GroupPage/groupTheme.test.ts
@@ -46,7 +46,7 @@ describe("coverFor", () => {
   });
   it("interactive_story uses the playful violet gradient", () => {
     const c = coverFor("interactive_story");
-    expect(c.icon).toBe("🌟");
+    expect(c.icon).toBe("🎭");
     expect(c.label).toBe("Interactive story");
   });
   it("kids_daily uses the podcast emerald-teal gradient", () => {

--- a/frontend/src/pages/GroupPage/groupTheme.ts
+++ b/frontend/src/pages/GroupPage/groupTheme.ts
@@ -127,7 +127,7 @@ export function coverFor(
   }
   return {
     gradient: "from-violet-400 via-fuchsia-300 to-sky-300",
-    icon: "🌟",
+    icon: "🎭",
     label: "Interactive story",
   };
 }


### PR DESCRIPTION
## Summary
- PR #492 only landed the PostCard.tsx hover-scale removal; the groupTheme.ts emoji swap (🌟 → 🎭) and its test assertion didn't make it into the merge commit.
- This PR re-applies the two missing edits.

## Changes
- `groupTheme.coverFor("interactive_story").icon`: `"🌟"` → `"🎭"`
- `groupTheme.test.ts`: assertion updated to expect `"🎭"`

## Test plan
- [x] `npx vitest run src/pages/GroupPage/groupTheme.test.ts` — 8/8 pass
- [ ] Verify in browser: open any Content Hub group page with an interactive_story post and confirm the cover icon renders as 🎭

Related to #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)