### PR TITLE
fix(kids-daily): connect Guest Anchor to recurring story characters

### DIFF
--- a/backend/src/agents/kids_daily_agent.py
+++ b/backend/src/agents/kids_daily_agent.py
@@ -931,17 +931,22 @@ async def generate_kids_daily_dialogue(
     age_group: str,
     child_id: Optional[str] = None,
     news_url: Optional[str] = None,
+    user_id: str = "",
 ) -> Dict[str, Any]:
     """Generate Kids Daily dialogue script with safety metadata."""
 
     source_text = _clean_source_text(news_text, news_url)
     topic = _headline_from_text(source_text)
 
-    # Resolve guest from recurring characters first (#365)
+    # Resolve guest from recurring characters first (#365). Pass the
+    # real user_id — characters are scoped (user_id, child_id), so an
+    # empty user_id silently returns no rows and we'd always fall back
+    # to the default Professor Owl, severing the connection to the
+    # child's art and interactive stories.
     guest_name = _default_guest(child_id)
-    if child_id:
+    if child_id and user_id:
         try:
-            characters = await character_repo.get_characters("", child_id)
+            characters = await character_repo.get_characters(user_id, child_id)
             if characters:
                 guest_name = characters[0].get("name", guest_name)
         except Exception:
@@ -998,6 +1003,7 @@ async def generate_kids_daily_episode(
     child_id: Optional[str],
     category: str,
     news_url: Optional[str] = None,
+    user_id: str = "",
 ) -> Dict[str, Any]:
     """Compose kid summary + dialogue script payload for Kids Daily."""
 
@@ -1016,6 +1022,7 @@ async def generate_kids_daily_episode(
         age_group=age_group,
         child_id=child_id,
         news_url=news_url,
+        user_id=user_id,
     )
 
     return {
@@ -1039,6 +1046,7 @@ async def stream_kids_daily_generation(
     child_id: Optional[str],
     category: str,
     news_url: Optional[str] = None,
+    user_id: str = "",
 ) -> AsyncGenerator[Dict[str, Any], None]:
     """Stream Kids Daily generation progress events."""
 
@@ -1061,6 +1069,7 @@ async def stream_kids_daily_generation(
         child_id=child_id,
         category=category,
         news_url=news_url,
+        user_id=user_id,
     )
 
     yield {

--- a/backend/src/api/routes/kids_daily.py
+++ b/backend/src/api/routes/kids_daily.py
@@ -428,6 +428,7 @@ async def _build_episode(
             child_id=child_id,
             category=request.category.value,
             news_url=request.news_url,
+            user_id=user.user_id,
         )
     except Exception:
         # Graceful fallback to deterministic baseline conversion
@@ -805,6 +806,7 @@ async def generate_kids_daily_on_demand_stream(
             child_id=build_request.child_id,
             category=build_request.category.value,
             news_url=None,
+            user_id=user.user_id,
         ):
             if await http_request.is_disconnected():
                 logger.info("Client disconnected during on-demand script generation, aborting")
@@ -877,6 +879,7 @@ async def generate_kids_daily_stream(
             child_id=request.child_id,
             category=request.category.value,
             news_url=request.news_url,
+            user_id=user.user_id,
         ):
             if await http_request.is_disconnected():
                 logger.info("Client disconnected during kids daily generation, aborting")

--- a/backend/tests/contracts/test_kids_daily_contract.py
+++ b/backend/tests/contracts/test_kids_daily_contract.py
@@ -1050,3 +1050,93 @@ class TestDegradedMetadata:
         restored = KidsDailyGenerationMetadata(**data)
         assert restored.is_degraded is True
         assert restored.degraded_reason == "mock_environment"
+
+
+# ---------------------------------------------------------------------------
+# Guest anchor uses recurring characters from art/interactive stories
+# ---------------------------------------------------------------------------
+class TestGuestAnchorRecurringCharacter:
+    """Contract: the Kids Daily guest anchor must be sourced from the child's
+    recurring story characters when one exists, so the show stays connected
+    to the art and interactive stories the child has already created."""
+
+    @pytest.mark.asyncio
+    async def test_recurring_character_overrides_default_guest(self):
+        """Top recurring character (by appearance_count) must replace the
+        deterministic default guest when (user_id, child_id) yields rows."""
+        from unittest.mock import AsyncMock, patch
+
+        from backend.src.agents.kids_daily_agent import generate_kids_daily_dialogue
+
+        with patch(
+            "backend.src.agents.kids_daily_agent._should_use_mock", return_value=True
+        ), patch(
+            "backend.src.agents.kids_daily_agent.character_repo.get_characters",
+            new_callable=AsyncMock,
+            return_value=[
+                {"name": "Lightning Dog", "appearance_count": 5},
+                {"name": "Sparkle Cat", "appearance_count": 2},
+            ],
+        ) as mock_get:
+            result = await generate_kids_daily_dialogue(
+                news_text="Scientists discovered a new planet.",
+                age_group="6-8",
+                child_id="c123",
+                user_id="u_abc",
+            )
+
+        # The lookup must be scoped to the actual user_id, not "".
+        # Empty user_id silently returned no rows pre-fix, defeating the feature.
+        mock_get.assert_awaited_once_with("u_abc", "c123")
+        assert result["guest_character"] == "Lightning Dog"
+
+    @pytest.mark.asyncio
+    async def test_empty_user_id_skips_lookup_falls_back_to_default(self):
+        """Without a user_id we MUST NOT query characters with "" — that
+        returns no rows by accident and is misleading. Skip and use default."""
+        from unittest.mock import AsyncMock, patch
+
+        from backend.src.agents.kids_daily_agent import generate_kids_daily_dialogue
+
+        with patch(
+            "backend.src.agents.kids_daily_agent._should_use_mock", return_value=True
+        ), patch(
+            "backend.src.agents.kids_daily_agent.character_repo.get_characters",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_get:
+            result = await generate_kids_daily_dialogue(
+                news_text="Scientists discovered a new planet.",
+                age_group="6-8",
+                child_id="c123",
+                # user_id intentionally omitted
+            )
+
+        mock_get.assert_not_awaited()
+        assert result["guest_character"], "Default guest must still be present"
+
+    @pytest.mark.asyncio
+    async def test_no_recurring_characters_uses_default_owl(self):
+        """When the lookup returns no characters, fall back to deterministic default."""
+        from unittest.mock import AsyncMock, patch
+
+        from backend.src.agents.kids_daily_agent import (
+            _default_guest,
+            generate_kids_daily_dialogue,
+        )
+
+        with patch(
+            "backend.src.agents.kids_daily_agent._should_use_mock", return_value=True
+        ), patch(
+            "backend.src.agents.kids_daily_agent.character_repo.get_characters",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await generate_kids_daily_dialogue(
+                news_text="Scientists discovered a new planet.",
+                age_group="6-8",
+                child_id="c123",
+                user_id="u_abc",
+            )
+
+        assert result["guest_character"] == _default_guest("c123")


### PR DESCRIPTION
## Summary
- The Kids Daily Guest Anchor always fell back to **Professor Owl** instead of being the child's own recurring character from their art and interactive stories.
- Root cause: `generate_kids_daily_dialogue` called `character_repo.get_characters(\"\", child_id)` with an empty `user_id`. Characters are scoped `(user_id, child_id)` — the empty `user_id` silently returned zero rows, so the default owl always won.
- Fix: plumb `user_id` end-to-end through the route → episode → dialogue → `get_characters` call chain, including the SSE streaming path.

## Changes
- `kids_daily_agent.generate_kids_daily_dialogue`: new `user_id` kwarg; lookup is `(user_id, child_id)` and is skipped entirely when `user_id` is empty (instead of issuing a guaranteed-miss query).
- `kids_daily_agent.generate_kids_daily_episode`: pass `user_id` through to dialogue.
- `kids_daily_agent.stream_kids_daily_generation`: accept and forward `user_id`.
- `routes/kids_daily.py`: pass `user.user_id` from `_build_episode` and both streaming endpoints.

## Why this matters
Personal Anchor (#365) is supposed to make Kids Daily *feel* like part of the child's creative world. The same character that starred in their drawing or branched through their interactive story should anchor the news show. Without this fix the feature is decorative — every child gets the same Professor Owl regardless of their library.

## Test plan
- [x] 3 new contract tests in `TestGuestAnchorRecurringCharacter`:
  - recurring character overrides default guest
  - empty `user_id` skips the lookup (no misleading `\"\"` query)
  - no recurring characters falls back to deterministic default
- [x] All 78 `tests/contracts/test_kids_daily_contract.py` tests pass
- [ ] Manual: log in as a user with at least one art_story or interactive_story; generate a Kids Daily episode; confirm the guest's name matches the most-frequent recurring character (visible in the dialogue script and the Kids Daily Episode page \"Guest Anchor\" chip).

Related to #365, #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)