### PR TITLE
feat(my-agent): run safety check on every buddy chat reply

### DIFF
--- a/backend/src/agents/my_agent_proxy.py
+++ b/backend/src/agents/my_agent_proxy.py
@@ -59,6 +59,61 @@ def _json_tool_result(data: dict[str, Any]) -> dict[str, Any]:
     return {"content": [{"type": "text", "text": json.dumps(data, ensure_ascii=False)}]}
 
 
+# Threshold matches the project-wide convention used in routes/agents.py
+# and PRD §3.4. Replies scoring below this are blocked and replaced with
+# a child-friendly fallback before delivery.
+_REPLY_SAFETY_THRESHOLD = 0.85
+
+# Warm, age-neutral fallback. Children are the audience — corporate
+# phrasing would feel jarring, but we also avoid implying the child did
+# anything wrong (the unsafe content came from the model, not the child).
+_SAFETY_FALLBACK_MESSAGE = (
+    "Let's try something else! What kind of story would you like to make?"
+)
+
+
+async def _check_reply_safety(text: str) -> tuple[Optional[float], Optional[str]]:
+    """Run the child-safety MCP against a buddy chat reply.
+
+    Returns ``(score, None)`` on success or ``(None, reason)`` when the
+    safety MCP is unreachable / returned a malformed envelope, so the
+    caller can fail closed without trusting a partial result. We never
+    raise — the proxy is mid-stream and an exception here would orphan
+    the SSE connection.
+
+    ``check_content_safety`` is decorated with the SDK's ``@tool``, which
+    wraps it in a non-callable ``SdkMcpTool`` registration object; the
+    raw async handler lives at ``.handler`` (same gotcha documented in
+    routes/agents.py::_run_safety_check).
+    """
+    try:
+        result = await check_content_safety.handler({
+            "content_text": text,
+            "content_type": "story",
+            "target_age": 7,
+        })
+    except Exception as exc:  # noqa: BLE001 — fail closed on any error
+        logger.warning("My Agent reply safety MCP unavailable: %s", exc)
+        return None, "safety_unavailable"
+
+    try:
+        data = json.loads(result["content"][0]["text"])
+    except (KeyError, IndexError, TypeError, ValueError):
+        logger.warning("My Agent reply safety MCP returned malformed payload")
+        return None, "safety_unavailable"
+
+    if not isinstance(data, dict) or "error" in data:
+        logger.warning("My Agent reply safety MCP returned error envelope: %s", data)
+        return None, "safety_unavailable"
+
+    score = data.get("safety_score")
+    if score is None:
+        logger.warning("My Agent reply safety MCP omitted safety_score")
+        return None, "safety_unavailable"
+
+    return float(score), None
+
+
 def _supports_callable(cls: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
     if cls is None:
         return {}
@@ -464,6 +519,51 @@ Return either a friendly chat reply or a short summary of the generated result.
         return
 
     final_text = final_text.strip() or "I'm here and ready to create with you."
+
+    # #498 — Safety gate: every buddy chat reply MUST pass content-safety
+    # review before reaching the client. We fail closed on MCP errors
+    # because PRD §3.4 treats child safety as non-negotiable; the user
+    # experience cost of a fallback message is far less than the cost
+    # of delivering unsafe text. The original (blocked) text is logged
+    # for telemetry but never re-emitted on the SSE stream.
+    safety_score, safety_error = await _check_reply_safety(final_text)
+    if safety_error is not None:
+        logger.warning(
+            "Replacing buddy reply with safe fallback (reason=%s, len=%d)",
+            safety_error,
+            len(final_text),
+        )
+        yield _sse(
+            "safety_blocked",
+            {
+                "reason": safety_error,
+                "safety_score": None,
+                "original_length": len(final_text),
+            },
+        )
+        final_text = _SAFETY_FALLBACK_MESSAGE
+        result_metadata = {"response_type": "chat"}
+    elif safety_score is not None and safety_score < _REPLY_SAFETY_THRESHOLD:
+        logger.warning(
+            "Replacing buddy reply with safe fallback (score=%.2f, len=%d)",
+            safety_score,
+            len(final_text),
+        )
+        yield _sse(
+            "safety_blocked",
+            {
+                "reason": "below_threshold",
+                "safety_score": safety_score,
+                "threshold": _REPLY_SAFETY_THRESHOLD,
+                "original_length": len(final_text),
+            },
+        )
+        final_text = _SAFETY_FALLBACK_MESSAGE
+        result_metadata = {"response_type": "chat"}
+    else:
+        # Successful safe reply — log score for monitoring (per-turn telemetry).
+        logger.info("Buddy reply passed safety review (score=%.2f)", safety_score or 0.0)
+
     result_payload = {
         "response_type": result_metadata["response_type"],
         "message": final_text,

--- a/backend/tests/contracts/test_my_agent_proxy.py
+++ b/backend/tests/contracts/test_my_agent_proxy.py
@@ -450,3 +450,258 @@ class TestAgentNotFoundPath:
         error_events = [e for e in events if e["event"] == "error"]
         assert error_events, f"Expected an SSE error event, got: {[e['event'] for e in events]}"
         assert error_events[0]["data"]["error"] == "AGENT_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Safety on every reply (#498)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSdkClient:
+    """Async-context-manager stand-in for ClaudeSDKClient that emits a
+    deterministic ResultMessage so we can exercise the post-SDK code path
+    (specifically the safety gate added by #498) without hitting Anthropic.
+
+    The real client yields a mix of StreamEvent / AssistantMessage / Tool*
+    blocks / ResultMessage. We only need ResultMessage to set ``final_text``,
+    because the safety check fires after the loop completes."""
+
+    def __init__(self, result_text: str = "Sure! Let's make a story.", session_id: str = "sdk_sess_test"):
+        self._result_text = result_text
+        self._session_id = session_id
+        self.queries: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def query(self, prompt: str) -> None:
+        self.queries.append(prompt)
+
+    async def receive_response(self):
+        # Yield a single ResultMessage-shaped object. The proxy checks
+        # ``isinstance(sdk_message, ResultMessage)`` — so we monkey-patch
+        # ResultMessage to ``_FakeResultMessage`` for the duration of the
+        # test (see _patched_sdk below).
+        yield _FakeResultMessage(result=self._result_text, session_id=self._session_id)
+
+
+class _FakeResultMessage:
+    """Minimal stand-in matching the attributes the proxy reads
+    (``result`` and ``session_id``)."""
+
+    def __init__(self, result: str, session_id: str):
+        self.result = result
+        self.session_id = session_id
+
+
+class _FakeOptions:
+    """Stand-in for ClaudeAgentOptions — must be instantiable with **kwargs."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+def _patched_sdk(monkeypatch_obj, result_text: str = "Sure! Let's make a story."):
+    """
+    Patch ClaudeSDKClient / ClaudeAgentOptions / ResultMessage so the SDK
+    loop runs deterministically and ``final_text`` ends up as ``result_text``.
+    Returns the fake client so the test can inspect it if needed.
+    """
+    fake_client = _FakeSdkClient(result_text=result_text)
+
+    def _client_factory(options):
+        # Real SDK takes options as a kw or positional; we don't care.
+        return fake_client
+
+    monkeypatch_obj.setattr(my_agent_proxy, "ClaudeSDKClient", _client_factory)
+    monkeypatch_obj.setattr(my_agent_proxy, "ClaudeAgentOptions", _FakeOptions)
+    monkeypatch_obj.setattr(my_agent_proxy, "ResultMessage", _FakeResultMessage)
+    return fake_client
+
+
+def _safety_envelope(score: float) -> dict[str, Any]:
+    return {"content": [{"type": "text", "text": json.dumps({"safety_score": score})}]}
+
+
+def _seed_agent_into_repo():
+    """Patch agent_repo.get_agent to return a stub agent so the proxy
+    proceeds past the AGENT_NOT_FOUND guard. We patch the repo (not the
+    DB) so tests don't depend on schema rows beyond the user FK."""
+    return patch.object(
+        my_agent_proxy.agent_repo,
+        "get_agent",
+        new=AsyncMock(return_value=_fake_agent(enabled_skills=["image_story"])),
+    )
+
+
+def _stub_context():
+    """Patch build_my_agent_context to avoid hitting real preference repos."""
+    return patch.object(
+        my_agent_proxy,
+        "build_my_agent_context",
+        new=AsyncMock(return_value="(test context)"),
+    )
+
+
+class TestSafetyOnEveryReply:
+    """#498 — Every successful buddy chat reply must pass through
+    check_content_safety before SSE delivery. Below-threshold replies
+    must be replaced with a child-friendly fallback AND emit a
+    ``safety_blocked`` telemetry event. Safety MCP errors must fail
+    closed (same fallback). PRD §3.4 calls this non-negotiable."""
+
+    @pytest.mark.asyncio
+    async def test_safe_reply_passes_through_unchanged(self, test_db, monkeypatch):
+        """Score >= 0.85 -> the original final_text reaches the result event."""
+        _patched_sdk(monkeypatch, result_text="Sure! Let's make a story about a brave fox.")
+
+        safety_mock = AsyncMock(return_value=_safety_envelope(0.99))
+        with _seed_agent_into_repo(), _stub_context(), patch.object(
+            my_agent_proxy.check_content_safety, "handler", new=safety_mock
+        ):
+            chunks: list[str] = []
+            async for chunk in my_agent_proxy.stream_my_agent_chat(
+                user_id=_TEST_USER_ID,
+                child_id=_TEST_CHILD_ID,
+                message="hi buddy",
+            ):
+                chunks.append(chunk)
+
+        events = _parse_sse_events("".join(chunks))
+        results = [e for e in events if e["event"] == "result"]
+        assert results, f"Expected a result event, got: {[e['event'] for e in events]}"
+        assert results[0]["data"]["message"] == "Sure! Let's make a story about a brave fox."
+        # No safety_blocked event when the reply passes.
+        assert not [e for e in events if e["event"] == "safety_blocked"]
+        # Safety check MUST have been called (every reply, not just some).
+        assert safety_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unsafe_reply_replaced_with_fallback_and_emits_safety_blocked(
+        self, test_db, monkeypatch
+    ):
+        """Score < 0.85 -> reply is replaced with a child-friendly fallback
+        and a ``safety_blocked`` SSE event is emitted for telemetry."""
+        original = "An unsafe-sounding reply the SDK produced."
+        _patched_sdk(monkeypatch, result_text=original)
+
+        safety_mock = AsyncMock(return_value=_safety_envelope(0.50))
+        with _seed_agent_into_repo(), _stub_context(), patch.object(
+            my_agent_proxy.check_content_safety, "handler", new=safety_mock
+        ):
+            chunks: list[str] = []
+            async for chunk in my_agent_proxy.stream_my_agent_chat(
+                user_id=_TEST_USER_ID,
+                child_id=_TEST_CHILD_ID,
+                message="please say something unsafe",
+            ):
+                chunks.append(chunk)
+
+        events = _parse_sse_events("".join(chunks))
+
+        # The result event must carry the fallback, not the unsafe original.
+        results = [e for e in events if e["event"] == "result"]
+        assert results, "Expected a result event"
+        assert results[0]["data"]["message"] != original
+        assert results[0]["data"]["message"], "Fallback message must be non-empty"
+
+        # Telemetry: safety_blocked event must be emitted with the score.
+        blocked = [e for e in events if e["event"] == "safety_blocked"]
+        assert blocked, "Expected a safety_blocked event when score < 0.85"
+        assert blocked[0]["data"].get("safety_score") == 0.50
+        # Reason should be present so observability can distinguish below-threshold from MCP errors.
+        assert blocked[0]["data"].get("reason") in {"below_threshold", "score_below_threshold"}
+
+        # The unsafe text must NOT appear in any emitted result/complete data.
+        joined = "".join(chunks)
+        assert original not in joined, "Unsafe text must not be delivered to the client"
+
+    @pytest.mark.asyncio
+    async def test_safety_mcp_error_fails_closed(self, test_db, monkeypatch):
+        """If check_content_safety.handler raises, the proxy must fail
+        closed: replace the reply with the safe fallback and emit a
+        ``safety_blocked`` event. Never silently let unchecked text through."""
+        original = "Some reply the SDK produced."
+        _patched_sdk(monkeypatch, result_text=original)
+
+        safety_mock = AsyncMock(side_effect=RuntimeError("boom"))
+        with _seed_agent_into_repo(), _stub_context(), patch.object(
+            my_agent_proxy.check_content_safety, "handler", new=safety_mock
+        ):
+            chunks: list[str] = []
+            async for chunk in my_agent_proxy.stream_my_agent_chat(
+                user_id=_TEST_USER_ID,
+                child_id=_TEST_CHILD_ID,
+                message="hi",
+            ):
+                chunks.append(chunk)
+
+        events = _parse_sse_events("".join(chunks))
+        results = [e for e in events if e["event"] == "result"]
+        assert results, "Expected a result event even when safety MCP errors"
+        assert results[0]["data"]["message"] != original
+
+        blocked = [e for e in events if e["event"] == "safety_blocked"]
+        assert blocked, "Expected safety_blocked event on MCP error (fail closed)"
+        assert blocked[0]["data"].get("reason") in {"safety_unavailable", "mcp_error"}
+
+        joined = "".join(chunks)
+        assert original not in joined
+
+    @pytest.mark.asyncio
+    async def test_safety_check_called_on_every_reply(self, test_db, monkeypatch):
+        """Acceptance criterion: every reply (not just sampled ones) hits
+        the safety MCP. We invoke the stream three times and assert
+        handler.await_count == 3."""
+        _patched_sdk(monkeypatch, result_text="A friendly reply.")
+
+        safety_mock = AsyncMock(return_value=_safety_envelope(0.95))
+        with _seed_agent_into_repo(), _stub_context(), patch.object(
+            my_agent_proxy.check_content_safety, "handler", new=safety_mock
+        ):
+            for _ in range(3):
+                async for _chunk in my_agent_proxy.stream_my_agent_chat(
+                    user_id=_TEST_USER_ID,
+                    child_id=_TEST_CHILD_ID,
+                    message="say something",
+                ):
+                    pass
+
+        assert safety_mock.await_count == 3, (
+            f"Safety check must run on every reply, ran {safety_mock.await_count} times"
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_safety_payload_fails_closed(self, test_db, monkeypatch):
+        """If the safety MCP returns a malformed envelope (missing
+        safety_score), the proxy must fail closed — same fallback. This
+        protects against partial outages where the MCP responds 200 but
+        with garbage."""
+        original = "A reply the SDK produced."
+        _patched_sdk(monkeypatch, result_text=original)
+
+        # Missing safety_score field.
+        bad_envelope = {"content": [{"type": "text", "text": json.dumps({"error": "rate_limited"})}]}
+        safety_mock = AsyncMock(return_value=bad_envelope)
+        with _seed_agent_into_repo(), _stub_context(), patch.object(
+            my_agent_proxy.check_content_safety, "handler", new=safety_mock
+        ):
+            chunks: list[str] = []
+            async for chunk in my_agent_proxy.stream_my_agent_chat(
+                user_id=_TEST_USER_ID,
+                child_id=_TEST_CHILD_ID,
+                message="hi",
+            ):
+                chunks.append(chunk)
+
+        events = _parse_sse_events("".join(chunks))
+        results = [e for e in events if e["event"] == "result"]
+        assert results, "Expected a result event even when safety payload malformed"
+        assert results[0]["data"]["message"] != original
+
+        blocked = [e for e in events if e["event"] == "safety_blocked"]
+        assert blocked, "Expected safety_blocked event on malformed payload (fail closed)"
+        assert blocked[0]["data"].get("reason") in {"safety_unavailable", "mcp_error"}


### PR DESCRIPTION
## Summary

- Adds a server-side safety gate to `stream_my_agent_chat` so every successful buddy chat reply runs through `check_content_safety` before SSE delivery.
- Below-threshold replies (`safety_score < 0.85`) are replaced with a warm, age-neutral fallback (`"Let's try something else! What kind of story would you like to make?"`) and the proxy emits a typed `safety_blocked` SSE event carrying the score + reason for observability.
- MCP errors and malformed envelopes fail closed with the same fallback (reason `safety_unavailable`). PRD §3.4 treats child safety as non-negotiable — we never let unchecked text reach a child.

Threshold and fallback live as module-level constants (`_REPLY_SAFETY_THRESHOLD = 0.85`, `_SAFETY_FALLBACK_MESSAGE`) matching the project-wide convention in `routes/agents.py`.

## Stacking

This PR stacks on PR #501 (#495 — My Agent proxy foundation). **Must merge AFTER #501**; the base branch is `feat/495-land-my-agent-proxy`, not `main`.

## TDD

Tests were written first and all five failed before the implementation landed:

- `test_safe_reply_passes_through_unchanged` — `score=0.99` → original text reaches `result` event, no `safety_blocked` emitted.
- `test_unsafe_reply_replaced_with_fallback_and_emits_safety_blocked` — `score=0.50` → fallback delivered, `safety_blocked` event emitted with score, original text never appears anywhere in the SSE stream.
- `test_safety_mcp_error_fails_closed` — handler raises → fail closed with fallback + `safety_unavailable` reason.
- `test_safety_check_called_on_every_reply` — 3 stream invocations → 3 handler awaits (acceptance criterion: every reply, not sampled).
- `test_malformed_safety_payload_fails_closed` — MCP returns 200 with malformed body → fail closed.

A deterministic `_FakeSdkClient` / `_FakeResultMessage` pair drives the `ResultMessage` code path without hitting Anthropic, so tests are 100% CI-safe.

## Out of scope

Deferred follow-ups (called out in the commit body):

- Age-aware threshold (`>= 0.90` for ages 3–5) — needs child age plumbed into the proxy.
- `suggest_content_improvements` + 1-retry path — keeps this PR small and reviewable; the cheap-fallback path is the minimum viable safety enforcement.

## Test plan

- [x] `pytest tests/contracts/test_my_agent_proxy.py -v` — **21/21 pass** (16 existing + 5 new).
- [x] Adjacent suites untouched: `test_agent_endpoint_contract.py`, `test_safety_failclosed_contract.py` still green (the 5 pre-existing `test_safety_prompt_contract` failures on `feat/495-land-my-agent-proxy` are unrelated to this PR — verified by re-running against `HEAD~1`).
- [ ] Manual smoke: send a chat request, confirm `safety_blocked` event surfaces in browser devtools when an unsafe reply is forced.

Fixes #498
Parent Epic: #436