### PR TITLE
feat(my-agent): emit launch_flow SSE event + frontend nav hook (#496)

### DIFF
--- a/backend/src/agents/my_agent_proxy.py
+++ b/backend/src/agents/my_agent_proxy.py
@@ -114,6 +114,91 @@ async def _check_reply_safety(text: str) -> tuple[Optional[float], Optional[str]
     return float(score), None
 
 
+# #496 — launch_flow whitelist. Maps the specialist `response_type` (set
+# by tools in `_make_tools` below) to the landing route the SPA should
+# navigate to and the payload field that carries the resource ID, if any.
+# Centralised so adding a new specialist requires updating exactly one
+# table — the contract test_invalid_response_type pins this whitelist.
+_LAUNCH_FLOW_REGISTRY: dict[str, dict[str, str]] = {
+    "image_story": {
+        "id_field": "story_id",
+        "detail_route": "/story",
+        "landing_route": "/upload",
+    },
+    "interactive_story": {
+        "id_field": "session_id",
+        "detail_route": "/interactive-story",
+        "landing_route": "/interactive",
+    },
+    "kids_daily": {
+        "id_field": "episode_id",
+        "detail_route": "/kids-daily",
+        "landing_route": "/kids-daily",
+    },
+}
+
+# Keys we are willing to forward as prefill query params. Bounded by
+# design so a future specialist that returns large or sensitive fields
+# can't accidentally leak them through the URL. PRD §3.4 keeps child
+# identifiers out of marketing surfaces — these keys are all safe to
+# pass through as query params on the user's own browser.
+_LAUNCH_FLOW_PREFILL_KEYS: frozenset[str] = frozenset(
+    {
+        "story_id",
+        "session_id",
+        "episode_id",
+        "child_id",
+        "age_group",
+        "theme",
+        "category",
+    }
+)
+
+
+def _build_launch_flow_data(parsed: dict[str, Any]) -> Optional[dict[str, Any]]:
+    """Translate a specialist tool result into a launch_flow event payload.
+
+    The proxy receives tool results shaped as
+    ``{"response_type": "<flow>", "payload": {...}}``. This helper returns
+    the SSE event body (``flow_type`` / ``route`` / ``prefill``) or
+    ``None`` when the response type is not in the whitelist (e.g.
+    plain chat replies, or an unknown future type) — the caller then
+    skips the event entirely rather than navigating somewhere undefined.
+
+    Trade-off: we whitelist routes server-side rather than letting the
+    subagent choose freely. That costs flexibility but eliminates the
+    risk of an LLM-generated route navigating the child to an unrelated
+    page on an open-redirect-style mistake.
+    """
+    if not isinstance(parsed, dict):
+        return None
+    response_type = parsed.get("response_type")
+    spec = _LAUNCH_FLOW_REGISTRY.get(response_type)
+    if spec is None:
+        return None
+    payload_raw = parsed.get("payload")
+    payload = payload_raw if isinstance(payload_raw, dict) else {}
+
+    resource_id = payload.get(spec["id_field"])
+    if resource_id:
+        route = f"{spec['detail_route']}/{resource_id}"
+    else:
+        # No persisted ID yet — bounce to the landing page so the user
+        # can finish the flow with prefilled defaults.
+        route = spec["landing_route"]
+
+    prefill = {
+        key: payload[key]
+        for key in _LAUNCH_FLOW_PREFILL_KEYS
+        if key in payload and payload[key] is not None
+    }
+    return {
+        "flow_type": response_type,
+        "route": route,
+        "prefill": prefill,
+    }
+
+
 def _supports_callable(cls: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
     if cls is None:
         return {}
@@ -783,6 +868,17 @@ async def stream_my_agent_chat(
                                         parsed = {}
                                     if isinstance(parsed, dict) and parsed.get("response_type"):
                                         result_metadata = parsed
+                                        # #496 — Surface a typed navigation
+                                        # hint as soon as a specialist
+                                        # tool returns a known flow. The
+                                        # event is emitted BEFORE the
+                                        # `result` event so the SPA can
+                                        # navigate to the matching page
+                                        # with prefill params while the
+                                        # chat reply is still streaming.
+                                        launch = _build_launch_flow_data(parsed)
+                                        if launch is not None:
+                                            yield _sse("launch_flow", launch)
                                 yield _sse(
                                     "tool_result",
                                     {"status": "completed", "message": "Specialist finished."},

--- a/backend/tests/contracts/test_my_agent_proxy.py
+++ b/backend/tests/contracts/test_my_agent_proxy.py
@@ -705,3 +705,248 @@ class TestSafetyOnEveryReply:
         blocked = [e for e in events if e["event"] == "safety_blocked"]
         assert blocked, "Expected safety_blocked event on malformed payload (fail closed)"
         assert blocked[0]["data"].get("reason") in {"safety_unavailable", "mcp_error"}
+
+
+# ---------------------------------------------------------------------------
+# launch_flow SSE event (#496)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSDKClient:
+    """Async-context-manager stand-in for ClaudeSDKClient.
+
+    Yields a caller-supplied list of SDK messages from receive_response()
+    so we can drive ToolResultBlock paths without spinning a real agent.
+    """
+
+    def __init__(self, *, messages):
+        self._messages = messages
+
+    def __call__(self, *_args, **_kwargs):  # pragma: no cover - unused
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def query(self, _prompt):
+        return None
+
+    async def receive_response(self):
+        for message in self._messages:
+            yield message
+
+
+def _assistant_with_tool_result(payload: dict[str, Any]):
+    """Build an AssistantMessage carrying a single ToolResultBlock with payload."""
+    from claude_agent_sdk import AssistantMessage, ToolResultBlock
+
+    block = ToolResultBlock(
+        tool_use_id="tu_test",
+        content=[{"type": "text", "text": json.dumps(payload, ensure_ascii=False)}],
+        is_error=False,
+    )
+    return AssistantMessage(content=[block], model="claude-haiku")
+
+
+def _fake_result_message(text: str):
+    """Build a ResultMessage stand-in with the SDK's real class.
+
+    The proxy checks `isinstance(sdk_message, ResultMessage)`, so we must
+    use the real class. We pass through enough kwargs to instantiate it.
+    """
+    from claude_agent_sdk import ResultMessage
+
+    return ResultMessage(
+        subtype="success",
+        duration_ms=0,
+        duration_api_ms=0,
+        is_error=False,
+        num_turns=1,
+        session_id="sdk_sess_1",
+        total_cost_usd=0.0,
+        result=text,
+    )
+
+
+async def _collect_launch_flow_run(messages, *, image_path=None):
+    """Drive stream_my_agent_chat with a fake SDK client and parse SSE.
+
+    Patches in:
+      - a fake SDKClient that yields the supplied messages,
+      - a fake agent persona with all four specialist skills enabled,
+      - a passthrough safety MCP so any future buddy-reply safety gate
+        (e.g. PRD §3.4) doesn't silently swallow the response and hide
+        the launch_flow contract we are exercising here.
+    """
+    fake_client = _FakeSDKClient(messages=messages)
+    fake_agent = _fake_agent(
+        enabled_skills=["image_story", "interactive_story", "kids_daily", "audio_narration"]
+    )
+    safe_envelope = {"content": [{"type": "text", "text": json.dumps({"safety_score": 0.99})}]}
+    with patch.object(my_agent_proxy.agent_repo, "get_agent", new=AsyncMock(return_value=fake_agent)), \
+         patch.object(my_agent_proxy, "ClaudeSDKClient", lambda *a, **kw: fake_client), \
+         patch.object(
+             my_agent_proxy,
+             "build_my_agent_context",
+             new=AsyncMock(return_value="ctx"),
+         ), \
+         patch(
+             "backend.src.agents.my_agent_proxy.check_content_safety.handler",
+             new=AsyncMock(return_value=safe_envelope),
+         ):
+        chunks: list[str] = []
+        async for chunk in my_agent_proxy.stream_my_agent_chat(
+            user_id=_TEST_USER_ID,
+            child_id=_TEST_CHILD_ID,
+            message="hi buddy",
+            image_path=image_path,
+        ):
+            chunks.append(chunk)
+    return _parse_sse_events("".join(chunks))
+
+
+class TestLaunchFlowEvent:
+    """When a specialist tool returns a structured payload the proxy must
+    emit a typed `launch_flow` SSE event BEFORE the `result` event. This is
+    the primitive that lets the My Agent chat hop the user to the matching
+    standalone experience page with prefilled query params (#496)."""
+
+    @pytest.mark.asyncio
+    async def test_image_story_emits_launch_flow_before_result(self, test_db):
+        payload = {
+            "response_type": "image_story",
+            "payload": {
+                "story_id": "stry_abc123",
+                "story": "Once upon a time...",
+                "child_id": "c_test",
+                "age_group": "6-8",
+                "themes": ["adventure"],
+            },
+        }
+        events = await _collect_launch_flow_run(
+            messages=[
+                _assistant_with_tool_result(payload),
+                _fake_result_message("Story made!"),
+            ],
+            image_path="/tmp/x.png",
+        )
+        names = [e["event"] for e in events]
+        assert "launch_flow" in names, f"launch_flow missing from {names}"
+        # launch_flow must come before result so the frontend can navigate first.
+        assert names.index("launch_flow") < names.index("result")
+        launch = next(e for e in events if e["event"] == "launch_flow")
+        assert launch["data"]["flow_type"] == "image_story"
+        assert launch["data"]["route"] == "/story/stry_abc123"
+        prefill = launch["data"]["prefill"]
+        assert prefill.get("story_id") == "stry_abc123"
+        # Prefill should carry the IDs the target page reads from query params.
+        assert "child_id" in prefill
+
+    @pytest.mark.asyncio
+    async def test_interactive_story_emits_launch_flow(self, test_db):
+        payload = {
+            "response_type": "interactive_story",
+            "payload": {
+                "session_id": "sess_xyz999",
+                "title": "Forest Quest",
+                "age_group": "6-8",
+                "theme": "forest",
+            },
+        }
+        events = await _collect_launch_flow_run(
+            messages=[
+                _assistant_with_tool_result(payload),
+                _fake_result_message("Story started!"),
+            ],
+        )
+        launch = next((e for e in events if e["event"] == "launch_flow"), None)
+        assert launch is not None, "launch_flow event missing for interactive_story"
+        assert launch["data"]["flow_type"] == "interactive_story"
+        assert launch["data"]["route"] == "/interactive-story/sess_xyz999"
+        prefill = launch["data"]["prefill"]
+        assert prefill.get("session_id") == "sess_xyz999"
+        assert prefill.get("age_group") == "6-8"
+
+    @pytest.mark.asyncio
+    async def test_kids_daily_emits_launch_flow(self, test_db):
+        payload = {
+            "response_type": "kids_daily",
+            "payload": {
+                "episode_id": "ep_777",
+                "kid_title": "Today's Big News",
+                "age_group": "6-8",
+                "category": "science",
+            },
+        }
+        events = await _collect_launch_flow_run(
+            messages=[
+                _assistant_with_tool_result(payload),
+                _fake_result_message("Episode ready!"),
+            ],
+        )
+        launch = next((e for e in events if e["event"] == "launch_flow"), None)
+        assert launch is not None, "launch_flow event missing for kids_daily"
+        assert launch["data"]["flow_type"] == "kids_daily"
+        assert launch["data"]["route"] == "/kids-daily/ep_777"
+        prefill = launch["data"]["prefill"]
+        assert prefill.get("episode_id") == "ep_777"
+
+    @pytest.mark.asyncio
+    async def test_chat_response_does_not_emit_launch_flow(self, test_db):
+        """When no specialist fires, response_type defaults to 'chat' and
+        the proxy must NOT emit a launch_flow event — otherwise the frontend
+        would try to navigate away from a plain text reply."""
+        events = await _collect_launch_flow_run(
+            messages=[_fake_result_message("Hi friend!")],
+        )
+        names = [e["event"] for e in events]
+        assert "launch_flow" not in names, (
+            f"Unexpected launch_flow for plain chat: {names}"
+        )
+        # We still expect a result event for the chat reply.
+        assert "result" in names
+
+    @pytest.mark.asyncio
+    async def test_invalid_response_type_does_not_emit_launch_flow(self, test_db):
+        """Defensive: an unknown response_type must not produce a
+        launch_flow event with an unmapped route. This snapshots the
+        whitelist policy so a future agent that returns 'video_story' or
+        similar can't silently navigate the user somewhere broken."""
+        payload = {"response_type": "video_story", "payload": {"video_id": "v1"}}
+        events = await _collect_launch_flow_run(
+            messages=[
+                _assistant_with_tool_result(payload),
+                _fake_result_message("Made a thing."),
+            ],
+        )
+        names = [e["event"] for e in events]
+        assert "launch_flow" not in names, (
+            f"launch_flow emitted for unknown response_type: {names}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_id_falls_back_to_landing_route(self, test_db):
+        """If the specialist payload has no story_id/session_id/episode_id
+        the proxy should still emit launch_flow pointing at the landing
+        page so the user lands in the right experience (with prefill) even
+        when persistence isn't wired through the buddy yet."""
+        payload = {
+            "response_type": "image_story",
+            "payload": {"child_id": "c_test", "age_group": "6-8"},  # no story_id
+        }
+        events = await _collect_launch_flow_run(
+            messages=[
+                _assistant_with_tool_result(payload),
+                _fake_result_message("Made a story."),
+            ],
+            image_path="/tmp/x.png",
+        )
+        launch = next((e for e in events if e["event"] == "launch_flow"), None)
+        assert launch is not None, "launch_flow should still fire without an ID"
+        assert launch["data"]["flow_type"] == "image_story"
+        # Landing route (no /:id) so the page can pick up where it left off.
+        assert launch["data"]["route"] == "/upload"
+        assert launch["data"]["prefill"].get("child_id") == "c_test"

--- a/frontend/src/__tests__/hooks/useLaunchFlowNavigation.test.ts
+++ b/frontend/src/__tests__/hooks/useLaunchFlowNavigation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * launch_flow contract tests (#496).
+ *
+ * Two layers are exercised here:
+ *
+ *   1. `buildLaunchFlowPath` — the pure helper that converts a
+ *      `launch_flow` SSE payload into a navigable path with prefill
+ *      query params. Pure function so we can pin it without spinning
+ *      up React Router.
+ *
+ *   2. `consumeSSEStream` — the shared SSE dispatcher must recognise
+ *      the new `launch_flow` event type and route it to
+ *      `callbacks.onLaunchFlow`. If an SPA omits that callback, the
+ *      stream must NOT throw (older clients should ignore the event
+ *      and fall back to the regular text reply per the issue body).
+ */
+import { describe, expect, it, vi } from "vitest";
+import { buildLaunchFlowPath } from "@/hooks/useLaunchFlowNavigation";
+import { consumeSSEStream } from "@/api/utils/sseStream";
+import type { SSELaunchFlowData, StreamCallbacks } from "@/types/api";
+
+function streamResponse(body: string): Response {
+  // Encode the SSE blob into a single-shot ReadableStream — matches
+  // what fetch() yields for a server-sent-events response.
+  return {
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(body));
+        controller.close();
+      },
+    }),
+  } as Response;
+}
+
+describe("buildLaunchFlowPath", () => {
+  it("preserves the route when prefill is empty", () => {
+    const data: SSELaunchFlowData = {
+      flow_type: "image_story",
+      route: "/story/stry_abc",
+      prefill: {},
+    };
+    expect(buildLaunchFlowPath(data)).toBe("/story/stry_abc");
+  });
+
+  it("appends prefill as query params", () => {
+    const data: SSELaunchFlowData = {
+      flow_type: "interactive_story",
+      route: "/interactive-story/sess_xyz",
+      prefill: { session_id: "sess_xyz", age_group: "6-8", theme: "forest" },
+    };
+    const path = buildLaunchFlowPath(data);
+    expect(path.startsWith("/interactive-story/sess_xyz?")).toBe(true);
+    const params = new URLSearchParams(path.split("?")[1]);
+    expect(params.get("session_id")).toBe("sess_xyz");
+    expect(params.get("age_group")).toBe("6-8");
+    expect(params.get("theme")).toBe("forest");
+  });
+
+  it("skips null/undefined prefill values", () => {
+    const data: SSELaunchFlowData = {
+      flow_type: "kids_daily",
+      route: "/kids-daily/ep_1",
+      prefill: { episode_id: "ep_1", theme: null },
+    };
+    const path = buildLaunchFlowPath(data);
+    expect(path).toContain("episode_id=ep_1");
+    expect(path).not.toContain("theme=");
+  });
+
+  it("URL-encodes special characters in prefill values", () => {
+    const data: SSELaunchFlowData = {
+      flow_type: "image_story",
+      route: "/upload",
+      prefill: { theme: "outer space & stars" },
+    };
+    const path = buildLaunchFlowPath(data);
+    // URLSearchParams encodes spaces as '+' and ampersands as '%26'.
+    expect(path).toContain("theme=outer+space+%26+stars");
+  });
+});
+
+describe("consumeSSEStream — launch_flow event", () => {
+  it("routes the launch_flow event to onLaunchFlow with the parsed payload", async () => {
+    const payload: SSELaunchFlowData = {
+      flow_type: "image_story",
+      route: "/story/stry_123",
+      prefill: { story_id: "stry_123", child_id: "c1" },
+    };
+    const blob = `event: launch_flow\ndata: ${JSON.stringify(payload)}\n\n`;
+    const onLaunchFlow = vi.fn();
+    const callbacks: StreamCallbacks = { onLaunchFlow };
+    await consumeSSEStream(streamResponse(blob), callbacks);
+    expect(onLaunchFlow).toHaveBeenCalledTimes(1);
+    expect(onLaunchFlow).toHaveBeenCalledWith(payload);
+  });
+
+  it("silently ignores launch_flow when no onLaunchFlow callback is registered", async () => {
+    // Older clients (pre-#496) won't have onLaunchFlow wired up. The
+    // SSE dispatcher must not throw — the user should still receive
+    // the regular text reply via onResult. Acceptance criteria: "If
+    // the frontend SSE handler is older and doesn't understand
+    // launch_flow, the user still sees a fallback text reply".
+    const launchBlob = `event: launch_flow\ndata: {"flow_type":"kids_daily","route":"/kids-daily/ep_1","prefill":{}}\n\n`;
+    const resultBlob = `event: result\ndata: {"message":"Episode ready!"}\n\n`;
+    const onResult = vi.fn();
+    await consumeSSEStream(
+      streamResponse(launchBlob + resultBlob),
+      { onResult } as StreamCallbacks,
+    );
+    expect(onResult).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/api/utils/sseStream.ts
+++ b/frontend/src/api/utils/sseStream.ts
@@ -42,6 +42,11 @@ export async function consumeSSEStream(
             case 'result':      callbacks.onResult?.(data);     break
             case 'complete':    callbacks.onComplete?.(data);   break
             case 'error':       callbacks.onError?.(data);      break
+            // #496 — launch_flow lets the buddy hand off control to a
+            // matching standalone experience page. Older SPAs that don't
+            // register onLaunchFlow simply ignore the event and fall back
+            // to the regular `result` text reply.
+            case 'launch_flow': callbacks.onLaunchFlow?.(data); break
           }
           eventType = null
         }

--- a/frontend/src/hooks/useLaunchFlowNavigation.ts
+++ b/frontend/src/hooks/useLaunchFlowNavigation.ts
@@ -1,0 +1,103 @@
+/**
+ * useLaunchFlowNavigation — React glue for the My Agent `launch_flow`
+ * SSE event (#496).
+ *
+ * The proxy emits `launch_flow` whenever a specialist tool returns a
+ * typed payload (image_story / interactive_story / kids_daily). The
+ * SPA consumes that event to hop the user from the buddy chat into the
+ * matching standalone experience page, with prefill query params.
+ *
+ * Why a hook (not a service-side redirect):
+ *   - Tests can pin navigation behavior without spinning up the SDK or
+ *     a real router.
+ *   - Page-level state (toast / animation) needs to run alongside the
+ *     navigate call.
+ *   - Navigation policy ("nav now" vs "wait for complete") is owned by
+ *     the page, not the API layer.
+ *
+ * Returned shape:
+ *   {
+ *     onLaunchFlow,           // Plug into `StreamCallbacks.onLaunchFlow`
+ *     pendingLaunchFlow,      // The most recent event captured this turn
+ *     navigateToPendingFlow,  // Trigger the deferred navigate after
+ *                              // `complete` / first paint
+ *     resetPendingFlow,       // Drop the pending event (e.g. on abort)
+ *   }
+ *
+ * Trade-off: we *capture* the event during the stream and *navigate*
+ * after the caller signals it's safe to leave the chat surface. This
+ * costs one bit of state but avoids whisking the user away before the
+ * trailing `result` message is rendered (PRD §3.11 favours legible
+ * feedback over speed for child users).
+ */
+import { useCallback, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import type { SSELaunchFlowData } from "@/types/api";
+
+/**
+ * Build a navigable path from a `launch_flow` payload. Exported as a
+ * pure function so contract tests can pin the URL shape without
+ * spinning up React Router.
+ */
+export function buildLaunchFlowPath(data: SSELaunchFlowData): string {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(data.prefill ?? {})) {
+    if (value === null || value === undefined) continue;
+    params.append(key, String(value));
+  }
+  const qs = params.toString();
+  return qs ? `${data.route}?${qs}` : data.route;
+}
+
+export interface UseLaunchFlowNavigationResult {
+  /** Pass this as `StreamCallbacks.onLaunchFlow`. */
+  onLaunchFlow: (data: SSELaunchFlowData) => void;
+  /** The launch_flow event captured this turn, or null. */
+  pendingLaunchFlow: SSELaunchFlowData | null;
+  /**
+   * Navigate to whatever launch_flow event was captured this turn.
+   * Returns the path navigated to, or null if nothing pending. Safe
+   * to call from `onComplete` — clears state on success.
+   */
+  navigateToPendingFlow: () => string | null;
+  /** Clear the pending event without navigating (e.g. user aborted). */
+  resetPendingFlow: () => void;
+}
+
+export function useLaunchFlowNavigation(): UseLaunchFlowNavigationResult {
+  const navigate = useNavigate();
+  const [pendingLaunchFlow, setPendingLaunchFlow] =
+    useState<SSELaunchFlowData | null>(null);
+  // Ref mirrors state so navigateToPendingFlow() reads the latest
+  // value even when called synchronously from the same render cycle
+  // that set it (e.g. onComplete fires immediately after onLaunchFlow
+  // when the stream closes fast in tests).
+  const pendingRef = useRef<SSELaunchFlowData | null>(null);
+
+  const onLaunchFlow = useCallback((data: SSELaunchFlowData) => {
+    pendingRef.current = data;
+    setPendingLaunchFlow(data);
+  }, []);
+
+  const resetPendingFlow = useCallback(() => {
+    pendingRef.current = null;
+    setPendingLaunchFlow(null);
+  }, []);
+
+  const navigateToPendingFlow = useCallback((): string | null => {
+    const data = pendingRef.current;
+    if (!data) return null;
+    const path = buildLaunchFlowPath(data);
+    pendingRef.current = null;
+    setPendingLaunchFlow(null);
+    navigate(path);
+    return path;
+  }, [navigate]);
+
+  return {
+    onLaunchFlow,
+    pendingLaunchFlow,
+    navigateToPendingFlow,
+    resetPendingFlow,
+  };
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -466,7 +466,8 @@ export type SSEEventType =
   | "session"
   | "result"
   | "complete"
-  | "error";
+  | "error"
+  | "launch_flow";
 
 // SSE event data
 export interface SSEStatusData {
@@ -500,6 +501,24 @@ export interface SSEErrorData {
   message: string;
 }
 
+/**
+ * SSE `launch_flow` payload — emitted by the My Agent proxy (#496) when
+ * a specialist tool returns a typed result. The frontend uses this to
+ * navigate to the matching standalone experience page (`/story/:id`,
+ * `/interactive-story/:session_id`, `/kids-daily/:episode_id`, etc.)
+ * with prefill values applied as query params.
+ *
+ * `route` is server-validated and always resolves to a known landing or
+ * detail route — the SPA should NOT compose its own route from
+ * `flow_type` because the proxy may also fall back to a landing route
+ * when no resource ID is available yet.
+ */
+export interface SSELaunchFlowData {
+  flow_type: "image_story" | "interactive_story" | "kids_daily";
+  route: string;
+  prefill: Record<string, string | number | boolean | null>;
+}
+
 // Stream callback types
 export interface StreamCallbacks {
   onStatus?: (data: SSEStatusData) => void;
@@ -511,4 +530,5 @@ export interface StreamCallbacks {
   onResult?: (data: any) => void;
   onComplete?: (data: SSEStatusData) => void;
   onError?: (data: SSEErrorData) => void;
+  onLaunchFlow?: (data: SSELaunchFlowData) => void;
 }


### PR DESCRIPTION
Fixes #496
Parent Epic: #436

## Stacking

This PR stacks on **PR #501** (`feat/495-land-my-agent-proxy`) and must merge **AFTER** #501. The base branch is intentionally `feat/495-land-my-agent-proxy`, not `main`.

## Summary

- Backend: My Agent proxy now emits a typed `launch_flow` SSE event when a specialist tool (image-to-story / interactive-story / kids-daily) returns a structured result. Event is emitted BEFORE the existing `result` event so the SPA can prepare to navigate while the chat reply is still streaming.
- Frontend: new `useLaunchFlowNavigation` hook + `buildLaunchFlowPath` helper + `onLaunchFlow` callback on the shared SSE stream. The hook stays router-agnostic at the service layer and only navigates from the React layer, so it's unit-testable without spinning up React Router in the SSE dispatcher.

## What changed

Backend (`backend/src/agents/my_agent_proxy.py`):
- `_LAUNCH_FLOW_REGISTRY` — server-side whitelist of allowed `response_type` -> route mapping. Unknown types are silently rejected.
- `_LAUNCH_FLOW_PREFILL_KEYS` — bounded set of payload fields safe to forward as query params (no leaking large/sensitive specialist output through the URL).
- `_build_launch_flow_data()` — pure helper turning a parsed tool result into the SSE payload (or `None`).
- SSE loop emits the event from inside the `ToolResultBlock` branch so it fires the moment the specialist returns, independent of any downstream reply-text safety gate.

Frontend:
- `frontend/src/types/api.ts` — added `launch_flow` to `SSEEventType`, new `SSELaunchFlowData` interface, new `onLaunchFlow` callback on `StreamCallbacks`.
- `frontend/src/api/utils/sseStream.ts` — dispatcher routes the new event; missing callback is a no-op (older SPAs degrade to the regular `result` text reply).
- `frontend/src/hooks/useLaunchFlowNavigation.ts` — new hook capturing the latest launch_flow event during streaming and exposing `navigateToPendingFlow()` so the page-level chat consumer can call it after the trailing `complete` event.

Tests:
- Backend: 6 new contract tests in `backend/tests/contracts/test_my_agent_proxy.py::TestLaunchFlowEvent`.
- Frontend: 6 new tests in `frontend/src/__tests__/hooks/useLaunchFlowNavigation.test.ts` covering `buildLaunchFlowPath` and the SSE dispatcher's new case.

## Note on scope

The actual MyAgentPage chat-surface UI lives in a sibling PR (it's WIP in a parallel session, layered on top of #501). This PR intentionally ships the SSE contract + the navigation hook so that work can plug in by simply registering `onLaunchFlow: hook.onLaunchFlow` and calling `hook.navigateToPendingFlow()` from `onComplete`. The hook is fully unit-tested without depending on the chat page.

## Test plan

- [x] `cd backend && pytest tests/contracts/test_my_agent_proxy.py -v` -> 22/22 pass (16 existing + 6 new launch_flow tests)
- [x] `cd frontend && npm test` -> 92/92 pass (86 existing + 6 new launch_flow tests)
- [x] `cd frontend && npm run build` -> TS clean, vite build succeeds
- [ ] Manual: once the chat-surface PR lands on top of this, ask the buddy "make a story from my drawing" and confirm the SPA hops to `/story/<id>` (or `/upload` when no story_id) with prefill query params applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)