### PR TITLE
feat(frontend): add global ErrorBoundary to prevent white-screen crashes

### DIFF
--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,92 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+import Button from './Button'
+import Card, { CardTitle, CardContent, CardFooter } from './Card'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  /** Optional override for the reload action — primarily used in tests. */
+  onReload?: () => void
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * Global ErrorBoundary.
+ *
+ * React error boundaries MUST be class components because the
+ * `getDerivedStateFromError` and `componentDidCatch` lifecycle hooks
+ * have no functional-component equivalent. Wrapping `<App />` at the
+ * top of `main.tsx` ensures any uncaught render-phase error in the
+ * tree falls back to a kid-friendly screen instead of a blank page.
+ *
+ * Scope (per issue #426):
+ *  - Catch render-phase errors anywhere in the tree
+ *  - Show warm, encouraging copy (no scary tech jargon)
+ *  - Offer a "Try Again" button that reloads the page
+ *  - Log the error to console so developers can debug
+ *
+ * Out of scope:
+ *  - Sentry / remote error reporting
+ *  - Recovering from async errors thrown outside React render
+ */
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    // Update state so the next render shows the fallback UI.
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // Log so developers can debug. No remote reporting (out of scope).
+    // eslint-disable-next-line no-console
+    console.error('ErrorBoundary caught an error:', error, errorInfo)
+  }
+
+  handleReload = (): void => {
+    if (this.props.onReload) {
+      this.props.onReload()
+      return
+    }
+    if (typeof window !== 'undefined') {
+      window.location.reload()
+    }
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children
+    }
+
+    return (
+      <div
+        role="alert"
+        className="min-h-screen flex items-center justify-center p-6 bg-gradient-to-br from-primary/5 to-accent/10"
+      >
+        <Card variant="elevated" padding="lg" hover={false} className="max-w-md w-full text-center">
+          <div className="text-6xl mb-4" aria-hidden="true">
+            🎨
+          </div>
+          <CardTitle className="text-2xl">Oops! Something went wrong</CardTitle>
+          <CardContent className="mt-3 text-base">
+            <p>Don&apos;t worry — these things happen sometimes.</p>
+            <p className="mt-2">Let&apos;s try that again together!</p>
+          </CardContent>
+          <CardFooter className="flex justify-center">
+            <Button variant="primary" size="lg" onClick={this.handleReload}>
+              Try Again
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    )
+  }
+}
+
+export default ErrorBoundary

--- a/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { ErrorInfo } from 'react'
+import ErrorBoundary from '../ErrorBoundary'
+
+/**
+ * Logic-only tests for the global ErrorBoundary.
+ *
+ * The project does not ship @testing-library/react, so instead of rendering
+ * we exercise the class lifecycle directly. This is sufficient because the
+ * behavior contract is encoded in `getDerivedStateFromError` (state
+ * transition) and `componentDidCatch` (logging side effect) — neither
+ * requires a DOM to verify.
+ */
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it('initializes with hasError=false and no error', () => {
+    // Construct without rendering: state defaults are the contract.
+    const instance = new ErrorBoundary({ children: null })
+    expect(instance.state.hasError).toBe(false)
+    expect(instance.state.error).toBeNull()
+  })
+
+  it('getDerivedStateFromError flips hasError=true and stores the error', () => {
+    const boom = new Error('kaboom')
+    const next = ErrorBoundary.getDerivedStateFromError(boom)
+    expect(next).toEqual({ hasError: true, error: boom })
+  })
+
+  it('componentDidCatch logs the error and errorInfo to console.error', () => {
+    const instance = new ErrorBoundary({ children: null })
+    const err = new Error('render exploded')
+    const info: ErrorInfo = { componentStack: '\n  in Component' }
+
+    instance.componentDidCatch(err, info)
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'ErrorBoundary caught an error:',
+      err,
+      info,
+    )
+  })
+
+  it('handleReload invokes the onReload override when provided', () => {
+    const onReload = vi.fn()
+    const instance = new ErrorBoundary({ children: null, onReload })
+    instance.handleReload()
+    expect(onReload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from './providers/AuthProvider'
 import { StreamVisualizationProvider } from './providers/StreamVisualizationProvider'
+import ErrorBoundary from './components/common/ErrorBoundary'
 import App from './App'
 import './styles/globals.css'
 
@@ -19,14 +20,16 @@ const queryClient = new QueryClient({
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <StreamVisualizationProvider>
-          <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
-            <App />
-          </BrowserRouter>
-        </StreamVisualizationProvider>
-      </AuthProvider>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <StreamVisualizationProvider>
+            <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+              <App />
+            </BrowserRouter>
+          </StreamVisualizationProvider>
+        </AuthProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Summary
- Adds a top-level React `ErrorBoundary` class component at `frontend/src/components/common/ErrorBoundary.tsx` with a kid-friendly fallback (emoji + "Oops! Something went wrong" + "Try Again" reload button) built on the existing `Card` / `Button` primitives.
- Wraps `<App />` in `frontend/src/main.tsx` so the boundary catches render-phase errors anywhere in the route tree — including inside `App` itself — instead of falling through to a blank white screen.
- Logs `error` and `errorInfo` via `console.error` in `componentDidCatch` for local debugging. Remote reporting (Sentry etc.) is intentionally out of scope.

## Test plan
- [x] `npx vitest run src/components/common/__tests__/ErrorBoundary.test.tsx` — 4 logic-only tests passing (initial state, `getDerivedStateFromError` transition, `componentDidCatch` logs, reload handler).
- [x] `npx vitest run` — full frontend suite green (90/90).
- [x] `npx tsc --noEmit` — no type errors.
- [ ] Manual smoke: temporarily throw inside a page component, confirm fallback renders and "Try Again" reloads the app.

Fixes #426
Related to #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)