### PR TITLE
feat(frontend): add responsive mobile hamburger navbar

### DIFF
--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Outlet, Link, useLocation, useNavigate } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import { shouldRedirectToOnboarding } from './requireOnboarded'
+import { closeMenu, toggleMenu } from './mobileMenu'
 import { AnimatedBackground } from '@/components/depth/AnimatedBackground'
 import { ConfettiController } from '@/components/effects/Confetti'
 import GenerationStatusBar from '@/components/layout/GenerationStatusBar'
@@ -27,6 +28,7 @@ function PageContainerInner() {
   const { isAuthenticated, user } = useAuthStore()
   const { setProfileAvatarEl } = useNavRef()
   const totalStars = useDailyTaskStore((s) => s.totalStars)
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   useGenerationNavigator()
 
@@ -55,6 +57,12 @@ function PageContainerInner() {
     navigate,
   ])
 
+  // Auto-close the mobile drawer on route change so navigation never leaves
+  // the menu open over fresh page content.
+  useEffect(() => {
+    setMobileOpen(closeMenu())
+  }, [location.pathname])
+
   const handleLogout = async () => {
     try {
       await authService.logout()
@@ -64,6 +72,9 @@ function PageContainerInner() {
     performFullLogout()
     navigate('/')
   }
+
+  const handleCloseMobile = () => setMobileOpen(closeMenu())
+  const handleToggleMobile = () => setMobileOpen((prev) => toggleMenu(prev))
 
   return (
     <div className="min-h-screen gradient-bg relative">
@@ -90,8 +101,8 @@ function PageContainerInner() {
               </span>
             </Link>
 
-            {/* Navigation links */}
-            <div className="flex items-center gap-4">
+            {/* Desktop navigation links — unchanged on >= 768px */}
+            <div className="hidden md:flex items-center gap-4">
               <NavLink to="/library" icon="📚" label="My Library" />
               <NavLink to="/my-agent" icon="🤖" label="My Agent" />
               <NavLink to="/content-hub" icon="🌐" label="Content Hub" />
@@ -140,9 +151,167 @@ function PageContainerInner() {
                 </Link>
               )}
             </div>
+
+            {/* Mobile hamburger button — visible on < 768px */}
+            <button
+              type="button"
+              onClick={handleToggleMobile}
+              aria-label={mobileOpen ? 'Close navigation menu' : 'Open navigation menu'}
+              aria-expanded={mobileOpen}
+              aria-controls="mobile-nav-drawer"
+              className="md:hidden inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-btn text-gray-700 hover:bg-gray-100 transition-colors"
+            >
+              {/* Hamburger / close icon (SVG, no new deps) */}
+              <svg
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                {mobileOpen ? (
+                  <>
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </>
+                ) : (
+                  <>
+                    <line x1="3" y1="6" x2="21" y2="6" />
+                    <line x1="3" y1="12" x2="21" y2="12" />
+                    <line x1="3" y1="18" x2="21" y2="18" />
+                  </>
+                )}
+              </svg>
+            </button>
           </div>
         </div>
       </nav>
+
+      {/* Mobile slide-out drawer + backdrop (only mounts when open) */}
+      <AnimatePresence>
+        {mobileOpen && (
+          <div className="md:hidden fixed inset-0 z-50">
+            {/* Backdrop: tap to close */}
+            <motion.div
+              className="absolute inset-0 bg-black/40"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              onClick={handleCloseMobile}
+              aria-hidden="true"
+            />
+
+            {/* Drawer panel */}
+            <motion.div
+              id="mobile-nav-drawer"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Mobile navigation"
+              className="absolute inset-y-0 right-0 w-72 max-w-[85vw] bg-white shadow-xl flex flex-col"
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ type: 'tween', duration: 0.25 }}
+            >
+              {/* Drawer header with close button */}
+              <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+                <span className="text-lg font-bold text-gradient">Menu</span>
+                <button
+                  type="button"
+                  onClick={handleCloseMobile}
+                  aria-label="Close navigation menu"
+                  className="inline-flex items-center justify-center min-h-[44px] min-w-[44px] rounded-btn text-gray-700 hover:bg-gray-100 transition-colors"
+                >
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    aria-hidden="true"
+                  >
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
+                  </svg>
+                </button>
+              </div>
+
+              {/* Drawer nav links */}
+              <div className="flex-1 overflow-y-auto px-3 py-4 flex flex-col gap-1">
+                <MobileNavLink
+                  to="/library"
+                  icon="📚"
+                  label="My Library"
+                  onNavigate={handleCloseMobile}
+                />
+                <MobileNavLink
+                  to="/my-agent"
+                  icon="🤖"
+                  label="My Agent"
+                  onNavigate={handleCloseMobile}
+                />
+                <MobileNavLink
+                  to="/content-hub"
+                  icon="🌐"
+                  label="Content Hub"
+                  onNavigate={handleCloseMobile}
+                />
+              </div>
+
+              {/* Drawer footer: auth */}
+              <div className="border-t border-gray-200 px-3 py-4">
+                {isAuthenticated ? (
+                  <div className="flex flex-col gap-2">
+                    <Link
+                      to="/profile"
+                      onClick={handleCloseMobile}
+                      className="flex items-center gap-3 px-3 py-3 rounded-btn min-h-[44px] text-gray-700 hover:bg-gray-100 transition-colors"
+                    >
+                      <AvatarDisplay avatarUrl={user?.avatar_url} size="sm" />
+                      <span className="text-sm font-medium">
+                        {user?.display_name || user?.username || 'Profile'}
+                      </span>
+                      {totalStars > 0 && (
+                        <span className="ml-auto min-w-[20px] h-[20px] flex items-center justify-center text-[11px] font-bold text-white bg-gradient-to-r from-yellow-400 to-orange-400 rounded-full px-1.5">
+                          {totalStars > 99 ? '99+' : totalStars}
+                        </span>
+                      )}
+                    </Link>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        handleCloseMobile()
+                        handleLogout()
+                      }}
+                      className="flex items-center gap-3 px-3 py-3 rounded-btn min-h-[44px] text-gray-500 hover:bg-gray-100 hover:text-red-500 transition-colors text-left"
+                    >
+                      <span aria-hidden="true">🚪</span>
+                      <span className="text-sm font-medium">Sign Out</span>
+                    </button>
+                  </div>
+                ) : (
+                  <Link
+                    to="/login"
+                    onClick={handleCloseMobile}
+                    className="flex items-center justify-center gap-2 min-h-[44px] px-4 py-3 rounded-btn font-medium bg-secondary text-white shadow-button"
+                  >
+                    <span aria-hidden="true">👤</span>
+                    <span>Sign In</span>
+                  </Link>
+                )}
+              </div>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
 
       {/* Generation progress bar (visible when generating on other pages) */}
       <GenerationStatusBar />
@@ -218,6 +387,39 @@ function NavLink({
         <span>{icon}</span>
         <span>{label}</span>
       </motion.div>
+    </Link>
+  )
+}
+
+function MobileNavLink({
+  to,
+  icon,
+  label,
+  onNavigate,
+}: {
+  to: string
+  icon: string
+  label: string
+  onNavigate: () => void
+}) {
+  const location = useLocation()
+  const isActive = location.pathname === to
+
+  return (
+    <Link
+      to={to}
+      onClick={onNavigate}
+      className={`flex items-center gap-3 px-4 py-3 rounded-btn font-medium min-h-[44px]
+        ${
+          isActive
+            ? 'bg-primary text-white shadow-button'
+            : 'text-gray-700 hover:bg-gray-100'
+        }`}
+    >
+      <span aria-hidden="true" className="text-xl">
+        {icon}
+      </span>
+      <span>{label}</span>
     </Link>
   )
 }

--- a/frontend/src/components/layout/PageContainer/mobileMenu.test.ts
+++ b/frontend/src/components/layout/PageContainer/mobileMenu.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { closeMenu, openMenu, toggleMenu } from "./mobileMenu";
+
+/**
+ * The mobile hamburger drawer (issue #427) hides itself on link clicks
+ * and backdrop taps. Both paths funnel through `closeMenu`, the hamburger
+ * button calls `toggleMenu`, and any future "force open" callsite uses
+ * `openMenu`. Lock these contracts so a refactor can't quietly invert
+ * the drawer (which would trap mobile users on a partially-opened nav).
+ */
+describe("mobileMenu state transitions", () => {
+  it("openMenu always returns true", () => {
+    expect(openMenu()).toBe(true);
+  });
+
+  it("closeMenu always returns false (used by link click + backdrop tap)", () => {
+    expect(closeMenu()).toBe(false);
+  });
+
+  it("toggleMenu flips false -> true (hamburger button: closed -> open)", () => {
+    expect(toggleMenu(false)).toBe(true);
+  });
+
+  it("toggleMenu flips true -> false (hamburger button: open -> closed)", () => {
+    expect(toggleMenu(true)).toBe(false);
+  });
+
+  it("toggleMenu twice is identity (idempotent double-tap)", () => {
+    expect(toggleMenu(toggleMenu(false))).toBe(false);
+    expect(toggleMenu(toggleMenu(true))).toBe(true);
+  });
+});

--- a/frontend/src/components/layout/PageContainer/mobileMenu.ts
+++ b/frontend/src/components/layout/PageContainer/mobileMenu.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure state transitions for the responsive mobile navbar drawer.
+ *
+ * The drawer is only visible on viewports < 768px (Tailwind's `md` breakpoint).
+ * Keeping the transitions as plain functions lets us unit-test the contract
+ * without needing @testing-library/react. The component (PageContainer)
+ * stores `open` in useState and applies these helpers in event handlers.
+ *
+ * Invariants (locked by tests):
+ *   - openMenu()  -> always returns true
+ *   - closeMenu() -> always returns false
+ *   - toggleMenu(prev) -> returns !prev
+ *
+ * If a future change accidentally inverts toggle semantics or breaks the
+ * close-on-link-click behaviour, the tests should flip red before users do.
+ */
+export type MobileMenuState = boolean
+
+export const openMenu = (): MobileMenuState => true
+export const closeMenu = (): MobileMenuState => false
+export const toggleMenu = (prev: MobileMenuState): MobileMenuState => !prev


### PR DESCRIPTION
## Summary

- Adds a hamburger button shown only on screens `< 768px` (Tailwind `md:hidden`) and a right-anchored slide-in drawer containing the same nav links (My Library, My Agent, Content Hub) plus the auth section. Desktop (`>= 768px`) layout is literally unchanged.
- Drawer closes on link click, backdrop tap, the close (X) button, and on every route change. All tap targets meet `min-h-[44px] min-w-[44px]`. Uses an inline SVG hamburger icon (no new deps) and the existing `framer-motion` for slide animation.
- Extracts pure state transitions (`openMenu` / `closeMenu` / `toggleMenu`) to `mobileMenu.ts` so the open/close contract is unit-testable without `@testing-library/react`.

## Test plan

- [x] `npx vitest run src/components/layout/PageContainer` — 13 tests pass (5 new mobile-menu contract tests + existing onboarding gate tests)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: on a phone-width viewport (< 768px) verify the hamburger appears, tapping opens the drawer, tapping a link / backdrop / close button dismisses it, and route changes auto-close
- [ ] Manual: on desktop (>= 768px) verify the horizontal nav is unchanged — same links, same spacing, same hover states
- [ ] Manual: verify touch targets are >= 44x44px using browser devtools

## Acceptance criteria (issue #427)

- [x] Desktop (>= 768px): full horizontal nav with all links visible — unchanged
- [x] Mobile (< 768px): hamburger icon, tap opens menu overlay
- [x] Menu closes on link click or backdrop tap
- [x] Touch targets >= 44x44px for all interactive elements

Fixes #427
Related to #313

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>