### PR TITLE
feat(library): add parent creativity dashboard

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -1292,10 +1292,33 @@ class RichStatsPeriod(BaseModel):
     story_type_breakdown: Dict[str, int] = Field(default_factory=dict, description="Count per story type")
 
 
+class ParentDashboardTheme(BaseModel):
+    """Parent dashboard theme summary without child/user identifiers (#532)."""
+    theme: str = Field(..., description="Theme label")
+    count: int = Field(..., description="Number of safe creations using this theme")
+
+
+class ParentDashboardRecentCreation(BaseModel):
+    """Parent-safe recent creation summary (#532)."""
+    id: str = Field(..., description="Creation identifier")
+    type: str = Field(..., description="Library content type")
+    title: str = Field(..., description="Display title")
+    created_at: str = Field(..., description="Creation timestamp")
+    thumbnail_url: Optional[str] = Field(None, description="Optional thumbnail URL")
+
+
 class RichStatsResponse(BaseModel):
     """Rich growth dashboard stats (#356)."""
     periods: List[RichStatsPeriod] = Field(..., description="Per-period growth metrics")
     streak_days: int = Field(0, description="Deprecated compatibility field; always 0")
+    top_themes: List[ParentDashboardTheme] = Field(
+        default_factory=list,
+        description="Parent dashboard safe theme summary",
+    )
+    recent_creations: List[ParentDashboardRecentCreation] = Field(
+        default_factory=list,
+        description="Parent dashboard recent safe creations",
+    )
 
 
 class PaginatedNewsResponse(BaseModel):

--- a/backend/src/api/routes/library.py
+++ b/backend/src/api/routes/library.py
@@ -14,7 +14,12 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from ...paths import AUDIO_DIR
-from ...services.database import favorite_repo, session_repo, story_repo
+from ...services.database import (
+    child_profile_repo,
+    favorite_repo,
+    session_repo,
+    story_repo,
+)
 from ...services.database.artifact_repository import StoryArtifactLinkRepository
 from ...services.database.connection import db_manager
 from ...services.database.sql_compat import date_format_sql
@@ -32,6 +37,8 @@ from ..models import (
     LibraryStatsGroupBy,
     LibraryStatsPeriod,
     LibraryStatsResponse,
+    ParentDashboardRecentCreation,
+    ParentDashboardTheme,
     RichStatsPeriod,
     RichStatsResponse,
 )
@@ -256,6 +263,10 @@ async def _ensure_owned_child_scope(user: UserData, child_id: Optional[str]) -> 
     if not child_id:
         return
 
+    profile = await child_profile_repo.get_for_user(user.user_id, child_id)
+    if profile is not None:
+        return
+
     if getattr(user, "default_child_id", None) == child_id:
         return
 
@@ -275,6 +286,114 @@ async def _ensure_owned_child_scope(user: UserData, child_id: Optional[str]) -> 
         status_code=status.HTTP_404_NOT_FOUND,
         detail="Child profile not found",
     )
+
+
+def _parse_theme_list(value) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, list):
+                return [
+                    str(item).strip()
+                    for item in parsed
+                    if str(item).strip()
+                ]
+        except (json.JSONDecodeError, ValueError, TypeError):
+            return [part.strip() for part in value.split(",") if part.strip()]
+    return []
+
+
+async def _get_parent_dashboard_themes(
+    user_id: str,
+    child_id: Optional[str],
+) -> list[ParentDashboardTheme]:
+    child_filter = " AND child_id = ?" if child_id else ""
+    rows = await db_manager.fetchall(
+        f"""
+        SELECT themes
+        FROM stories
+        WHERE user_id = ?
+          AND (safety_score IS NULL OR safety_score >= ?)
+          {child_filter}
+        """,
+        (user_id, SAFETY_THRESHOLD, child_id) if child_id else (user_id, SAFETY_THRESHOLD),
+    )
+
+    counts: dict[str, int] = {}
+    for row in rows:
+        for theme in _parse_theme_list(row.get("themes")):
+            counts[theme] = counts.get(theme, 0) + 1
+
+    return [
+        ParentDashboardTheme(theme=theme, count=count)
+        for theme, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:5]
+    ]
+
+
+async def _get_parent_dashboard_recent_creations(
+    user_id: str,
+    child_id: Optional[str],
+) -> list[ParentDashboardRecentCreation]:
+    child_filter = " AND child_id = ?" if child_id else ""
+    story_params = (
+        (user_id, SAFETY_THRESHOLD, child_id)
+        if child_id
+        else (user_id, SAFETY_THRESHOLD)
+    )
+    story_rows = await db_manager.fetchall(
+        f"""
+        SELECT story_id, story_text, story_type, image_url, created_at
+        FROM stories
+        WHERE user_id = ?
+          AND (safety_score IS NULL OR safety_score >= ?)
+          {child_filter}
+        ORDER BY created_at DESC
+        LIMIT 5
+        """,
+        story_params,
+    )
+
+    session_params = (user_id, child_id) if child_id else (user_id,)
+    session_rows = await db_manager.fetchall(
+        f"""
+        SELECT session_id, story_title, created_at
+        FROM sessions
+        WHERE user_id = ?{child_filter}
+        ORDER BY created_at DESC
+        LIMIT 5
+        """,
+        session_params,
+    )
+
+    items: list[ParentDashboardRecentCreation] = []
+    for row in story_rows:
+        story_type = row.get("story_type") or "image_to_story"
+        items.append(
+            ParentDashboardRecentCreation(
+                id=row["story_id"],
+                type=_resolve_story_type({"story_type": story_type}).value,
+                title=_extract_title(row.get("story_text") or ""),
+                created_at=row["created_at"],
+                thumbnail_url=row.get("image_url"),
+            )
+        )
+    for row in session_rows:
+        items.append(
+            ParentDashboardRecentCreation(
+                id=row["session_id"],
+                type=LibraryItemType.INTERACTIVE.value,
+                title=row.get("story_title") or "Interactive Story",
+                created_at=row["created_at"],
+                thumbnail_url=None,
+            )
+        )
+
+    items.sort(key=lambda item: item.created_at, reverse=True)
+    return items[:5]
 
 
 # ============================================================================
@@ -500,7 +619,6 @@ async def get_rich_stats(
     fmt = "%Y-%m" if group_by == LibraryStatsGroupBy.MONTH else "%Y-W%W"
     period_expr = date_format_sql("created_at", fmt, db_manager.dialect)
     child_filter = " AND child_id = ?" if child_id else ""
-    story_params = (user.user_id, child_id) if child_id else (user.user_id,)
     session_params = (user.user_id, child_id) if child_id else (user.user_id,)
 
     # 1) Stories: count, word_count sum, themes, story_type per period
@@ -512,10 +630,17 @@ async def get_rich_stats(
             GROUP_CONCAT(themes, '||') AS all_themes,
             GROUP_CONCAT(story_type, '||') AS all_types
         FROM stories
-        WHERE user_id = ?{child_filter}
+        WHERE user_id = ?
+          AND (safety_score IS NULL OR safety_score >= ?)
+          {child_filter}
         GROUP BY period
         ORDER BY period
     """
+    story_params = (
+        (user.user_id, SAFETY_THRESHOLD, child_id)
+        if child_id
+        else (user.user_id, SAFETY_THRESHOLD)
+    )
     story_rows = await db_manager.fetchall(stories_query, story_params)
 
     # 2) Sessions: count, completed count per period
@@ -605,7 +730,21 @@ async def get_rich_stats(
         )
 
     sorted_periods = sorted(all_periods.values(), key=lambda x: x.period)
-    return RichStatsResponse(periods=sorted_periods, streak_days=0)
+    top_themes: list[ParentDashboardTheme] = []
+    recent_creations: list[ParentDashboardRecentCreation] = []
+    if parent_dashboard:
+        top_themes = await _get_parent_dashboard_themes(user.user_id, child_id)
+        recent_creations = await _get_parent_dashboard_recent_creations(
+            user.user_id,
+            child_id,
+        )
+
+    return RichStatsResponse(
+        periods=sorted_periods,
+        streak_days=0,
+        top_themes=top_themes,
+        recent_creations=recent_creations,
+    )
 
 
 # ============================================================================

--- a/backend/tests/api/test_library_stats.py
+++ b/backend/tests/api/test_library_stats.py
@@ -11,7 +11,12 @@ from datetime import datetime, timedelta
 
 from backend.src.api.deps import get_current_user
 from backend.src.main import app
-from backend.src.services.database import story_repo, session_repo, db_manager
+from backend.src.services.database import (
+    child_profile_repo,
+    story_repo,
+    session_repo,
+    db_manager,
+)
 from backend.src.services.database.schema import init_schema
 from backend.src.services.database.user_repository import UserData
 
@@ -329,12 +334,25 @@ class TestRichStatsParentDashboardAccess:
             ),
         )
         await db_manager.commit()
+        await db_manager.execute(
+            "DELETE FROM child_profiles WHERE user_id = ? AND child_id IN (?, ?, ?)",
+            (self.parent_user_id, "child_alpha", "child_beta", "child_empty"),
+        )
+        await db_manager.commit()
 
         self.story_ids = []
         for user_id, child_id, label in [
             (self.parent_user_id, "child_alpha", "alpha"),
             (self.parent_user_id, "child_beta", "beta"),
         ]:
+            await child_profile_repo.create(
+                user_id=user_id,
+                child_id=child_id,
+                name=label.title(),
+                age_group="9-12",
+                interests=[],
+                is_default=child_id == "child_alpha",
+            )
             sid = f"parent-rich-{label}-{uuid.uuid4().hex[:8]}"
             self.story_ids.append(sid)
             await story_repo.create(
@@ -355,6 +373,34 @@ class TestRichStatsParentDashboardAccess:
                 }
             )
 
+        await child_profile_repo.create(
+            user_id=self.parent_user_id,
+            child_id="child_empty",
+            name="Empty",
+            age_group="6-8",
+            interests=[],
+        )
+
+        unsafe_id = f"parent-rich-unsafe-{uuid.uuid4().hex[:8]}"
+        self.story_ids.append(unsafe_id)
+        await story_repo.create(
+            {
+                "story_id": unsafe_id,
+                "user_id": self.parent_user_id,
+                "child_id": "child_alpha",
+                "age_group": "9-12",
+                "story": {
+                    "text": "Unsafe dashboard fixture should stay hidden.",
+                    "word_count": 6,
+                },
+                "educational_value": {"themes": ["unsafe"]},
+                "characters": [],
+                "safety_score": 0.4,
+                "story_type": "image_to_story",
+                "created_at": now,
+            }
+        )
+
         yield
 
         if self.previous_override is None:
@@ -363,6 +409,15 @@ class TestRichStatsParentDashboardAccess:
             app.dependency_overrides[get_current_user] = self.previous_override
         for sid in self.story_ids:
             await db_manager.execute("DELETE FROM stories WHERE story_id = ?", (sid,))
+        for child_id in ("child_alpha", "child_beta", "child_empty"):
+            await db_manager.execute(
+                "DELETE FROM child_profiles WHERE user_id = ? AND child_id = ?",
+                (self.parent_user_id, child_id),
+            )
+        await db_manager.execute(
+            "UPDATE users SET default_child_id = NULL WHERE user_id = ?",
+            (self.parent_user_id,),
+        )
         await db_manager.commit()
 
     def _override_user(self, *, role: str = "parent") -> None:
@@ -408,6 +463,9 @@ class TestRichStatsParentDashboardAccess:
         data = resp.json()
         assert sum(p["creation_count"] for p in data["periods"]) == 1
         assert data["streak_days"] == 0
+        assert data["top_themes"] == [{"theme": "alpha", "count": 1}]
+        assert [item["id"] for item in data["recent_creations"]] == [self.story_ids[0]]
+        assert data["recent_creations"][0]["title"].startswith("alpha creativity")
 
     async def test_parent_dashboard_rejects_unowned_child_scope(self, test_client):
         self._override_user(role="parent")
@@ -419,3 +477,18 @@ class TestRichStatsParentDashboardAccess:
             )
 
         assert resp.status_code == 404
+
+    async def test_parent_dashboard_loads_empty_owned_child_profile(self, test_client):
+        self._override_user(role="parent")
+
+        async with test_client as client:
+            resp = await client.get(
+                "/api/v1/library/stats-rich",
+                params={"parent_dashboard": True, "child_id": "child_empty"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["periods"] == []
+        assert data["top_themes"] == []
+        assert data["recent_creations"] == []

--- a/frontend/src/api/services/libraryService.ts
+++ b/frontend/src/api/services/libraryService.ts
@@ -73,9 +73,24 @@ export interface RichStatsPeriod {
   story_type_breakdown: Record<string, number>
 }
 
+export interface ParentDashboardTheme {
+  theme: string
+  count: number
+}
+
+export interface ParentDashboardRecentCreation {
+  id: string
+  type: LibraryItemType
+  title: string
+  created_at: string
+  thumbnail_url?: string | null
+}
+
 export interface RichStatsResponse {
   periods: RichStatsPeriod[]
   streak_days: number
+  top_themes: ParentDashboardTheme[]
+  recent_creations: ParentDashboardRecentCreation[]
 }
 
 export interface RichStatsOptions {

--- a/frontend/src/components/library/GrowthTimeline/index.tsx
+++ b/frontend/src/components/library/GrowthTimeline/index.tsx
@@ -8,9 +8,14 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
-import { TrendingUp } from 'lucide-react'
+import { BookOpen, Sparkles, TrendingUp } from 'lucide-react'
 import { libraryService } from '@/api/services/libraryService'
-import type { StatsGroupBy, RichStatsPeriod } from '@/api/services/libraryService'
+import type {
+  ParentDashboardRecentCreation,
+  ParentDashboardTheme,
+  RichStatsPeriod,
+  StatsGroupBy,
+} from '@/api/services/libraryService'
 import useAuthStore from '@/store/useAuthStore'
 
 // ---- Metric Card ----
@@ -211,6 +216,70 @@ function EmptyState({ isParentDashboard }: { isParentDashboard?: boolean }) {
   )
 }
 
+function ParentThemeList({ themes }: { themes: ParentDashboardTheme[] }) {
+  if (themes.length === 0) return null
+
+  return (
+    <section className="bg-white rounded-2xl border border-gray-100 p-4 shadow-sm">
+      <div className="mb-3 flex items-center gap-2">
+        <Sparkles size={16} className="text-amber-500" />
+        <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+          Favorite Themes
+        </p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {themes.map((theme) => (
+          <span
+            key={theme.theme}
+            className="rounded-full bg-amber-50 px-3 py-1.5 text-sm font-medium text-amber-800"
+          >
+            {theme.theme}
+          </span>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function formatCreationType(type: string): string {
+  if (type === 'art-story') return 'Art Story'
+  if (type === 'interactive') return 'Interactive Story'
+  if (type === 'kids-daily') return 'Kids Daily'
+  if (type === 'kids-news') return 'Kids News'
+  return 'Creation'
+}
+
+function ParentRecentCreations({
+  items,
+}: {
+  items: ParentDashboardRecentCreation[]
+}) {
+  if (items.length === 0) return null
+
+  return (
+    <section className="bg-white rounded-2xl border border-gray-100 p-4 shadow-sm">
+      <div className="mb-3 flex items-center gap-2">
+        <BookOpen size={16} className="text-emerald-500" />
+        <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+          Recent Safe Creations
+        </p>
+      </div>
+      <div className="divide-y divide-gray-100">
+        {items.map((item) => (
+          <div key={`${item.type}-${item.id}`} className="py-2 first:pt-0 last:pb-0">
+            <p className="truncate text-sm font-semibold text-gray-700">
+              {item.title}
+            </p>
+            <p className="mt-0.5 text-xs text-gray-400">
+              {formatCreationType(item.type)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
 // ---- Main Component ----
 
 export default function GrowthTimeline({
@@ -229,6 +298,8 @@ export default function GrowthTimeline({
   })
 
   const periods = data?.periods ?? []
+  const topThemes = data?.top_themes ?? []
+  const recentCreations = data?.recent_creations ?? []
 
   // Aggregate latest period for headline metrics
   const latest = periods.length > 0 ? periods[periods.length - 1] : null
@@ -348,6 +419,13 @@ export default function GrowthTimeline({
             </p>
             <ContentMixBar breakdown={allMix} />
           </div>
+
+          {isParentDashboard && (
+            <>
+              <ParentThemeList themes={topThemes} />
+              <ParentRecentCreations items={recentCreations} />
+            </>
+          )}
         </div>
       )}
     </motion.div>


### PR DESCRIPTION
## Summary
- extend the rich library stats API with parent-safe theme and recent creation summaries
- validate parent dashboard child scopes against parent-owned child profiles, including empty profiles
- render parent dashboard theme chips and recent safe creations in the Library growth view

## Tests
- backend/.venv/bin/python -m pytest backend/tests/api/test_library_stats.py -q
- npm run build
- npm run test -- libraryService.test.ts (fails before tests load: Vitest worker hits html-encoding-sniffer ERR_REQUIRE_ESM)

Parent Epic: #531
Fixes #532