### PR TITLE
feat: productize story video fallback

### DIFF
--- a/backend/src/api/routes/video.py
+++ b/backend/src/api/routes/video.py
@@ -48,6 +48,25 @@ def load_job_from_file(job_id: str) -> Optional[dict]:
     return None
 
 
+async def get_owned_video_job_or_404(job_id: str, user: UserData) -> tuple[dict, dict]:
+    """Load a video job and verify it is bound to a story owned by the user."""
+    job_data = load_job_from_file(job_id)
+    if not job_data or not job_data.get("story_id"):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Video job is not linked to an owned story",
+        )
+
+    story = await get_story_for_owner(job_data["story_id"], user.user_id)
+    return job_data, story
+
+
+async def call_mcp_tool(tool_ref, payload: dict) -> dict:
+    """Invoke either a raw async tool function or an SDK-wrapped MCP tool."""
+    handler = getattr(tool_ref, "handler", tool_ref)
+    return await handler(payload)
+
+
 @router.post(
     "/generate",
     response_model=VideoJobResponse,
@@ -86,7 +105,7 @@ async def generate_video(
 
     # 3. Call video generation tool
     try:
-        result = await generate_painting_video({
+        result = await call_mcp_tool(generate_painting_video, {
             "image_path": image_path,
             "style": request.style.value,
             "duration_seconds": request.duration_seconds,
@@ -128,7 +147,7 @@ async def generate_video(
                 audio_path = str(DATA_DIR / audio_url.removeprefix("/data/"))
 
                 if video_path and Path(audio_path).exists():
-                    combine_result = await combine_video_audio({
+                    combine_result = await call_mcp_tool(combine_video_audio, {
                         "video_path": video_path,
                         "audio_path": audio_path,
                         "output_filename": f"combined_{job_id}.mp4"
@@ -178,12 +197,10 @@ async def get_video_status(
     Check video generation job status (requires authentication + story ownership)
     """
     try:
-        # Verify ownership via the job's story_id
-        job_data_check = load_job_from_file(job_id)
-        if job_data_check and job_data_check.get("story_id"):
-            await get_story_for_owner(job_data_check["story_id"], user.user_id)
+        # Verify ownership before asking the provider or exposing any video URL.
+        job_data_check, owned_story = await get_owned_video_job_or_404(job_id, user)
 
-        result = await check_video_status({"job_id": job_id})
+        result = await call_mcp_tool(check_video_status, {"job_id": job_id})
         result_data = json.loads(result["content"][0]["text"])
 
         if not result_data.get("success"):
@@ -193,7 +210,7 @@ async def get_video_status(
             )
 
         # Load job details to get combined video URL
-        job_data = load_job_from_file(job_id)
+        job_data = load_job_from_file(job_id) or job_data_check
         video_url = result_data.get("video_url")
 
         # Prefer combined video
@@ -211,9 +228,8 @@ async def get_video_status(
         if result_data["status"] == VideoStatus.COMPLETED.value and job_data:
             story_id = job_data.get("story_id")
             if story_id:
-                story = await get_story_for_owner(story_id, user.user_id)
                 await achievement_service.award_event_safely(
-                    user.user_id, story.get("child_id"), FIRST_VIDEO
+                    user.user_id, owned_story.get("child_id"), FIRST_VIDEO
                 )
 
         return VideoJobStatusResponse(
@@ -252,17 +268,7 @@ async def get_video_info(
     """
     Get video metadata (requires authentication + story ownership)
     """
-    job_data = load_job_from_file(video_id)
-
-    if not job_data:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Video not found: {video_id}"
-        )
-
-    # Verify ownership via the job's story_id
-    if job_data.get("story_id"):
-        await get_story_for_owner(job_data["story_id"], user.user_id)
+    job_data, _story = await get_owned_video_job_or_404(video_id, user)
 
     if job_data.get("status") != "completed":
         raise HTTPException(

--- a/backend/src/mcp_servers/video_generator_server.py
+++ b/backend/src/mcp_servers/video_generator_server.py
@@ -454,11 +454,32 @@ async def combine_video_audio(args: Dict[str, Any]) -> Dict[str, Any]:
         }
 
 
+# Expose directly callable async functions for in-process use while preserving
+# the MCP tool objects for agent tool registration.
+_generate_painting_video_tool = generate_painting_video
+_check_video_status_tool = check_video_status
+_combine_video_audio_tool = combine_video_audio
+
+generate_painting_video = getattr(
+    _generate_painting_video_tool, "handler", _generate_painting_video_tool
+)
+check_video_status = getattr(
+    _check_video_status_tool, "handler", _check_video_status_tool
+)
+combine_video_audio = getattr(
+    _combine_video_audio_tool, "handler", _combine_video_audio_tool
+)
+
+
 # Create MCP Server
 video_server = create_sdk_mcp_server(
     name="video-generation",
     version="1.0.0",
-    tools=[generate_painting_video, check_video_status, combine_video_audio]
+    tools=[
+        _generate_painting_video_tool,
+        _check_video_status_tool,
+        _combine_video_audio_tool,
+    ]
 )
 
 

--- a/backend/tests/api/test_video_routes.py
+++ b/backend/tests/api/test_video_routes.py
@@ -1,0 +1,199 @@
+import json
+from datetime import datetime
+
+import pytest
+from fastapi import HTTPException, status
+
+from backend.src.api.models import VideoJobRequest
+from backend.src.api.routes import video
+from backend.src.services.database.user_repository import UserData
+
+
+def _user(user_id: str = "owner") -> UserData:
+    return UserData(
+        user_id=user_id,
+        username=user_id,
+        email=f"{user_id}@example.com",
+        password_hash="hash",
+        is_active=True,
+        is_verified=True,
+        created_at="",
+        updated_at="",
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_video_checks_story_owner_before_provider(monkeypatch, tmp_path):
+    image_path = tmp_path / "drawing.png"
+    image_path.write_bytes(b"fake-png")
+    called_provider = False
+
+    async def fake_get_story_for_owner(story_id: str, user_id: str):
+        assert story_id == "story-1"
+        assert user_id == "owner"
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+
+    async def fake_generate_painting_video(_payload):
+        nonlocal called_provider
+        called_provider = True
+        return {"content": [{"text": json.dumps({"success": True})}]}
+
+    monkeypatch.setattr(video, "get_story_for_owner", fake_get_story_for_owner)
+    monkeypatch.setattr(video, "generate_painting_video", fake_generate_painting_video)
+
+    with pytest.raises(HTTPException) as exc:
+        await video.generate_video(
+            VideoJobRequest(story_id="story-1"),
+            user=_user("owner"),
+        )
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+    assert called_provider is False
+
+
+@pytest.mark.asyncio
+async def test_generate_video_unwraps_sdk_tool_handler(monkeypatch, tmp_path):
+    image_path = tmp_path / "drawing.png"
+    image_path.write_bytes(b"fake-png")
+
+    async def fake_get_story_for_owner(story_id: str, user_id: str):
+        return {"story_id": story_id, "user_id": user_id, "image_path": str(image_path)}
+
+    class FakeSdkTool:
+        async def handler(self, payload):
+            assert payload["story_id"] == "story-1"
+            return {
+                "content": [
+                    {
+                        "text": json.dumps(
+                            {
+                                "success": True,
+                                "job_id": "job-1",
+                                "status": "pending",
+                            }
+                        )
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(video, "get_story_for_owner", fake_get_story_for_owner)
+    monkeypatch.setattr(video, "generate_painting_video", FakeSdkTool())
+
+    result = await video.generate_video(
+        VideoJobRequest(story_id="story-1"),
+        user=_user("owner"),
+    )
+
+    assert result.job_id == "job-1"
+    assert result.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_get_video_status_rejects_unowned_job_without_story_binding(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(video, "VIDEO_JOBS_DIR", tmp_path)
+    (tmp_path / "job-1.json").write_text(
+        json.dumps({"job_id": "job-1", "status": "completed"}),
+        encoding="utf-8",
+    )
+
+    async def fake_check_video_status(_payload):
+        raise AssertionError("status provider should not be called")
+
+    monkeypatch.setattr(video, "check_video_status", fake_check_video_status)
+
+    with pytest.raises(HTTPException) as exc:
+        await video.get_video_status("job-1", user=_user("owner"))
+
+    assert exc.value.status_code == status.HTTP_404_NOT_FOUND
+    assert exc.value.detail == "Video job is not linked to an owned story"
+
+
+@pytest.mark.asyncio
+async def test_get_video_status_verifies_story_owner_before_returning_url(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(video, "VIDEO_JOBS_DIR", tmp_path)
+    (tmp_path / "job-1.json").write_text(
+        json.dumps(
+            {
+                "job_id": "job-1",
+                "story_id": "story-1",
+                "status": "completed",
+                "created_at": datetime.now().isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async def fake_get_story_for_owner(story_id: str, user_id: str):
+        assert story_id == "story-1"
+        assert user_id == "intruder"
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+
+    async def fake_check_video_status(_payload):
+        raise AssertionError("status provider should not be called")
+
+    monkeypatch.setattr(video, "get_story_for_owner", fake_get_story_for_owner)
+    monkeypatch.setattr(video, "check_video_status", fake_check_video_status)
+
+    with pytest.raises(HTTPException) as exc:
+        await video.get_video_status("job-1", user=_user("intruder"))
+
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_get_video_status_returns_owned_completed_video_url(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(video, "VIDEO_JOBS_DIR", tmp_path)
+    (tmp_path / "job-1.json").write_text(
+        json.dumps(
+            {
+                "job_id": "job-1",
+                "story_id": "story-1",
+                "status": "completed",
+                "combined_video_url": "/data/videos/combined.mp4",
+                "created_at": "2026-05-20T10:00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async def fake_get_story_for_owner(story_id: str, user_id: str):
+        assert story_id == "story-1"
+        assert user_id == "owner"
+        return {"story_id": story_id, "child_id": "child-1"}
+
+    async def fake_check_video_status(_payload):
+        return {
+            "content": [
+                {
+                    "text": json.dumps(
+                        {
+                            "success": True,
+                            "status": "completed",
+                            "progress_percent": 100,
+                            "video_url": "/data/videos/raw.mp4",
+                            "created_at": "2026-05-20T10:00:00",
+                            "completed_at": "2026-05-20T10:02:00",
+                        }
+                    )
+                }
+            ]
+        }
+
+    class NoopAchievementService:
+        async def award_event_safely(self, *_args, **_kwargs):
+            return None
+
+    monkeypatch.setattr(video, "get_story_for_owner", fake_get_story_for_owner)
+    monkeypatch.setattr(video, "check_video_status", fake_check_video_status)
+    monkeypatch.setattr(video, "achievement_service", NoopAchievementService())
+
+    result = await video.get_video_status("job-1", user=_user("owner"))
+
+    assert result.status == "completed"
+    assert result.video_url == "/data/videos/combined.mp4"

--- a/frontend/src/pages/StoryPage/index.tsx
+++ b/frontend/src/pages/StoryPage/index.tsx
@@ -15,16 +15,54 @@ import useChildStore from "@/store/useChildStore";
 import useAuthStore from "@/store/useAuthStore";
 import storyService from "@/api/services/storyService";
 import videoService from "@/api/services/videoService";
-import type { VideoStatus } from "@/types/api";
+import type { StoryVideosResponse, VideoStatus } from "@/types/api";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
 import ShareToHubModal from "@/components/hub/ShareToHubModal";
 
-type StoryVideoUiState =
+export type StoryVideoUiState =
   | "idle"
   | "queued"
   | "generating"
   | "completed"
   | "failed";
+
+export function applyProviderStatusToStoryVideo(
+  status: VideoStatus,
+): StoryVideoUiState {
+  if (status === "pending") return "queued";
+  if (status === "processing") return "generating";
+  if (status === "completed") return "completed";
+  return "failed";
+}
+
+export function getStoryVideoStatusMessage(status: StoryVideoUiState): string {
+  if (status === "queued") return "Queued for video magic";
+  if (status === "generating") return "Making your story video";
+  if (status === "completed") return "Your video is ready";
+  if (status === "failed") return "Video is not available right now";
+  return "";
+}
+
+export function shouldRenderPictureBookFallback(
+  userRequestedFallback: boolean,
+  videoStatus: StoryVideoUiState,
+): boolean {
+  return userRequestedFallback || videoStatus === "failed";
+}
+
+export function findLatestCompletedStoryVideoUrl(
+  response: StoryVideosResponse | undefined,
+): string | null {
+  const completed = [...(response?.videos ?? [])]
+    .filter((video) => video.status === "completed" && video.video_url)
+    .sort((a, b) => {
+      const left = a.created_at ? Date.parse(a.created_at) : 0;
+      const right = b.created_at ? Date.parse(b.created_at) : 0;
+      return right - left;
+    });
+
+  return completed[0]?.video_url ?? null;
+}
 
 function deriveStoryTitleFromText(storyText: string | undefined): string {
   if (!storyText) return "Your Story";
@@ -128,15 +166,24 @@ function StoryPage() {
     }
   }, [story, isAudioGenerating]);
 
-  const applyProviderStatus = useCallback(
-    (status: VideoStatus): StoryVideoUiState => {
-      if (status === "pending") return "queued";
-      if (status === "processing") return "generating";
-      if (status === "completed") return "completed";
-      return "failed";
-    },
-    [],
-  );
+  const { data: storyVideos } = useQuery({
+    queryKey: ["story-videos", story?.story_id],
+    queryFn: () => videoService.getVideosByStory(story!.story_id),
+    enabled: isAuthenticated && !!story?.story_id,
+    retry: 1,
+  });
+
+  useEffect(() => {
+    if (videoStatus !== "idle") return;
+
+    const completedVideoUrl = findLatestCompletedStoryVideoUrl(storyVideos);
+    if (!completedVideoUrl) return;
+
+    setVideoStatus("completed");
+    setVideoProgress(100);
+    setVideoUrl(resolveMediaUrl(completedVideoUrl));
+    setVideoError(null);
+  }, [storyVideos, videoStatus]);
 
   const handleStartVideo = useCallback(async () => {
     if (!story || videoStatus === "queued" || videoStatus === "generating") return;
@@ -156,7 +203,7 @@ function StoryPage() {
       });
 
       setVideoJobId(result.job_id);
-      setVideoStatus(applyProviderStatus(result.status));
+      setVideoStatus(applyProviderStatusToStoryVideo(result.status));
 
       if (result.status === "completed") {
         const completed = await videoService.getVideoStatus(result.job_id);
@@ -174,8 +221,9 @@ function StoryPage() {
       setVideoJobId(null);
       setVideoStatus("failed");
       setVideoError(message);
+      setShowPictureBook(true);
     }
-  }, [applyProviderStatus, onDemandAudioUrl, story, videoStatus]);
+  }, [onDemandAudioUrl, story, videoStatus]);
 
   useEffect(() => {
     if (!videoJobId || !["queued", "generating"].includes(videoStatus)) return;
@@ -186,11 +234,15 @@ function StoryPage() {
         const result = await videoService.getVideoStatus(videoJobId);
         if (cancelled) return;
 
-        setVideoStatus(applyProviderStatus(result.status));
+        const nextStatus = applyProviderStatusToStoryVideo(result.status);
+        setVideoStatus(nextStatus);
         setVideoProgress(result.progress_percent ?? 0);
         setVideoError(result.error_message ?? null);
         if (result.video_url) {
           setVideoUrl(resolveMediaUrl(result.video_url));
+        }
+        if (nextStatus === "failed") {
+          setShowPictureBook(true);
         }
       } catch (err) {
         if (cancelled) return;
@@ -200,6 +252,7 @@ function StoryPage() {
             : "We could not check the video status.";
         setVideoStatus("failed");
         setVideoError(message);
+        setShowPictureBook(true);
       }
     };
 
@@ -210,7 +263,7 @@ function StoryPage() {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [applyProviderStatus, videoJobId, videoStatus]);
+  }, [videoJobId, videoStatus]);
 
   const handleNewStory = () => {
     reset();
@@ -376,10 +429,7 @@ function StoryPage() {
         {videoStatus !== "idle" && (
           <div className={`story-video-status ${videoStatus}`} role="status">
             <span>
-              {videoStatus === "queued" && "Queued for video magic"}
-              {videoStatus === "generating" && "Making your story video"}
-              {videoStatus === "completed" && "Your video is ready"}
-              {videoStatus === "failed" && "Video is not available right now"}
+              {getStoryVideoStatusMessage(videoStatus)}
             </span>
             {(videoStatus === "queued" || videoStatus === "generating") && (
               <div
@@ -408,7 +458,7 @@ function StoryPage() {
           />
         )}
 
-        {showPictureBook && (
+        {shouldRenderPictureBookFallback(showPictureBook, videoStatus) && (
           <DynamicPictureBook
             story={story.story}
             title={storyTitle || `Story #${story.story_id.slice(0, 6)}`}

--- a/frontend/src/pages/StoryPage/storyVideoState.test.ts
+++ b/frontend/src/pages/StoryPage/storyVideoState.test.ts
@@ -1,0 +1,62 @@
+/* @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+import {
+  applyProviderStatusToStoryVideo,
+  findLatestCompletedStoryVideoUrl,
+  getStoryVideoStatusMessage,
+  shouldRenderPictureBookFallback,
+} from ".";
+
+describe("story video state helpers", () => {
+  it("maps provider statuses to child-facing UI states", () => {
+    expect(applyProviderStatusToStoryVideo("pending")).toBe("queued");
+    expect(applyProviderStatusToStoryVideo("processing")).toBe("generating");
+    expect(applyProviderStatusToStoryVideo("completed")).toBe("completed");
+    expect(applyProviderStatusToStoryVideo("failed")).toBe("failed");
+  });
+
+  it("automatically renders the picture-book fallback when video fails", () => {
+    expect(shouldRenderPictureBookFallback(false, "failed")).toBe(true);
+    expect(shouldRenderPictureBookFallback(false, "idle")).toBe(false);
+    expect(shouldRenderPictureBookFallback(true, "completed")).toBe(true);
+  });
+
+  it("uses recoverable copy for failed provider states", () => {
+    expect(getStoryVideoStatusMessage("failed")).toBe(
+      "Video is not available right now",
+    );
+  });
+
+  it("hydrates the newest completed story video URL for owner-visible playback", () => {
+    const url = findLatestCompletedStoryVideoUrl({
+      story_id: "story-1",
+      total: 3,
+      videos: [
+        {
+          video_id: "pending-1",
+          status: "processing",
+          video_url: null,
+          has_audio: false,
+          created_at: "2026-05-20T10:00:00",
+        },
+        {
+          video_id: "done-new",
+          status: "completed",
+          video_url: "/data/videos/new.mp4",
+          has_audio: true,
+          created_at: "2026-05-20T11:00:00",
+        },
+        {
+          video_id: "done-old",
+          status: "completed",
+          video_url: "/data/videos/old.mp4",
+          has_audio: false,
+          created_at: "2026-05-20T09:00:00",
+        },
+      ],
+    });
+
+    expect(url).toBe("/data/videos/new.mp4");
+  });
+});


### PR DESCRIPTION
## Summary
- automatically render the dynamic picture-book fallback when provider video generation fails or cannot be checked
- hydrate the newest completed owner-visible story video on StoryPage and keep the existing Make Video polling flow
- harden video status/info routes so job metadata must be linked to an owned story before provider calls or video URLs are exposed
- preserve MCP server tool registration while exposing callable video tool handlers for in-process route/test use

## Issues
Fixes #533.
Fixes #534.

Parent epic: #531.

## Verification
- backend/.venv/bin/python -m pytest backend/tests/api/test_video_routes.py backend/tests/test_batch_235_182_150.py::TestVideoFailFast -q
- cd frontend && npm test -- src/pages/StoryPage/storyVideoState.test.ts src/components/story/DynamicPictureBook/DynamicPictureBook.test.ts src/api/services/videoService.test.ts --environment node
- cd frontend && npm run build

## Notes
- Expanded `backend/tests/test_batch_235_182_150.py` still has an unrelated pre-existing failure in `TestStreamingCharacterSync.test_streaming_route_contains_character_sync_code`, which asserts a removed source-code comment string in image-to-story.