### PR TITLE
test: make achievement API fixture idempotent

### DIFF
--- a/backend/tests/api/test_achievements.py
+++ b/backend/tests/api/test_achievements.py
@@ -9,6 +9,12 @@ from backend.src.services.database import child_profile_repo, db_manager
 
 
 async def _ensure_owned_child(child_id: str) -> None:
+    existing = await child_profile_repo.get_for_user(
+        "test_user", child_id, include_archived=True
+    )
+    if existing is not None:
+        return
+
     await db_manager.execute(
         """
         INSERT OR IGNORE INTO users (


### PR DESCRIPTION
## Summary
- make the achievement API test child-profile setup idempotent across repeated local runs
- keep the existing #536/#537 badge implementation unchanged

## Tests
- backend/.venv/bin/python -m pytest backend/tests/contracts/test_achievement_contract.py backend/tests/api/test_achievements.py -q
- npm test -- --run src/components/profile/AchievementBadges/achievementBadges.test.ts src/api/services/achievementService.test.ts

Related to #536
Related to #537

Parent Epic: #531