### PR TITLE
chore(docs): align pitch deck claims

### DIFF
--- a/docs/pitch/HOW_TO_USE.md
+++ b/docs/pitch/HOW_TO_USE.md
@@ -123,7 +123,7 @@ Each script follows a consistent shape:
 
 Tips:
 - **Don't read robotically.** Memorize the first sentence of each slide; paraphrase the rest. The transitions matter most — those are the glue.
-- **Numbers out loud sound bigger.** "Two hundred seventy-two" beats "272 slash 272."
+- **Numbers out loud sound bigger.** "Three hundred thirteen shipped out of three hundred fifteen" beats "313 slash 315."
 - **Pauses are content.** When the script says `[PAUSE]`, take 2-3 seconds. Silence is more uncomfortable for you than for the audience.
 
 ## Why Marp instead of building in Keynote directly

--- a/docs/pitch/assets/architecture.svg
+++ b/docs/pitch/assets/architecture.svg
@@ -30,7 +30,7 @@
     <text x="580" y="172" text-anchor="middle" fill="#94A3B8" font-size="12" font-style="italic">deterministic + LLM</text>
   </g>
 
-  <!-- 4 specialist nodes -->
+  <!-- 3 product specialists + 1 reusable audio tool -->
   <g>
     <rect x="40" y="260" width="240" height="80" rx="12" fill="#0F172A" stroke="#C4B5FD" stroke-width="2"/>
     <text x="160" y="290" text-anchor="middle" fill="#F8FAFC" font-size="16" font-weight="600">📖 image_story</text>
@@ -58,10 +58,10 @@
   <line x1="580" y1="190" x2="680" y2="260" stroke="#C4B5FD" stroke-width="2" marker-end="url(#arrow)"/>
   <line x1="580" y1="190" x2="940" y2="260" stroke="#C4B5FD" stroke-width="2" marker-end="url(#arrow)"/>
 
-  <!-- A2A extensible callout -->
+  <!-- Future A2A extensible callout -->
   <g>
     <text x="1080" y="305" text-anchor="middle" fill="#A78BFA" font-size="32">+</text>
-    <text x="1080" y="330" text-anchor="middle" fill="#94A3B8" font-size="11">A2A</text>
+    <text x="1080" y="330" text-anchor="middle" fill="#94A3B8" font-size="11">future A2A</text>
   </g>
 
   <!-- Safety review subagent (distinguished by pink border, thicker) -->

--- a/docs/pitch/assets/backend-layers.svg
+++ b/docs/pitch/assets/backend-layers.svg
@@ -9,7 +9,7 @@
   <g>
     <rect x="80" y="40" width="1000" height="50" rx="10" fill="#1E293B" stroke="#F472B6" stroke-width="2"/>
     <text x="100" y="70" fill="#F472B6" font-size="18" font-weight="700">1 · Routes</text>
-    <text x="1060" y="65" text-anchor="end" fill="#F8FAFC" font-size="13">backend/src/api/routes/ · 14 modules</text>
+    <text x="1060" y="65" text-anchor="end" fill="#F8FAFC" font-size="13">backend/src/api/routes/ · 22 modules</text>
     <text x="1060" y="80" text-anchor="end" fill="#94A3B8" font-size="11" font-style="italic">parse request · validate · return response</text>
   </g>
   <line x1="580" y1="92" x2="580" y2="108" stroke="#C4B5FD" stroke-width="1.5" marker-end="url(#arrL)"/>
@@ -29,7 +29,7 @@
     <text x="100" y="208" fill="#F472B6" font-size="18" font-weight="700">3 · Agents (AI orchestration)</text>
     <text x="100" y="227" fill="#FFFFFF" font-size="12">my_agent_proxy + 3 specialists (image_story · interactive_story · kids_daily) + audio_narration tool</text>
     <text x="1060" y="208" text-anchor="end" fill="#F8FAFC" font-size="13">backend/src/agents/</text>
-    <text x="1060" y="227" text-anchor="end" fill="#94A3B8" font-size="11" font-style="italic">Claude Agent SDK · AgentDefinition</text>
+    <text x="1060" y="227" text-anchor="end" fill="#94A3B8" font-size="11" font-style="italic">Claude Agent SDK · static specialists</text>
   </g>
   <line x1="580" y1="242" x2="580" y2="258" stroke="#C4B5FD" stroke-width="1.5" marker-end="url(#arrL)"/>
 
@@ -47,7 +47,7 @@
   <g>
     <rect x="80" y="340" width="1000" height="50" rx="10" fill="#1E293B" stroke="#C4B5FD" stroke-width="2"/>
     <text x="100" y="370" fill="#C4B5FD" font-size="18" font-weight="700">5 · Services</text>
-    <text x="1060" y="365" text-anchor="end" fill="#F8FAFC" font-size="13">backend/src/services/ · 14 modules</text>
+    <text x="1060" y="365" text-anchor="end" fill="#F8FAFC" font-size="13">backend/src/services/ · 17 modules</text>
     <text x="1060" y="380" text-anchor="end" fill="#94A3B8" font-size="11" font-style="italic">TTS · auth · memory · my_agent_context</text>
   </g>
   <line x1="580" y1="392" x2="580" y2="408" stroke="#C4B5FD" stroke-width="1.5" marker-end="url(#arrL)"/>
@@ -56,7 +56,7 @@
   <g>
     <rect x="80" y="410" width="1000" height="50" rx="10" fill="#1E293B" stroke="#C4B5FD" stroke-width="2"/>
     <text x="100" y="440" fill="#C4B5FD" font-size="18" font-weight="700">6 · Repositories</text>
-    <text x="1060" y="435" text-anchor="end" fill="#F8FAFC" font-size="13">backend/src/services/database/ · 20 repos</text>
+    <text x="1060" y="435" text-anchor="end" fill="#F8FAFC" font-size="13">backend/src/services/database/ · 19 repos</text>
     <text x="1060" y="450" text-anchor="end" fill="#94A3B8" font-size="11" font-style="italic">repository pattern · one repo per table</text>
   </g>
   <line x1="580" y1="462" x2="580" y2="478" stroke="#C4B5FD" stroke-width="1.5" marker-end="url(#arrL)"/>

--- a/docs/pitch/assets/roadmap.svg
+++ b/docs/pitch/assets/roadmap.svg
@@ -25,7 +25,7 @@
     <text x="200" y="216" text-anchor="middle" fill="#D1FAE5" font-size="13">Single agent</text>
     <text x="200" y="234" text-anchor="middle" fill="#D1FAE5" font-size="13">Image-to-Story</text>
     <text x="200" y="252" text-anchor="middle" fill="#D1FAE5" font-size="13">Safety · TTS</text>
-    <text x="200" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">92/92 stories</text>
+    <text x="200" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">95/95 issues</text>
   </g>
 
   <!-- Phase 2 -->
@@ -36,18 +36,18 @@
     <text x="460" y="216" text-anchor="middle" fill="#D1FAE5" font-size="13">Multi-agent + memory</text>
     <text x="460" y="234" text-anchor="middle" fill="#D1FAE5" font-size="13">Kids Daily · Community</text>
     <text x="460" y="252" text-anchor="middle" fill="#D1FAE5" font-size="13">Per-reply safety</text>
-    <text x="460" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">180/180 stories</text>
+    <text x="460" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">188/188 issues</text>
   </g>
 
   <!-- Phase 3 -->
   <g>
     <rect x="600" y="120" width="240" height="180" rx="14" fill="url(#design)" opacity="0.92"/>
     <text x="720" y="155" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">PHASE 3</text>
-    <text x="720" y="186" text-anchor="middle" fill="#FFFFFF" font-size="22" font-weight="700">🔜 Next</text>
+    <text x="720" y="186" text-anchor="middle" fill="#FFFFFF" font-size="22" font-weight="700">🚧 Nearly done</text>
     <text x="720" y="216" text-anchor="middle" fill="#FCE7F3" font-size="13">Video / dynamic books</text>
     <text x="720" y="234" text-anchor="middle" fill="#FCE7F3" font-size="13">Parent dashboard</text>
     <text x="720" y="252" text-anchor="middle" fill="#FCE7F3" font-size="13">Gamification</text>
-    <text x="720" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">in design</text>
+    <text x="720" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">30/32 issues</text>
   </g>
 
   <!-- Phase 4 -->
@@ -58,7 +58,7 @@
     <text x="980" y="216" text-anchor="middle" fill="#EDE9FE" font-size="13">Autonomous</text>
     <text x="980" y="234" text-anchor="middle" fill="#EDE9FE" font-size="13">Multi-step planning</text>
     <text x="980" y="252" text-anchor="middle" fill="#EDE9FE" font-size="13">Scheduled initiatives</text>
-    <text x="980" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">A2A external teams</text>
+    <text x="980" y="278" text-anchor="middle" fill="#FFFFFF" font-size="14" font-weight="700">future A2A teams</text>
   </g>
 
   <!-- Status dots on the timeline -->
@@ -69,8 +69,8 @@
 
   <!-- Today marker between Phase 2 and 3 -->
   <line x1="590" y1="170" x2="590" y2="230" stroke="#1E293B" stroke-width="2" stroke-dasharray="3,3"/>
-  <text x="590" y="160" text-anchor="middle" fill="#1E293B" font-size="11" font-weight="700">we are here ↓</text>
+  <text x="590" y="160" text-anchor="middle" fill="#1E293B" font-size="11" font-weight="700">phase 3 wrap-up ↓</text>
 
   <!-- Caption (title is on the slide itself) -->
-  <text x="580" y="370" text-anchor="middle" fill="#64748B" font-size="14">292 tracked work items · 700+ contract tests · multi-agent in production</text>
+  <text x="580" y="370" text-anchor="middle" fill="#64748B" font-size="14">313/315 tracked work items shipped · 700+ contract tests · multi-agent in production</text>
 </svg>

--- a/docs/pitch/build_editable_pptx.py
+++ b/docs/pitch/build_editable_pptx.py
@@ -243,7 +243,7 @@ add_table(s, [
     ["Not personalized enough",
      "**Persona + character memory** — buddy is named & customized; recurring characters recalled across sessions (`character_repo`)"],
     ["Not highly customized",
-     "**Per-child `AgentDefinition` + skills gating** — age-aware capabilities (3–5 / 6–8 / 9–12); persona shared as system context to every specialist"],
+     "**Persisted buddy persona + skills gating** — age-aware capabilities (3–5 / 6–8 / 9–12); persona shared as system context to every specialist"],
     ["No suited news for kids",
      "**`kids_daily` specialist** — age-stratified prompts + per-reply safety review; news arrives as a kid-safe podcast in the buddy's voice"],
     ["No long-term persistence",
@@ -273,15 +273,15 @@ set_notes(s, 5)
 # SLIDE 6 — Four architecture patterns
 # ════════════════════════════════════════════════════════════════════════
 s = new_slide()
-heading(s, "Four agent architecture patterns — we use all four")
+heading(s, "Four agent architecture patterns — two shipped, two ready next")
 add_table(s, [
     ["#", "Pattern", "What it does", "Where we use it"],
-    ["1", "🤖 Single agent", "One agent, one job · linear inference", "Straight TTS via `audio_narration`"],
-    ["2", "🔀 Sub-agent fan-out", "Same task spawned in parallel for speed", "Concurrent vision crops · parallel `character_repo` lookups"],
-    ["3", "👥 Agent team", "Multiple agents collaborate by **role** · via `AgentDefinition`", "**My Agent**: proxy + 4 role specialists + `safety_review`"],
-    ["4", "🎼 Multi-agent orchestrator", "Agents created **dynamically** · A2A extensible", "Proxy registers new `AgentDefinition`s at runtime"],
+    ["1", "🤖 Single agent/tool", "One callable, one job · linear inference", "TTS via reusable `audio_narration` tool"],
+    ["2", "👥 Static agent team", "Multiple specialists collaborate by role", "**My Agent**: proxy + 3 product specialists + TTS tool + `safety_review`"],
+    ["3", "🔀 Sub-agent fan-out (future)", "Same task spawned in parallel for speed", "Candidate path for parallel vision crops and richer memory search"],
+    ["4", "🎼 Dynamic orchestrator (future)", "Agents registered dynamically · A2A extensible", "Future `AgentDefinition` registration / A2A bridge"],
 ], top=1.6, height=4.4, col_widths=[0.5, 2.7, 4.3, 4.43])
-caption(s, "Shared state flows through build_my_agent_context(). A2A extends to external teams (future).")
+caption(s, "Shared state flows through build_my_agent_context(); recurring characters use character_repo + vector memory. A2A is future work.")
 set_notes(s, 6)
 
 # ════════════════════════════════════════════════════════════════════════
@@ -306,7 +306,7 @@ set_notes(s, 7)
 # ════════════════════════════════════════════════════════════════════════
 s = new_slide(DARK_BG)
 textbox(s, Inches(0.7), Inches(0.4), Inches(12.0), Inches(0.9),
-        [("The team — one proxy, four specialists, one safety gate", 30, PINK_DARK, True)])
+        [("The team — one proxy, three specialists, one reusable tool, one safety gate", 30, PINK_DARK, True)])
 add_image(s, svg_to_png("architecture.svg"), max_w=11.0, max_h=5.0, top=1.5)
 textbox(s, Inches(0.7), Inches(6.7), Inches(12.0), Inches(0.5),
         [("Built on Claude Agent SDK + custom MCP tool servers.", 14, RGBColor(0x94, 0xA3, 0xB8), False)])
@@ -362,7 +362,7 @@ heading(s, "Community & sharing — COPPA by schema, not by policy")
 add_table(s, [
     ["Where most products fail", "What we do"],
     ["Posts JOIN to `users.name` for byline",
-     "`hub_posts.agent_name` is a **snapshot column** — written at post time, never JOINed"],
+     "`agent_name_snapshot`, `agent_avatar_id_snapshot`, and `agent_title_snapshot` are **snapshot columns** — written at post time, never JOINed"],
     ["`users.email` accidentally leaks via API",
      "Read paths can't reach `users` at all — schema doesn't allow it"],
     ["Safety is a code-review checklist",
@@ -376,18 +376,22 @@ set_notes(s, 13)
 # SLIDE 14 — Open by design (code block)
 # ════════════════════════════════════════════════════════════════════════
 s = new_slide()
-heading(s, "Open by design — one AgentDefinition adds a specialist")
+heading(s, "Open by design — static team today, AgentDefinition extensions next")
 code = (
-    '# Adding a "music_story" specialist to the agent team:\n'
-    'proxy.register(AgentDefinition(\n'
+    '# Today: proxy builds a fixed specialist map in _build_subagents().\n'
+    'subagents = {\n'
+    '    "image_story": image_story_agent,\n'
+    '    "interactive_story": interactive_story_agent,\n'
+    '    "kids_daily": kids_daily_agent,\n'
+    '}\n\n'
+    '# Future: adding a "music_story" specialist via AgentDefinition.\n'
+    'AgentDefinition(\n'
     '    name="music_story",\n'
     '    model="haiku",\n'
     '    system_prompt=Path("prompts/music-story.md").read_text(),\n'
     '    tools=["music_generator", "vector_search"],\n'
     '    enabled_skills=["compose"],\n'
-    '))\n\n'
-    '# Routing picks it up automatically. Safety gate runs on every reply.\n'
-    '# Shared context (persona, child_id, recurring chars) flows in.'
+    ')'
 )
 box = s.shapes.add_textbox(Inches(1.0), Inches(1.9), Inches(11.3), Inches(3.6))
 box.fill.solid()
@@ -412,7 +416,7 @@ set_notes(s, 14)
 # SLIDE 15 — Roadmap
 # ════════════════════════════════════════════════════════════════════════
 s = new_slide()
-heading(s, "Roadmap — two phases shipped, two ahead")
+heading(s, "Roadmap — three phases shipped or nearly shipped, one vision")
 add_image(s, svg_to_png("roadmap.svg"), max_w=12.0, max_h=4.8, top=1.7)
 set_notes(s, 15)
 
@@ -423,9 +427,9 @@ s = new_slide()
 heading(s, "Where we are")
 add_table(s, [
     ["Milestone", "Status"],
-    ["Phase 1 — MVP: single agent + image-to-story + safety + TTS", "✅ 92/92 shipped"],
-    ["Phase 2 — multi-agent team + memory + news + community", "✅ 180/180 shipped"],
-    ["Phase 3 — video · parent dashboard · gamification", "🔜 In design"],
+    ["Phase 1 — MVP: single agent + image-to-story + safety + TTS", "✅ 95/95 shipped"],
+    ["Phase 2 — multi-agent team + memory + news + community", "✅ 188/188 shipped"],
+    ["Phase 3 — video · parent dashboard · gamification", "🚧 30/32 shipped"],
 ], top=1.7, height=2.6, col_widths=[9.0, 2.93])
 textbox(s, Inches(0.7), Inches(4.7), Inches(12.0), Inches(1.4), [
     ("Engineering rigor: 700+ contract tests · per-reply programmatic safety (age-aware) · "
@@ -464,7 +468,7 @@ textbox(s, Inches(0.9), Inches(0.7), Inches(11.5), Inches(1.0),
         [("Why this matters", 44, PINK, True)])
 textbox(s, Inches(0.9), Inches(1.9), Inches(11.5), Inches(3.2), [
     ("Agentic from day one — not a wrapper, not a prompt. Real SDK, real tools, real orchestration.", 21, SLATE, False),
-    ("272 stories shipped across 3 milestones — execution proof.", 21, SLATE, False),
+    ("313 shipped / 315 tracked work items across milestones — execution proof.", 21, SLATE, False),
     ("Programmatic safety on every reply — non-negotiable, code-enforced, not vibes.", 21, SLATE, False),
     ("Community that protects child PII at the schema level — COPPA by construction.", 21, SLATE, False),
     ("A buddy that grows with the child — character continuity across image, story, podcast, share.", 21, SLATE, False),
@@ -480,13 +484,13 @@ s = new_slide()
 heading(s, "Appendix — technical deep-dive (backup for Q&A)")
 add_table(s, [
     ["Topic", "One-line answer"],
-    ["Agent", "`AgentDefinition(model, system_prompt, tools, enabled_skills)` — one specialist w/ a curated capability set"],
-    ["Subagent", "An agent registered under the proxy's `agents=` dict · invoked via the SDK's Agent tool delegation"],
+    ["Specialist", "Static proxy entry with its own prompt, tools, and skill gates; AgentDefinition registration is future work"],
+    ["Subagent", "A specialist in the proxy's map · invoked through explicit intent routing and SDK delegation"],
     ["Agent team", "Proxy + 3 product subagents + audio_narration tool + safety_review · all share the context bus"],
     ["Orchestrator", "The proxy — routes intent · composes specialist outputs · runs safety_review on every reply"],
     ["Why this shape", "Bigger prompt degrades w/ specialty count · prompt chaining = no shared state · agent team = shared context + parallel specialty"],
     ["Per-reply safety", "`enforce_chat_safety()` after every reply · age-aware threshold · suggest-improvements retry · `safety_blocked` telemetry"],
-    ["COPPA pattern", "`hub_posts.agent_name/avatar/title` — immutable snapshot columns; no read path JOINs `users`"],
+    ["COPPA pattern", "`hub_posts.agent_name_snapshot/avatar_id_snapshot/title_snapshot` — immutable snapshot columns; no read path JOINs `users`"],
     ["Tech stack", "FastAPI + Pydantic v2 · SQLite (dev) / Postgres + pgvector (prod) · React 18 + TS + Tailwind"],
 ], top=1.5, height=5.0, col_widths=[2.4, 9.53])
 set_notes(s, 19)

--- a/docs/pitch/keynote-deck.md
+++ b/docs/pitch/keynote-deck.md
@@ -162,7 +162,7 @@ Existing AI extracts from kids. We collaborate with them."
 | Problem | Our agent's ability |
 |---|---|
 | Not personalized enough | **Persona + character memory** — buddy is named & customized; recurring characters recalled across sessions (`character_repo`) |
-| Not highly customized | **Per-child `AgentDefinition` + skills gating** — age-aware capabilities (3–5 / 6–8 / 9–12); buddy persona shared as system context to every specialist |
+| Not highly customized | **Per-child buddy profile + skills gating** — age-aware capabilities (3–5 / 6–8 / 9–12); buddy persona shared as system context to every specialist |
 | No suited news for kids | **`kids_daily` specialist** — age-stratified prompts + per-reply safety review; news arrives as a kid-safe podcast in the buddy's voice |
 | No long-term persistence | **`agent_repo` + `character_repo` + vector search** — buddy persona and recurring characters survive every session; one buddy, for life |
 
@@ -227,34 +227,32 @@ And autonomous — that's next: multi-step planning, scheduled buddy initiatives
 
 ---
 
-## Four agent architecture patterns — *we use all four*
+## Four agent architecture patterns — *two shipped, two ready next*
 
 | # | Pattern | What it does | Where we use it |
 |---|---|---|---|
-| 1 | **🤖 Single agent** | One agent, one job · linear inference | Straight TTS via `audio_narration` |
-| 2 | **🔀 Sub-agent fan-out** | Same task spawned in parallel for speed | Concurrent vision crops · parallel `character_repo` lookups |
-| 3 | **👥 Agent team** | Multiple agents collaborate by **role** · defined via `AgentDefinition` | **My Agent**: proxy + 4 role specialists + `safety_review` |
-| 4 | **🎼 Multi-agent orchestrator** | Agents created **dynamically** · A2A extensible to external teams | Proxy registers new `AgentDefinition`s at runtime |
+| 1 | **🤖 Single agent/tool** | One callable, one job · linear inference | TTS via the reusable `audio_narration` tool |
+| 2 | **👥 Static agent team** | Multiple specialists collaborate by role | **My Agent** proxy routes to 3 product specialists + TTS tool + `safety_review` |
+| 3 | **🔀 Sub-agent fan-out** *(future)* | Same task spawned in parallel for speed | Candidate path for parallel vision crops and richer memory search |
+| 4 | **🎼 Dynamic orchestrator** *(future)* | Agents registered dynamically · A2A extensible to external teams | Future `AgentDefinition` registration / A2A bridge |
 
-<small>**Shared state** within a team flows through `build_my_agent_context()` — persona, child_id, recurring characters reach every specialist. **A2A** extends to external agent teams (future).</small>
+<small>**Shared state** within the shipped team flows through `build_my_agent_context()` — persona, tone, style, skills, topics, goals, child_id, and age. Recurring characters flow through `character_repo` and vector memory. **A2A** remains future work.</small>
 
 <!--
 🎤 SCRIPT · Slide 6 · Four architecture patterns
 ⏱ ~26 seconds · 5-min cut: KEEP
 
-"Four agent architecture patterns — and we use all four.
+"Four agent architecture patterns — two shipped, two ready next.
 
-Single agent — one job, linear inference. We use it for text-to-speech.
+Single agent or tool — one job, linear inference. We use it for text-to-speech.
 
-Sub-agent fan-out — the same task in parallel, for speed.
+Static agent team — our My Agent proxy routes to image story, interactive story, Kids Daily, a reusable audio tool, and safety review.
 
-Agent team — multiple agents collaborating by role, each an AgentDefinition. That's our My Agent.
+Sub-agent fan-out and dynamic orchestration are future extension paths.
 
-Multi-agent orchestrator — agents created dynamically at runtime. That's what makes us extensible.
+Shared context carries persona and style; recurring characters come from character memory. A2A to external teams is future work."
 
-Shared state flows to every specialist through the agent context. A2A to external teams is future work."
-
-🎬 Walk pattern by pattern. "We use all four" is the punchline.
+🎬 Walk pattern by pattern. Land the shipped-versus-future split clearly.
 ➡ Next: "And every agent is wired to six memory layers."
 -->
 
@@ -303,7 +301,7 @@ Put it together: the buddy remembers, understands, acts, talks, and reasons in f
 <!-- _color: "#F8FAFC" -->
 <!-- _class: dark -->
 
-## The team — *one proxy, four specialists, one safety gate*
+## The team — *one proxy, three specialists, one tool, one safety gate*
 
 One agent hit a ceiling. Branching stories, news podcasts, per-reply safety — each needed its own expertise. We extended to an **agent team** — still on Claude Agent SDK.
 
@@ -381,7 +379,7 @@ Routes parse requests. Dependencies handle auth and quota.
 
 Agents orchestrate the AI. MCP servers are the tool layer — seven of them.
 
-Services hold business logic. Repositories wrap database access — twenty of them.
+Services hold business logic — seventeen modules today. Repositories wrap database access — nineteen of them.
 
 And the database adapter — SQLite in dev, Postgres in production.
 
@@ -453,12 +451,12 @@ Three surfaces, same character. Continuity made real — not just claimed."
 
 | Where most products fail | What we do |
 |---|---|
-| Posts JOIN to `users.name` for byline | `hub_posts.agent_name` is a **snapshot column** — written at post time, never JOINed |
+| Posts JOIN to `users.name` for byline | `agent_name_snapshot`, `agent_avatar_id_snapshot`, and `agent_title_snapshot` are **snapshot columns** — written at post time, never JOINed |
 | `users.email` accidentally leaks via API | Read paths can't reach `users` at all — schema doesn't allow it |
 | Safety is a code-review checklist | Safety is a CHECK constraint + invariant test |
 
 ```
-hub_posts (id, agent_name, agent_avatar, agent_title, story_id, ...)
+hub_posts (id, agent_name_snapshot, agent_avatar_id_snapshot, agent_title_snapshot, story_id, ...)
                               ▲ immutable persona snapshot — no user JOIN
 ```
 
@@ -482,23 +480,27 @@ The unsafe query can't even be expressed. Safety is a schema invariant — with 
 
 ---
 
-## Open by design — *one AgentDefinition adds a specialist*
+## Open by design — *static team today, AgentDefinition extensions next*
 
 ```python
-# Adding a "music_story" specialist to the agent team:
-proxy.register(AgentDefinition(
+# Today: the proxy builds a fixed specialist map in _build_subagents().
+subagents = {
+    "image_story": image_story_agent,
+    "interactive_story": interactive_story_agent,
+    "kids_daily": kids_daily_agent,
+}
+
+# Future: adding a "music_story" specialist via AgentDefinition.
+AgentDefinition(
     name="music_story",
     model="haiku",
     system_prompt=Path("prompts/music-story.md").read_text(),
     tools=["music_generator", "vector_search"],
     enabled_skills=["compose"],
-))
-
-# Routing picks it up automatically. Safety gate runs on every reply.
-# Shared context (persona, child_id, recurring chars) flows in.
+)
 ```
 
-<small>**A2A bridge** (future) extends to external agent teams — partner specialists join the buddy's team via the same registration contract.</small>
+<small>Today, routing is explicit and safety-gated. **A2A bridge** and dynamic `AgentDefinition` registration are future extension work.</small>
 
 <!--
 🎤 SCRIPT · Slide 14 · Open by design (extensibility)
@@ -506,19 +508,19 @@ proxy.register(AgentDefinition(
 
 "This architecture is open by design.
 
-Adding a new specialist takes one AgentDefinition — a model, a prompt, its tools, its skills.
+Today, the proxy builds a static specialist map. That keeps routing explicit and easy to test.
 
-Register it, and routing picks it up automatically. The safety gate still runs on every reply. Shared context still flows in.
+The next extension is AgentDefinition registration: a model, a prompt, tools, and skills. The safety gate still runs on every reply. Shared context still flows in.
 
 And in the future, an A2A bridge lets external agent teams join — through the same contract."
 
-🎬 Let the audience read the code. "One AgentDefinition" is the moat — slow on that.
+🎬 Let the audience read the code. Land the split between today's static team and tomorrow's dynamic extension.
 ➡ Next: "And here's where we're headed."
 -->
 
 ---
 
-## Roadmap — *two phases shipped, two ahead*
+## Roadmap — *three phases shipped or nearly shipped, one vision*
 
 ![roadmap h:380](assets/roadmap.svg)
 
@@ -526,13 +528,13 @@ And in the future, an A2A bridge lets external agent teams join — through the 
 🎤 SCRIPT · Slide 15 · Roadmap (Phase 1 → 4)
 ⏱ ~30 seconds · 5-min cut: KEEP
 
-"Our roadmap — two phases shipped, two ahead.
+"Our roadmap — two phases shipped, one nearly complete, one vision.
 
 Phase one, the MVP — single agent, image-to-story, safety, TTS. Done.
 
 Phase two, the agent team — multi-agent, memory, Kids Daily, community. Done.
 
-Phase three, in design — video, parent dashboard, gamification.
+Phase three, nearly complete — video, parent dashboard, gamification.
 
 Phase four, the vision — autonomous.
 
@@ -548,9 +550,9 @@ We don't pitch features. We ship them."
 
 | Milestone | Status |
 |---|---|
-| **Phase 1** MVP — Single agent + image-to-story + safety + TTS | ✅ **92/92** shipped |
-| **Phase 2** Multi-agent team + memory + news + community | ✅ **180/180** shipped |
-| **Phase 3** Video · parent dashboard · gamification | 🔜 In design |
+| **Phase 1** MVP — Single agent + image-to-story + safety + TTS | ✅ **95/95** shipped |
+| **Phase 2** Multi-agent team + memory + news + community | ✅ **188/188** shipped |
+| **Phase 3** Video · parent dashboard · gamification | 🚧 **30/32** shipped |
 
 <br>
 
@@ -562,7 +564,7 @@ We don't pitch features. We ship them."
 🎤 SCRIPT · Slide 16 · Where we are
 ⏱ ~22 seconds · 5-min cut: KEEP
 
-"Where we are today. Two hundred ninety-two tracked work items — phases one and two done, phase three moving into build.
+"Where we are today. Three hundred thirteen shipped work items out of three hundred fifteen tracked across milestones — phases one and two done, phase three nearly complete.
 
 The engineering rigor: over seven hundred contract tests, per-reply safety, a silent safety bug we caught and fixed in twenty-four hours.
 
@@ -609,7 +611,7 @@ Most pitches hide bugs. We name ours."
 # Why this matters
 
 - **Agentic from day one** — not a wrapper, not a prompt. Real SDK, real tools, real orchestration.
-- **292 tracked work items** across shipped and planned milestones — *execution proof*
+- **313 shipped / 315 tracked work items** across milestones — *execution proof*
 - **Programmatic safety on every reply** — non-negotiable, code-enforced, not vibes
 - **Community that protects child PII at the schema level** — COPPA by construction
 - **A buddy that grows with the child** — character continuity across image, story, podcast, share
@@ -626,7 +628,7 @@ Most pitches hide bugs. We name ours."
 
 Agentic from day one — real SDK, real tools, real orchestration. Not a wrapper.
 
-292 tracked work items across shipped and planned milestones — execution proof.
+Three hundred thirteen shipped work items out of three hundred fifteen tracked across milestones — execution proof.
 
 Programmatic safety on every reply — code-enforced, not vibes.
 
@@ -652,16 +654,16 @@ I'd love to take your questions."
 
 | Topic | One-line answer |
 |---|---|
-| **Agent** | `AgentDefinition(model="haiku", system_prompt=..., tools=[...], enabled_skills=[...])` — one specialist w/ a curated capability set |
-| **Subagent** | An agent registered under the proxy's `agents=` dict · invoked via the SDK's `Agent` tool delegation |
+| **Specialist** | Static proxy entry with its own prompt, tools, and skill gates; future `AgentDefinition` registration can make this dynamic |
+| **Subagent** | A specialist in the proxy's map · invoked through explicit intent routing and SDK delegation |
 | **Agent team** | Proxy + 3 product subagents (image_story · interactive_story · kids_daily) + audio_narration tool + safety_review · all share the context bus |
 | **Orchestrator** | The proxy ("My Agent") — routes intent · composes specialist outputs · runs safety_review on every reply |
 | **Why this shape** | Bigger prompt → quality degrades w/ specialty count · prompt chaining → no shared state · agent team → shared context + parallel specialty + future A2A extensibility |
-| **SDK** | `claude_agent_sdk` — `ClaudeSDKClient` + `AgentDefinition`s + custom MCP servers via `@tool` |
+| **SDK** | `claude_agent_sdk` — `ClaudeSDKClient` + custom MCP servers via `@tool`; dynamic `AgentDefinition` registration is future extension work |
 | **Intent routing** | `_classify_intent(utterance, age)` — deterministic keyword rules + LLM disambiguation · age 3-5 vague `"story?"` → image_story by default |
 | **Per-reply safety** | `enforce_chat_safety()` after every proxy reply · age-aware threshold · `suggest_content_improvements` retry · `safety_blocked` SSE telemetry on fail |
-| **Shared state** | `build_my_agent_context(user_id, child_id)` passes persona + recurring characters to every specialist's system prompt |
-| **COPPA pattern** | `hub_posts.agent_name`, `agent_avatar`, `agent_title` — immutable snapshot columns; no read path JOINs `users` |
+| **Shared state** | `build_my_agent_context(user_id, child_id)` passes persona, tone, style, skills, topics, goals, child_id, and age; recurring characters flow through `character_repo` and vector memory |
+| **COPPA pattern** | `hub_posts.agent_name_snapshot`, `agent_avatar_id_snapshot`, `agent_title_snapshot` — immutable snapshot columns; no read path JOINs `users` |
 | **Streaming** | SSE event types: `status` · `progress` · `tool_use` · `tool_result` · `launch_flow` · `safety_blocked` · `result` · `complete` |
 | **Testing** | 700+ contract tests · per-MCP-tool + per-agent + per-route contracts · pytest, `pytest-asyncio` |
 | **Tech stack** | FastAPI + Pydantic v2 · SQLite (dev) / Postgres + pgvector (prod) · React 18 + TypeScript + Tailwind + TanStack Query |
@@ -680,13 +682,13 @@ Only reveal it if a judge asks a deep technical question. Then jump straight to 
 Here are three example answers you might give out loud:
 
 If they ask "what's the difference between an agent and a subagent?":
-"An agent in our system is an AgentDefinition — it has a model, a system prompt, a set of tools, and a set of skills. A subagent is one of those registered underneath our proxy. The SDK's Agent tool is what lets the proxy delegate to a subagent based on the child's intent."
+"Today, a specialist in our system is a static entry in the proxy's specialist map — it has its own prompt, tools, and skill gates. A subagent is one of those specialists invoked by the proxy based on the child's intent. AgentDefinition registration is the future extension path for new specialists."
 
 If they ask "why didn't you just use a bigger prompt?":
 "Two reasons. First, quality degrades as you stuff more specialties into one prompt — the model loses focus. And second, we'd lose the per-reply safety subagent as a separate gate, which is non-negotiable for a kids product."
 
 If they ask "how is your COPPA pattern different from other kid-AI products?":
-"Most teams enforce their kid-PII rules in code review. We enforce them in the schema. The hub_posts table has agent_name, agent_avatar, and agent_title as immutable snapshot columns — written once at post time. No read path in our codebase JOINs the users table. The unsafe query literally can't be expressed in our schema."
+"Most teams enforce their kid-PII rules in code review. We enforce them in the schema. The hub_posts table has agent_name_snapshot, agent_avatar_id_snapshot, and agent_title_snapshot as immutable snapshot columns — written once at post time. No read path in our codebase JOINs the users table. The unsafe query literally can't be expressed in our schema."
 
 🎬 Don't read the whole table out loud. Just jump to the row that answers the question and explain it conversationally.
 -->

--- a/docs/pitch/slide-blueprints.md
+++ b/docs/pitch/slide-blueprints.md
@@ -223,10 +223,10 @@ Keep this file open in your IDE alongside `keynote-deck.md` while assembling sli
 **Speaker beat:** Walk the diagram top-to-bottom. About 10 seconds per element:
 1. *"We extended — same SDK, new shape."*
 2. *"The proxy ORCHESTRATES — routes the child's intent to the right specialist."*
-3. *"Four specialists, each with their own prompt, tools, and skills."*
+3. *"Three product specialists, each with their own prompt, tools, and skills — plus a reusable audio tool."*
 4. *"Every reply passes through safety_review — that subagent is the non-negotiable gate."* **(pause here)**
-5. *"And underneath everything — SHARED CONTEXT. Persona, child_id, recurring characters — flows to every agent. So Lightning the puppy is the same dog in the story AS in the podcast."*
-6. *"Two more properties unlocked: responsive (right specialist in milliseconds) and dynamic (different experience per turn). And A2A extensible — new specialists plug in by registering one AgentDefinition."*
+5. *"And underneath everything — SHARED CONTEXT. Persona, tone, style, skills, topics, goals, child_id, and age flow to every specialist. Recurring characters come from character_repo and vector memory, so Lightning the puppy is the same dog in the story AS in the podcast."*
+6. *"Two more properties unlocked: responsive (right specialist in milliseconds) and dynamic (different experience per turn). A2A and dynamic registration are future extension paths."*
 
 **Why this slide exists:** **THE moat.** Multi-agent orchestration with shared state is hard. Doing it for kids with per-reply safety is harder. If a judge remembers only one technical slide, this is it.
 
@@ -246,7 +246,7 @@ Keep this file open in your IDE alongside `keynote-deck.md` while assembling sli
 | Table headers | `Decision` · `Alternative we rejected` · `What we chose` · `Why` | Violet #7C3AED · 18px · weight 700 | Row 1 |
 | Row — Prompts | `Prompts` / `Python f-strings inline in code` / `Markdown files in backend/src/prompts/` / `Versioned · code-reviewable · age-stratified per file` | Slate body · 17px · bold "Prompts" · code styling for file paths | Row 2 |
 | Row — Tools | `Tools` / `Direct API calls in agent loops` / `Custom MCP servers · typed JSON envelopes · .handler calling convention` / `Composable · testable · independently versionable` | Slate body · 17px · bold "Tools" · code styling for .handler | Row 3 |
-| Row — Skills | `Skills` / `Hardcoded behaviors per agent class` / `enabled_skills field on AgentDefinition · _enabled(agent, skill) runs server-side` / `Per-age gating · A2A plug-in · single registration` | Slate body · 17px · bold "Skills" · code styling | Row 4 |
+| Row — Skills | `Skills` / `Hardcoded behaviors per agent class` / `enabled_skills on the persisted buddy + server-side _enabled(agent, skill)` / `Per-age gating today · AgentDefinition plug-in path later` | Slate body · 17px · bold "Skills" · code styling | Row 4 |
 | Row — Multi-agent | `Multi-agent` / `Bigger prompt + conditional branching` / `Proxy + 3 product subagents + audio tool + shared context bus` / `Specialty isolation · safety_review on EVERY reply · responsive routing` | Slate body · 17px · bold "Multi-agent" · "EVERY" emphasized | Row 5 |
 | Vocabulary footer | `Vocabulary — agent · subagent · team · orchestrator — each role is precise. See appendix.` | Slate body · 18px · italic on the four vocabulary words | Below table · 24px gap |
 
@@ -257,8 +257,8 @@ Keep this file open in your IDE alongside `keynote-deck.md` while assembling sli
 **Speaker beat:** Walk it row-by-row, ~7 seconds per row:
 1. *"Prompts could have been Python f-strings. We chose markdown in git — versioned and code-reviewable."*
 2. *"Tools could have been direct API calls. We chose MCP servers with typed envelopes — composable and testable."*
-3. *"Skills could have been hardcoded. We chose enabled_skills as a field on AgentDefinition — per-age gating, A2A extensible."*
-4. *"Multi-agent could have been a bigger prompt with branching. We chose a proxy plus 4 subagents — specialty isolated, safety_review runs on EVERY reply."*
+3. *"Skills could have been hardcoded. We chose persisted enabled skills with server-side gates — per-age gating today, dynamic plug-ins later."*
+4. *"Multi-agent could have been a bigger prompt with branching. We chose a proxy plus 3 product specialists and a reusable audio tool — specialty isolated, safety_review runs on EVERY reply."*
 
 Close: *"We didn't adopt defaults. Each row is a trade-off we made deliberately."* Point at the vocabulary footer: *"And we use precise terms — agent, subagent, team, orchestrator. Each role is distinct."*
 
@@ -285,7 +285,7 @@ Close: *"We didn't adopt defaults. Each row is a trade-off we made deliberately.
 | **Row 1 / col 1** | `Multi-agent + shared state on Claude Agent SDK — proxy + 3 product specialists, a TTS tool, and a shared context bus` | Slate body · 17px · bold "Multi-agent + shared state" | Cell |
 | **Row 1 / col 2** | `Per-reply programmatic safety — age-aware thresholds (0.90 for 3-5, 0.85 for 6-12), suggest-then-retry` | Slate body · 17px · bold "Per-reply programmatic safety" | Cell |
 | **Row 1 / col 3** | `Character continuity across surfaces — Lightning the puppy in image, story, podcast, and community` | Slate body · 17px · bold "Character continuity across surfaces" | Cell |
-| **Row 2 / col 1** | `A2A extensible — new specialists plug in via one AgentDefinition registration` | Slate body · 17px · bold "A2A extensible" | Cell |
+| **Row 2 / col 1** | `Future A2A extension — new specialists can plug in via AgentDefinition registration after the static team` | Slate body · 17px · bold "Future A2A extension" | Cell |
 | **Row 2 / col 2** | `COPPA at the schema level — persona-snapshot columns; the unsafe JOIN can't be expressed` | Slate body · 17px · bold "COPPA at the schema level" · italic accent on "can't be expressed" | Cell |
 | **Row 2 / col 3** | `One buddy, N specialists, one identity — child sees one persona; system orchestrates the rest` | Slate body · 17px · bold "One buddy, N specialists, one identity" | Cell |
 | Punchline | `Most kid-AI products ship one of these. We ship all six.` | Slate muted #64748B · 20px · italic · **bold "one"** and **bold "all six"** | Bottom-center · 40px from edge |
@@ -298,7 +298,7 @@ Close: *"We didn't adopt defaults. Each row is a trade-off we made deliberately.
 **Timing:** ~30 seconds
 
 **Speaker beat:** Walk it column-by-column, ~7 seconds per cell:
-1. *"Agentic stack: multi-agent with shared state on the SDK — A2A extensible, so new specialists plug in by registering a single AgentDefinition."*
+1. *"Agentic stack: multi-agent with shared state on the SDK today — A2A and dynamic AgentDefinition registration are the next extension path."*
 2. *"Safety architecture: per-reply programmatic safety with age-aware thresholds — and COPPA enforced AT THE SCHEMA LEVEL. The unsafe JOIN can't even be expressed."*
 3. *"Kid experience: character continuity across surfaces — same Lightning the puppy from her drawing shows up in her interactive story, her podcast, her community feed. One buddy, many specialists, one identity."*
 
@@ -345,7 +345,7 @@ Land hard on: *"Most ship one of these. We ship all six."* Pause. Then move.
 | Component | Content | Style | Position |
 |---|---|---|---|
 | H2 heading | `Where we are` | Violet #7C3AED · 36px · weight 700 | Top-left |
-| Progress table | 3 rows: Phase 1 MVP ✅ 92/92 (single agent) · Phase 2 ✅ 180/180 (multi-agent team) · Phase 3 🔜 In design | Violet headers · 20px body · ✅/🔜 emoji · bold counts | Center · full-width minus 80px |
+| Progress table | 3 rows: Phase 1 MVP ✅ 95/95 (single agent) · Phase 2 ✅ 188/188 (multi-agent team) · Phase 3 🚧 30/32 (video, parent dashboard, gamification) | Violet headers · 20px body · ✅/🚧 emoji · bold counts | Center · full-width minus 80px |
 | Engineering rigor line | `Engineering rigor: 700+ contract tests · per-reply programmatic safety (age-aware) · silent safety-bypass caught + fixed in 1 day · merge-train of 7 PRs landed last week` | Slate body · 18px · bold "Engineering rigor:" | Below table · 30px gap |
 | Real-numbers line | `Add real numbers in Keynote: pilot users · sessions/week · feedback quotes.` | Slate muted #64748B · 16px · italic | Bottom · centered |
 
@@ -353,7 +353,7 @@ Land hard on: *"Most ship one of these. We ship all six."* Pause. Then move.
 
 **Timing:** ~25 seconds
 
-**Speaker beat:** *"292 tracked work items across shipped and planned milestones. We don't pitch features — we ship them. And the engineering rigor line — programmatic per-reply safety, caught and fixed a silent safety-bypass in one day, landed a 7-PR merge train last week — that's how we treat production AI for kids."*
+**Speaker beat:** *"313 shipped work items out of 315 tracked across milestones. We don't pitch features — we ship them. And the engineering rigor line — programmatic per-reply safety, caught and fixed a silent safety-bypass in one day, landed a 7-PR merge train last week — that's how we treat production AI for kids."*
 
 **Why this slide exists:** Execution velocity + engineering rigor are the contest-judged proxies for "this team can ship." Both deserve their own line.
 
@@ -404,7 +404,7 @@ Land hard on punchline: *"Most pitches hide bugs. We name ours."*
 | Component | Content | Style | Position |
 |---|---|---|---|
 | H1 heading | `Why this matters` | Pink #DB2777 · 56px · weight 800 | Top-left |
-| 5 achievements | Agentic from day one · 292 tracked work items · Programmatic safety on every reply · COPPA at schema level · Buddy that grows with the child | Slate body · 22px · 1.5 line-height · **bold lead phrase** + supporting clause | Center-left · 40px gap below H1 |
+| 5 achievements | Agentic from day one · 313 shipped / 315 tracked work items · Programmatic safety on every reply · COPPA at schema level · Buddy that grows with the child | Slate body · 22px · 1.5 line-height · **bold lead phrase** + supporting clause | Center-left · 40px gap below H1 |
 | Closing bookend | `AI that grows up *with* kids — safely.` | Pink #DB2777 · 56px · weight 800 · italic accent on "with" | Bottom-center · 50px from edge |
 
 **Visuals:** None. The gradient + typography is the visual.

--- a/docs/pitch/speaker-scripts.md
+++ b/docs/pitch/speaker-scripts.md
@@ -85,17 +85,15 @@
 ## Slide 6 — Four architecture patterns
 *~26 seconds · 5-min cut: KEEP*
 
-> "Four agent architecture patterns — and we use all four.
+> "Four agent architecture patterns — two shipped, two ready next.
 >
-> Single agent — one job, linear inference. We use it for text-to-speech.
+> Single agent or tool — one job, linear inference. We use it for text-to-speech.
 >
-> Sub-agent fan-out — the same task in parallel, for speed.
+> Static agent team — our My Agent proxy routes to image story, interactive story, Kids Daily, a reusable audio tool, and safety review.
 >
-> Agent team — multiple agents collaborating by role, each an AgentDefinition. That's our My Agent.
+> Sub-agent fan-out and dynamic orchestration are future extension paths.
 >
-> Multi-agent orchestrator — agents created dynamically at runtime. That's what makes us extensible.
->
-> Shared state flows to every specialist through the agent context. A2A to external teams is future work."
+> Shared context carries persona and style; recurring characters come from character memory. A2A to external teams is future work."
 
 ---
 
@@ -139,7 +137,7 @@
 >
 > [point at the context bus]
 >
-> And underneath, shared context — persona, characters — flows to every agent. Same character in the story and the podcast.
+> And underneath, shared context — persona, tone, style, skills, topics, and goals — flows to every specialist. Recurring characters come from the character repository and vector memory, so the same character can show up in the story and the podcast.
 >
 > This unlocks responsive, dynamic, and A2A-extensible."
 
@@ -171,7 +169,7 @@
 >
 > Agents orchestrate the AI. MCP servers are the tool layer — seven of them.
 >
-> Services hold business logic. Repositories wrap database access — twenty of them.
+> Services hold business logic — seventeen modules today. Repositories wrap database access — nineteen of them.
 >
 > And the database adapter — SQLite in dev, Postgres in production.
 >
@@ -227,9 +225,9 @@
 
 > "This architecture is open by design.
 >
-> Adding a new specialist takes one AgentDefinition — a model, a prompt, its tools, its skills.
+> Today, the proxy builds a static specialist map. That keeps routing explicit and easy to test.
 >
-> Register it, and routing picks it up automatically. The safety gate still runs on every reply. Shared context still flows in.
+> The next extension is AgentDefinition registration — a model, a prompt, its tools, its skills. The safety gate still runs on every reply. Shared context still flows in.
 >
 > And in the future, an A2A bridge lets external agent teams join — through the same contract."
 
@@ -238,13 +236,13 @@
 ## Slide 15 — Roadmap (Phase 1 → 4)
 *~30 seconds · 5-min cut: KEEP*
 
-> "Our roadmap — two phases shipped, two ahead.
+> "Our roadmap — two phases shipped, one nearly complete, one vision.
 >
 > Phase one, the MVP — single agent, image-to-story, safety, TTS. Done.
 >
 > Phase two, the agent team — multi-agent, memory, Kids Daily, community. Done.
 >
-> Phase three, in design — video, parent dashboard, gamification.
+> Phase three, nearly complete — video, parent dashboard, achievements surfaced.
 >
 > Phase four, the vision — autonomous.
 >
@@ -255,7 +253,7 @@
 ## Slide 16 — Where we are
 *~22 seconds · 5-min cut: KEEP*
 
-> "Where we are today. Two hundred ninety-two tracked work items — phases one and two done, phase three moving into build.
+> "Where we are today. Three hundred thirteen shipped work items out of three hundred fifteen tracked across milestones — phases one and two done, phase three nearly complete.
 >
 > The engineering rigor: over seven hundred contract tests, per-reply safety, a silent safety bug we caught and fixed in twenty-four hours.
 >
@@ -285,7 +283,7 @@
 >
 > Agentic from day one — real SDK, real tools, real orchestration. Not a wrapper.
 >
-> 292 tracked work items across shipped and planned milestones — execution proof.
+> Three hundred thirteen shipped work items out of three hundred fifteen tracked across milestones — execution proof.
 >
 > Programmatic safety on every reply — code-enforced, not vibes.
 >
@@ -314,12 +312,12 @@
 > Here are three example answers you might give out loud:
 >
 > If they ask "what's the difference between an agent and a subagent?":
-> "An agent in our system is an AgentDefinition — it has a model, a system prompt, a set of tools, and a set of skills. A subagent is one of those registered underneath our proxy. The SDK's Agent tool is what lets the proxy delegate to a subagent based on the child's intent."
+> "Today, a specialist in our system is a static entry in the proxy's specialist map — it has its own prompt, tools, and skill gates. A subagent is one of those specialists invoked by the proxy based on the child's intent. AgentDefinition registration is the future extension path for new specialists."
 >
 > If they ask "why didn't you just use a bigger prompt?":
 > "Two reasons. First, quality degrades as you stuff more specialties into one prompt — the model loses focus. And second, we'd lose the per-reply safety subagent as a separate gate, which is non-negotiable for a kids product."
 >
 > If they ask "how is your COPPA pattern different from other kid-AI products?":
-> "Most teams enforce their kid-PII rules in code review. We enforce them in the schema. The hub_posts table has agent_name, agent_avatar, and agent_title as immutable snapshot columns — written once at post time. No read path in our codebase JOINs the users table. The unsafe query literally can't be expressed in our schema."
+> "Most teams enforce their kid-PII rules in code review. We enforce them in the schema. The hub_posts table has agent_name_snapshot, agent_avatar_id_snapshot, and agent_title_snapshot as immutable snapshot columns — written once at post time. No read path in our codebase JOINs the users table. The unsafe query literally can't be expressed in our schema."
 
 ---


### PR DESCRIPTION
## Summary
- align pitch architecture copy with shipped static My Agent specialists, TTS tooling, and future A2A/dynamic registration language
- refresh milestone and backend count proof points to current source/GitHub state
- update COPPA byline wording to implemented hub snapshot columns across deck sources and SVGs

## Verification
- python docs/pitch/build_editable_pptx.py
- git diff --cached --check
- rg stale-claim scan across docs/pitch

Parent Epic: #531
Fixes #522