### PR TITLE
fix(referral): qualify Supabase invite rewards

### DIFF
--- a/backend/src/api/deps.py
+++ b/backend/src/api/deps.py
@@ -303,9 +303,8 @@ async def _get_or_create_supabase_user(claims) -> Optional[UserData]:
 
                 # Qualify immediately if email is confirmed (#425)
                 if claims.email_confirmed:
-                    await referral_repo.qualify_referral(claims.sub)
                     from ..services.user_service import user_service
-                    await user_service.qualify_and_maybe_upgrade(referrer.user_id)
+                    await user_service.qualify_and_maybe_upgrade(claims.sub)
         except Exception:
             pass  # Referral is non-critical — don't block user creation
 

--- a/backend/tests/api/test_supabase_referrals.py
+++ b/backend/tests/api/test_supabase_referrals.py
@@ -1,0 +1,148 @@
+"""Supabase referral signup tests.
+
+These cover the production auth path where referral codes arrive through
+Supabase signUp user metadata and are handled while syncing the local user row.
+"""
+
+import importlib
+
+import pytest
+import pytest_asyncio
+
+from backend.src.api import deps
+from backend.src.services.database.child_profile_repository import ChildProfileRepository
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.referral_repository import ReferralRepository
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.user_repository import UserRepository
+from backend.src.services.supabase_auth import SupabaseClaims
+
+
+@pytest_asyncio.fixture
+async def referral_env(monkeypatch):
+    db = DatabaseManager(":memory:")
+    await db.connect()
+    await init_schema(db)
+
+    user_repo = UserRepository()
+    user_repo._db = db
+    ref_repo = ReferralRepository()
+    ref_repo._db = db
+    child_repo = ChildProfileRepository(db)
+
+    monkeypatch.setattr(deps, "db_manager", db)
+    monkeypatch.setattr(deps, "user_repo", user_repo)
+    monkeypatch.setattr(deps, "referral_repo", ref_repo)
+    monkeypatch.setattr(deps, "child_profile_repo", child_repo)
+
+    user_service_module = importlib.import_module("backend.src.services.user_service")
+    original_repo = user_service_module.user_service._repo
+    original_db = user_service_module.user_service._db
+    monkeypatch.setattr(user_service_module, "referral_repo", ref_repo)
+    user_service_module.user_service._repo = user_repo
+    user_service_module.user_service._db = db
+
+    yield {
+        "db": db,
+        "user_repo": user_repo,
+        "ref_repo": ref_repo,
+        "user_service_module": user_service_module,
+        "original_repo": original_repo,
+        "original_db": original_db,
+    }
+
+    user_service_module.user_service._repo = original_repo
+    user_service_module.user_service._db = original_db
+    await db.disconnect()
+
+
+def _claims(
+    *,
+    sub: str,
+    email: str,
+    referral_code: str | None = None,
+    email_confirmed: bool = False,
+) -> SupabaseClaims:
+    return SupabaseClaims(
+        sub=sub,
+        email=email,
+        email_confirmed=email_confirmed,
+        referral_code=referral_code,
+        role="parent",
+    )
+
+
+async def _create_referrer(user_repo: UserRepository):
+    return await user_repo.create_user(
+        username="referrer",
+        email="referrer@test.com",
+        password_hash="hash",
+        role="parent",
+        consent_status="not_required",
+    )
+
+
+@pytest.mark.asyncio
+async def test_supabase_signup_metadata_creates_pending_referral(referral_env):
+    referrer = await _create_referrer(referral_env["user_repo"])
+
+    user = await deps._get_or_create_supabase_user(
+        _claims(
+            sub="supabase-referred",
+            email="referred@test.com",
+            referral_code=referrer.referral_code,
+            email_confirmed=False,
+        )
+    )
+
+    assert user is not None
+    assert user.referred_by == referrer.referral_code
+
+    referral = await referral_env["ref_repo"].get_referral_by_referred_user(user.user_id)
+    assert referral is not None
+    assert referral["referrer_user_id"] == referrer.user_id
+    assert referral["referral_code"] == referrer.referral_code
+    assert referral["is_qualified"] == 0
+
+
+@pytest.mark.asyncio
+async def test_supabase_confirmed_signup_qualifies_and_promotes_at_threshold(
+    referral_env,
+):
+    user_repo = referral_env["user_repo"]
+    ref_repo = referral_env["ref_repo"]
+    referrer = await _create_referrer(user_repo)
+
+    for i in range(9):
+        referred = await user_repo.create_user(
+            username=f"existing_ref_{i}",
+            email=f"existing_ref_{i}@test.com",
+            password_hash="hash",
+            role="parent",
+            consent_status="not_required",
+            referred_by=referrer.referral_code,
+        )
+        await ref_repo.create_referral(
+            referrer_user_id=referrer.user_id,
+            referred_user_id=referred.user_id,
+            referral_code=referrer.referral_code,
+        )
+        await ref_repo.qualify_referral(referred.user_id)
+
+    user = await deps._get_or_create_supabase_user(
+        _claims(
+            sub="supabase-tenth-referral",
+            email="tenth@test.com",
+            referral_code=referrer.referral_code,
+            email_confirmed=True,
+        )
+    )
+
+    assert user is not None
+    referral = await ref_repo.get_referral_by_referred_user(user.user_id)
+    assert referral is not None
+    assert referral["is_qualified"] == 1
+
+    promoted = await user_repo.get_by_id(referrer.user_id)
+    assert promoted is not None
+    assert promoted.membership_tier == "plus"

--- a/frontend/src/api/services/authService.supabase.test.ts
+++ b/frontend/src/api/services/authService.supabase.test.ts
@@ -1,0 +1,62 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("authService Supabase referrals", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("passes referral code through Supabase signUp metadata", async () => {
+    vi.stubGlobal("window", {
+      location: {
+        origin: "http://localhost:5173",
+      },
+    });
+
+    const signUp = vi.fn().mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
+
+    vi.doMock("../client", () => ({
+      default: {
+        post: vi.fn(),
+        get: vi.fn(),
+      },
+    }));
+
+    vi.doMock("@/lib/supabase", () => ({
+      default: {
+        auth: {
+          signUp,
+        },
+      },
+      isSupabaseEnabled: () => true,
+    }));
+
+    const { authService } = await import("./authService");
+
+    await authService.register({
+      username: "friend",
+      email: "friend@test.com",
+      password: "password123",
+      referral_code: "abc12345",
+    });
+
+    expect(signUp).toHaveBeenCalledWith({
+      email: "friend@test.com",
+      password: "password123",
+      options: {
+        emailRedirectTo: window.location.origin,
+        data: expect.objectContaining({
+          username: "friend",
+          display_name: "friend",
+          role: "parent",
+          referral_code: "abc12345",
+        }),
+      },
+    });
+  });
+});

--- a/frontend/src/api/services/authService.test.ts
+++ b/frontend/src/api/services/authService.test.ts
@@ -68,6 +68,46 @@ describe("authService registration ownership", () => {
     });
   });
 
+  it("passes referral code during legacy registration", async () => {
+    const response = {
+      user: {
+        user_id: "u2",
+        username: "friend",
+        email: "friend@test.com",
+        display_name: "Friend",
+        avatar_url: null,
+        is_active: true,
+        is_verified: false,
+        role: "parent",
+        created_at: "2026-01-01T00:00:00",
+        last_login_at: null,
+        membership_tier: "free",
+        referral_code: "friend01",
+      },
+      token: {
+        access_token: "token",
+        token_type: "bearer",
+        expires_in: 3600,
+      },
+    };
+    vi.mocked(apiClient.post).mockResolvedValueOnce({ data: response });
+
+    await authService.register({
+      username: "friend",
+      email: "friend@test.com",
+      password: "password123",
+      referral_code: "abc12345",
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith("/users/register", {
+      username: "friend",
+      email: "friend@test.com",
+      password: "password123",
+      referral_code: "abc12345",
+      role: "parent",
+    });
+  });
+
   it("supports parent approval endpoints", async () => {
     vi.mocked(apiClient.post)
       .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary
Fixes the production Supabase referral reward path so invite links can create referral records and confirmed referred users count toward Plus promotion. The backend was creating the referral, then calling the upgrade helper with the referrer id instead of the referred user id, so threshold promotion could be skipped.

## Changes
- Pass the referred Supabase user id into referral qualification and upgrade checks.
- Add backend regression tests for Supabase referral metadata, pending referrals, qualification, and Plus promotion at the 10-referral threshold.
- Add frontend tests for referral codes in both legacy registration and Supabase signUp metadata.

## Testing
- backend/.venv/bin/python -m pytest backend/tests/api/test_supabase_referrals.py -vv
- backend/.venv/bin/python -m pytest backend/tests/api/test_registration_referral.py backend/tests/api/test_referral_status.py backend/tests/test_referral_data_model.py backend/tests/contracts/test_referral_repository_contract.py -q
- npm test -- authService.test.ts authService.supabase.test.ts

## Agent / MCP Impact
No agent or MCP behavior changes.

## Related Issues
Related to #425
**Parent Epic**: #346