### PR TITLE
feat(my-agent): surface recurring-character chip on chat panel

### DIFF
--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -32,9 +32,10 @@ import {
   X,
 } from "lucide-react";
 import { agentService } from "@/api/services/agentService";
+import { memoryService } from "@/api/services/memoryService";
 import { useLaunchFlowNavigation } from "@/hooks/useLaunchFlowNavigation";
 import type { Agent } from "@/types/agent";
-import type { AgeGroup } from "@/types/api";
+import type { AgeGroup, MemoryCharacter } from "@/types/api";
 import type {
   SSEErrorData,
   SSELaunchFlowData,
@@ -48,6 +49,10 @@ import {
   settleAssistantMessage,
   type ChatMessage,
 } from "./chatMessageState";
+import {
+  chipPrefillForCharacter,
+  pickRecurringCharacter,
+} from "./recurringCharacter";
 
 interface Props {
   agent: Agent;
@@ -129,6 +134,8 @@ export default function AgentChatPanel({
   const [statusText, setStatusText] = useState<string | null>(null);
   const [toolText, setToolText] = useState<string | null>(null);
   const [errorText, setErrorText] = useState<string | null>(null);
+  const [recurringCharacter, setRecurringCharacter] =
+    useState<MemoryCharacter | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -143,6 +150,33 @@ export default function AgentChatPanel({
   useEffect(() => {
     return () => abortRef.current?.abort();
   }, []);
+
+  // Fetch recurring characters for the active child to surface a
+  // "Remember…" chip above the composer (#560). Cancelled on
+  // child-id change so a slow response for a previous child can't
+  // overwrite the next child's chip — the same active-child precedent
+  // we follow across creation surfaces (#548).
+  useEffect(() => {
+    if (!childId) {
+      setRecurringCharacter(null);
+      return;
+    }
+    let cancelled = false;
+    memoryService
+      .getCharacters(childId)
+      .then((response) => {
+        if (cancelled) return;
+        setRecurringCharacter(pickRecurringCharacter(response.characters));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // Non-critical surface — hide the chip on failure.
+        setRecurringCharacter(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [childId]);
 
   const tail = messages[messages.length - 1]?.text ?? "";
   useEffect(() => {
@@ -172,6 +206,11 @@ export default function AgentChatPanel({
   const useStarter = (prompt: string) => {
     setDraft(prompt);
     setTimeout(() => textareaRef.current?.focus(), 0);
+  };
+
+  const useRecurringCharacter = () => {
+    if (!recurringCharacter) return;
+    useStarter(chipPrefillForCharacter(recurringCharacter.name));
   };
 
   const cancelStream = () => {
@@ -414,6 +453,19 @@ export default function AgentChatPanel({
         <label htmlFor="agent-chat-message" className="sr-only">
           Message {agent.agent_name}
         </label>
+        {recurringCharacter && !isStreaming && (
+          <div className="mb-2">
+            <button
+              type="button"
+              onClick={useRecurringCharacter}
+              className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-900 transition-colors hover:border-amber-400 hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-500"
+              title={`Chat about ${recurringCharacter.name}`}
+            >
+              <Sparkles size={12} className="text-amber-500" />
+              Remember {recurringCharacter.name}?
+            </button>
+          </div>
+        )}
         {image && (
           <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-violet-100 bg-violet-50 px-3 py-1.5 text-xs text-violet-800">
             <span className="truncate">{image.name}</span>

--- a/frontend/src/pages/MyAgentPage/recurringCharacter.test.ts
+++ b/frontend/src/pages/MyAgentPage/recurringCharacter.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  chipPrefillForCharacter,
+  pickRecurringCharacter,
+} from "./recurringCharacter";
+import type { MemoryCharacter } from "@/types/api";
+
+function mkChar(overrides: Partial<MemoryCharacter>): MemoryCharacter {
+  return {
+    name: "Sparkle",
+    description: null,
+    visual_features: null,
+    traits: null,
+    appearance_count: 2,
+    first_seen_at: "2026-01-01T00:00:00",
+    last_seen_at: "2026-01-02T00:00:00",
+    ...overrides,
+  };
+}
+
+describe("pickRecurringCharacter", () => {
+  it("returns null when the input is null or empty", () => {
+    expect(pickRecurringCharacter(null)).toBeNull();
+    expect(pickRecurringCharacter(undefined)).toBeNull();
+    expect(pickRecurringCharacter([])).toBeNull();
+  });
+
+  it("returns null when no character has appeared at least twice", () => {
+    expect(
+      pickRecurringCharacter([
+        mkChar({ name: "Lightning", appearance_count: 1 }),
+        mkChar({ name: "Comet", appearance_count: 1 }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("picks the character with the highest appearance_count", () => {
+    const winner = pickRecurringCharacter([
+      mkChar({ name: "Sparkle", appearance_count: 2 }),
+      mkChar({ name: "Lightning", appearance_count: 5 }),
+      mkChar({ name: "Comet", appearance_count: 3 }),
+    ]);
+    expect(winner?.name).toBe("Lightning");
+  });
+
+  it("breaks count ties by most-recent last_seen_at", () => {
+    const winner = pickRecurringCharacter([
+      mkChar({
+        name: "Sparkle",
+        appearance_count: 4,
+        last_seen_at: "2026-01-01T00:00:00",
+      }),
+      mkChar({
+        name: "Lightning",
+        appearance_count: 4,
+        last_seen_at: "2026-03-01T00:00:00",
+      }),
+    ]);
+    expect(winner?.name).toBe("Lightning");
+  });
+
+  it("skips characters with empty names even when count is high", () => {
+    const winner = pickRecurringCharacter([
+      mkChar({ name: "", appearance_count: 10 }),
+      mkChar({ name: "Sparkle", appearance_count: 2 }),
+    ]);
+    expect(winner?.name).toBe("Sparkle");
+  });
+
+  it("respects the 2-appearance floor exactly (>= 2)", () => {
+    expect(
+      pickRecurringCharacter([mkChar({ appearance_count: 2 })])?.name,
+    ).toBe("Sparkle");
+    expect(
+      pickRecurringCharacter([mkChar({ appearance_count: 1 })]),
+    ).toBeNull();
+  });
+});
+
+describe("chipPrefillForCharacter", () => {
+  it("composes a clear, child-friendly opener", () => {
+    expect(chipPrefillForCharacter("Sparkle the Brave Lion")).toBe(
+      "Tell me more about Sparkle the Brave Lion",
+    );
+  });
+});

--- a/frontend/src/pages/MyAgentPage/recurringCharacter.ts
+++ b/frontend/src/pages/MyAgentPage/recurringCharacter.ts
@@ -1,0 +1,42 @@
+/**
+ * Recurring character chip selector (#560).
+ *
+ * Pure helper extracted so the chip-selection rule can be unit-tested
+ * without a DOM — the project does not ship @testing-library/react, so
+ * UI logic that lives in components is exercised through a pure
+ * function instead.
+ *
+ * Rule: a character is chip-worthy only if it has appeared at least
+ * twice. Among chip-worthy characters, the one with the most
+ * appearances wins. Ties broken by `last_seen_at` (most-recent first)
+ * so a tied "favourite" feels current to the child.
+ *
+ * The 2-appearance floor is deliberate: a one-off character isn't a
+ * pattern, and the chip is meant to surface continuity, not noise.
+ */
+
+import type { MemoryCharacter } from "@/types/api";
+
+const RECURRING_THRESHOLD = 2;
+
+export function pickRecurringCharacter(
+  characters: readonly MemoryCharacter[] | null | undefined,
+): MemoryCharacter | null {
+  if (!characters || characters.length === 0) return null;
+  const recurring = characters.filter(
+    (c) => (c.appearance_count ?? 0) >= RECURRING_THRESHOLD && Boolean(c.name),
+  );
+  if (recurring.length === 0) return null;
+
+  // Sort by appearance_count desc, then last_seen_at desc.
+  const sorted = [...recurring].sort((a, b) => {
+    const byCount = (b.appearance_count ?? 0) - (a.appearance_count ?? 0);
+    if (byCount !== 0) return byCount;
+    return (b.last_seen_at ?? "").localeCompare(a.last_seen_at ?? "");
+  });
+  return sorted[0] ?? null;
+}
+
+export function chipPrefillForCharacter(name: string): string {
+  return `Tell me more about ${name}`;
+}


### PR DESCRIPTION
## Summary

Adds a small **"Remember Sparkle?"** chip above the composer on `/my-agent`. Tap → prefills the chat textbox with `Tell me more about <name>` and focuses the input. No auto-submit, no destructive controls.

- Pure helper `pickRecurringCharacter` selects the top character with `appearance_count >= 2`. Ties broken by `last_seen_at` so a tied "favourite" feels current.
- `AgentChatPanel` fetches `memoryService.getCharacters(childId)` on mount and re-fetches on active-child change. Stale responses are cancelled so a slow previous-child response can't overwrite the new child's chip (`#548` active-child precedent).
- Failure path hides the chip silently — non-critical surface, never blocks chat.
- No new API endpoint — reuses `GET /api/v1/memory/characters/{child_id}` already implemented under §3.5.

## Test plan

- [x] `recurringCharacter.test.ts` — 7 unit tests covering: null/empty input, sub-threshold characters, count tie-breakers, empty-name skip, and the exact `>= 2` floor.
- [x] `npx tsc --noEmit` clean.
- [x] All 16 MyAgentPage tests pass.
- [ ] Manual visual verification on `/my-agent` against a seeded child with a recurring character (deferred to PR review).

## Independence from #558 / #559

This PR does not depend on the backend memory wiring work (#558, #559). The chip reads from the existing memory endpoint and works regardless of whether the proxy prompt has been updated — though the chip's user-visible value increases once the backend buddy is also memory-aware.

## Out of Scope

- Multiple chips per turn.
- Chip for prior stories (v1 covers recurring characters only).
- Memory deletion UI on `/my-agent` (stays on Profile → Memory tab).

Fixes #560
Parent Epic: #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)