### PR TITLE
feat(my-agent): inject factual memory (preferences) into buddy chat

### DIFF
--- a/backend/src/agents/my_agent_proxy.py
+++ b/backend/src/agents/my_agent_proxy.py
@@ -48,8 +48,15 @@ from .interactive_story_agent import (
 from .kids_daily_agent import generate_kids_daily_episode
 from ..mcp_servers import check_content_safety
 from ..mcp_servers.tts_generator_server import generate_story_audio
-from ..services.database import agent_chat_repo, agent_repo, session_repo, usage_repo
+from ..services.database import (
+    agent_chat_repo,
+    agent_repo,
+    preference_repo,
+    session_repo,
+    usage_repo,
+)
 from ..services.my_agent_context import build_my_agent_context
+from ..services.my_agent_memory import build_factual_memory_prompt
 from ..services.story_memory import get_story_memory_prompt
 from ..utils.model_config import get_claude_agent_model
 
@@ -825,6 +832,7 @@ def _build_user_prompt(
     age_group: Optional[str] = None,
     interests: Optional[list[str]] = None,
     story_memory: str = "",
+    factual_memory: str = "",
 ) -> str:
     """Build the per-turn user prompt with a routing hint reminder.
 
@@ -836,6 +844,11 @@ def _build_user_prompt(
     produced by ``story_memory.get_story_memory_prompt`` and is already
     self-formatted with ``**Story Memory**`` / ``**Recurring Characters**``
     headers, so the empty-safe contract is "empty string in, no header out".
+
+    ``factual_memory`` is the same shape for the preference layer
+    (#559) — produced by ``my_agent_memory.format_factual_memory`` and
+    appended next to ``story_memory`` so the buddy sees the child's
+    stable interests + recent themes.
     """
     profile_lines = ""
     if child_id or age_group or interests:
@@ -847,7 +860,7 @@ Active child profile:
 - interests: {", ".join(child_interests) if child_interests else "adventure"}
 """
 
-    memory_block = story_memory if story_memory else ""
+    memory_block = (story_memory or "") + (factual_memory or "")
 
     return f"""
 {my_agent_context}
@@ -1055,6 +1068,10 @@ async def stream_my_agent_chat(
     except Exception:  # pragma: no cover - non-critical, degrade gracefully
         story_memory_block = ""
 
+    factual_memory_block = await build_factual_memory_prompt(
+        user_id, child_id, preference_repo=preference_repo
+    )
+
     prompt = _build_user_prompt(
         my_agent_context=my_agent_context,
         history=history,
@@ -1064,6 +1081,7 @@ async def stream_my_agent_chat(
         age_group=child_age_group,
         interests=child_interests,
         story_memory=story_memory_block,
+        factual_memory=factual_memory_block,
     )
 
     allowed_tools = [

--- a/backend/src/services/my_agent_memory.py
+++ b/backend/src/services/my_agent_memory.py
@@ -1,0 +1,118 @@
+"""Factual memory helper for the My Agent buddy (#559).
+
+Turns a normalized child preference profile (themes + interests +
+recent_choices) into a small empty-safe markdown block that
+``my_agent_proxy`` appends to every chat turn. The buddy uses this to
+say things like "I know you love dinosaurs" without needing access to
+agent configuration.
+
+Episodic + semantic memory (past stories + recurring characters) is
+already covered by ``story_memory.get_story_memory_prompt`` (#558), so
+this helper deliberately scopes to the factual layer only — no
+duplication, no header collisions.
+
+Parent Epic: #557 (Buddy Memory Wiring)
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+# Prompt-size bound: never inject more than ``N`` labels per bucket so
+# the prompt stays small even after months of accumulated preference
+# data. The hard cap is the dial we want PMs to think in (3 keeps
+# things crisp; raising to 5 should be a deliberate decision).
+_MAX_LABELS_PER_BUCKET = 3
+
+
+def _top_labels(scores: Optional[Dict[str, Any]], limit: int) -> List[str]:
+    """Return the top ``limit`` labels by descending score.
+
+    Defensive against bad inputs — ``scores`` may be ``None`` (no row
+    yet), an empty dict (no signal), or contain non-numeric values from
+    a corrupted profile. None of those cases should raise mid-chat.
+    """
+    if not isinstance(scores, dict) or not scores:
+        return []
+    safe_items: List[tuple[str, float]] = []
+    for label, raw in scores.items():
+        if not isinstance(label, str) or not label.strip():
+            continue
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            continue
+        safe_items.append((label.strip(), value))
+    safe_items.sort(key=lambda item: item[1], reverse=True)
+    return [label for label, _ in safe_items[:limit]]
+
+
+def format_factual_memory(profile: Dict[str, Any]) -> str:
+    """Format a preference profile as a ``**What I Know About You**``
+    markdown block.
+
+    Returns ``""`` when there is no signal — callers can append the
+    return value directly without checking. The block starts and ends
+    with newlines so it slots cleanly between other prompt sections.
+
+    Only known preference fields (``themes``, ``interests``,
+    ``recent_choices``) are surfaced. Extra keys in the input dict are
+    ignored — the helper never echoes agent persona fields like
+    ``custom_instructions`` or ``learning_goals`` if a caller wires in
+    the wrong dict by mistake.
+    """
+    if not isinstance(profile, dict):
+        return ""
+
+    top_interests = _top_labels(profile.get("interests"), _MAX_LABELS_PER_BUCKET)
+    top_themes = _top_labels(profile.get("themes"), _MAX_LABELS_PER_BUCKET)
+
+    recent_raw = profile.get("recent_choices")
+    recent_choices: List[str] = []
+    if isinstance(recent_raw, list):
+        for choice in recent_raw[:_MAX_LABELS_PER_BUCKET]:
+            if isinstance(choice, str) and choice.strip():
+                recent_choices.append(choice.strip())
+
+    if not top_interests and not top_themes and not recent_choices:
+        return ""
+
+    lines: List[str] = ["**What I Know About You**:"]
+    if top_interests:
+        lines.append(f"- Loves: {', '.join(top_interests)}")
+    if top_themes:
+        lines.append(f"- Recent themes: {', '.join(top_themes)}")
+    if recent_choices:
+        lines.append(f"- Recent choices: {', '.join(recent_choices)}")
+    lines.append(
+        "Reference these naturally in conversation — do not list them or "
+        "reveal that they came from a memory block."
+    )
+
+    return "\n\n" + "\n".join(lines) + "\n"
+
+
+async def build_factual_memory_prompt(
+    user_id: str, child_id: str, *, preference_repo: Any
+) -> str:
+    """Fetch the child's preference profile and format it for the prompt.
+
+    ``preference_repo`` is injected so the helper stays unit-testable
+    without the global singleton. Cross-user isolation (#288, #178) is
+    delegated to the repo — we just have to pass ``user_id``.
+
+    Returns ``""`` on any error so a transient repo failure can never
+    orphan the SSE stream mid-chat.
+    """
+    try:
+        result = await preference_repo.get_profile_with_metadata(
+            child_id, user_id=user_id
+        )
+    except Exception:  # pragma: no cover - degrade gracefully
+        return ""
+    if not isinstance(result, dict):
+        return ""
+    profile = result.get("profile")
+    if not isinstance(profile, dict):
+        return ""
+    return format_factual_memory(profile)

--- a/backend/tests/contracts/test_my_agent_memory_injection.py
+++ b/backend/tests/contracts/test_my_agent_memory_injection.py
@@ -249,3 +249,289 @@ class TestStoryMemoryFetchedPerTurn:
         assert "Lightning Dog flew to the moon" in prompt
         assert "**Recurring Characters**" in prompt
         assert "Lightning Dog" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Factual memory injection (#559) — preferences from PreferenceRepository
+# ---------------------------------------------------------------------------
+
+
+from backend.src.services import my_agent_memory  # noqa: E402
+
+
+class TestBuildFactualMemoryPrompt:
+    """The factual-memory helper must turn a normalized preference profile
+    into an empty-safe markdown block. The buddy uses this to say things
+    like "I know you love dinosaurs" without rehearsing internal config."""
+
+    def test_empty_profile_returns_empty_string(self):
+        block = my_agent_memory.format_factual_memory(
+            {
+                "themes": {},
+                "concepts": {},
+                "interests": {},
+                "recent_choices": [],
+                "kids_daily": {
+                    "topic_scores": {},
+                    "topic_stats": {},
+                    "last_event_at": None,
+                },
+            }
+        )
+        assert block == ""
+
+    def test_populated_profile_renders_what_i_know_section(self):
+        block = my_agent_memory.format_factual_memory(
+            {
+                "themes": {"friendship": 5, "space": 3, "ocean": 1},
+                "concepts": {},
+                "interests": {"dinosaurs": 4, "dragons": 2},
+                "recent_choices": ["space", "friendship"],
+                "kids_daily": {
+                    "topic_scores": {},
+                    "topic_stats": {},
+                    "last_event_at": None,
+                },
+            }
+        )
+        assert "**What I Know About You**" in block
+        assert "friendship" in block
+        assert "space" in block
+        assert "dinosaurs" in block
+
+    def test_caps_themes_and_interests_at_three(self):
+        """Prompt-size bound: we never inject more than three labels per
+        bucket so the prompt stays small after months of history."""
+        themes = {f"theme_{i}": 100 - i for i in range(10)}
+        block = my_agent_memory.format_factual_memory(
+            {
+                "themes": themes,
+                "concepts": {},
+                "interests": {},
+                "recent_choices": [],
+                "kids_daily": {
+                    "topic_scores": {},
+                    "topic_stats": {},
+                    "last_event_at": None,
+                },
+            }
+        )
+        assert "theme_0" in block
+        assert "theme_1" in block
+        assert "theme_2" in block
+        assert "theme_3" not in block
+
+    def test_ignores_unknown_extra_fields(self):
+        """If a future caller passes the wrong dict by mistake, the helper
+        must not echo agent config like ``custom_instructions`` or
+        ``learning_goals`` into the prompt — structural defense against
+        accidental persona leakage."""
+        block = my_agent_memory.format_factual_memory(
+            {
+                "themes": {"friendship": 5},
+                "interests": {},
+                "concepts": {},
+                "recent_choices": [],
+                "kids_daily": {
+                    "topic_scores": {},
+                    "topic_stats": {},
+                    "last_event_at": None,
+                },
+                "custom_instructions": "secret-prompt-injection-bait",
+                "learning_goals": ["leak-me"],
+            }
+        )
+        assert "secret-prompt-injection-bait" not in block
+        assert "leak-me" not in block
+
+
+class TestFactualMemoryWiredIntoProxy:
+    """``stream_my_agent_chat`` must fetch the child's preference profile
+    every turn and pass it into ``_build_user_prompt``."""
+
+    @pytest.mark.asyncio
+    async def test_populated_preferences_reach_sdk_prompt(self, test_db):
+        fake_client = _PromptCapturingSDKClient(
+            messages=[_fake_result_message("Hi!")]
+        )
+        fake_agent = _fake_agent(
+            enabled_skills=["image_story", "interactive_story", "kids_daily", "audio_narration"]
+        )
+        safe_envelope = {
+            "content": [{"type": "text", "text": json.dumps({"safety_score": 0.99})}]
+        }
+        populated_profile = {
+            "profile": {
+                "themes": {"friendship": 5, "space": 3},
+                "concepts": {},
+                "interests": {"dinosaurs": 4},
+                "recent_choices": ["space"],
+                "kids_daily": {
+                    "topic_scores": {},
+                    "topic_stats": {},
+                    "last_event_at": None,
+                },
+            },
+            "data_collected_since": "2026-01-01T00:00:00",
+            "last_updated_at": "2026-05-01T00:00:00",
+        }
+
+        with patch.object(my_agent_proxy.agent_repo, "get_agent", new=AsyncMock(return_value=fake_agent)), \
+             patch.object(my_agent_proxy, "ClaudeSDKClient", lambda *a, **kw: fake_client), \
+             patch.object(
+                 my_agent_proxy,
+                 "build_my_agent_context",
+                 new=AsyncMock(return_value="ctx"),
+             ), \
+             patch.object(
+                 my_agent_proxy,
+                 "get_story_memory_prompt",
+                 new=AsyncMock(return_value=""),
+             ), \
+             patch.object(
+                 my_agent_proxy.preference_repo,
+                 "get_profile_with_metadata",
+                 new=AsyncMock(return_value=populated_profile),
+             ), \
+             patch(
+                 "backend.src.agents.my_agent_proxy.check_content_safety.handler",
+                 new=AsyncMock(return_value=safe_envelope),
+             ):
+            async for _ in my_agent_proxy.stream_my_agent_chat(
+                user_id=_TEST_USER_ID,
+                child_id=_TEST_CHILD_ID,
+                message="hi",
+            ):
+                pass
+
+        prompt = fake_client.captured_prompt
+        assert prompt is not None
+        assert "**What I Know About You**" in prompt
+        assert "friendship" in prompt
+        assert "dinosaurs" in prompt
+
+    @pytest.mark.asyncio
+    async def test_empty_preferences_do_not_leak_header(self, test_db):
+        fake_client = _PromptCapturingSDKClient(
+            messages=[_fake_result_message("Hi!")]
+        )
+        fake_agent = _fake_agent(
+            enabled_skills=["image_story", "interactive_story", "kids_daily", "audio_narration"]
+        )
+        safe_envelope = {
+            "content": [{"type": "text", "text": json.dumps({"safety_score": 0.99})}]
+        }
+        empty_profile = {
+            "profile": {
+                "themes": {},
+                "concepts": {},
+                "interests": {},
+                "recent_choices": [],
+                "kids_daily": {
+                    "topic_scores": {},
+                    "topic_stats": {},
+                    "last_event_at": None,
+                },
+            },
+            "data_collected_since": None,
+            "last_updated_at": None,
+        }
+
+        with patch.object(my_agent_proxy.agent_repo, "get_agent", new=AsyncMock(return_value=fake_agent)), \
+             patch.object(my_agent_proxy, "ClaudeSDKClient", lambda *a, **kw: fake_client), \
+             patch.object(
+                 my_agent_proxy,
+                 "build_my_agent_context",
+                 new=AsyncMock(return_value="ctx"),
+             ), \
+             patch.object(
+                 my_agent_proxy,
+                 "get_story_memory_prompt",
+                 new=AsyncMock(return_value=""),
+             ), \
+             patch.object(
+                 my_agent_proxy.preference_repo,
+                 "get_profile_with_metadata",
+                 new=AsyncMock(return_value=empty_profile),
+             ), \
+             patch(
+                 "backend.src.agents.my_agent_proxy.check_content_safety.handler",
+                 new=AsyncMock(return_value=safe_envelope),
+             ):
+            async for _ in my_agent_proxy.stream_my_agent_chat(
+                user_id=_TEST_USER_ID,
+                child_id=_TEST_CHILD_ID,
+                message="hi",
+            ):
+                pass
+
+        prompt = fake_client.captured_prompt
+        assert prompt is not None
+        assert "**What I Know About You**" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_preference_fetch_scoped_by_user_id(self, test_db):
+        """Cross-user isolation precedent (#288, #178): preference fetch
+        must scope by user_id so user A's themes never leak to user B."""
+        fake_client = _PromptCapturingSDKClient(
+            messages=[_fake_result_message("Hi!")]
+        )
+        fake_agent = _fake_agent(
+            enabled_skills=["image_story", "interactive_story", "kids_daily", "audio_narration"]
+        )
+        safe_envelope = {
+            "content": [{"type": "text", "text": json.dumps({"safety_score": 0.99})}]
+        }
+        pref_mock = AsyncMock(
+            return_value={
+                "profile": {
+                    "themes": {},
+                    "concepts": {},
+                    "interests": {},
+                    "recent_choices": [],
+                    "kids_daily": {
+                        "topic_scores": {},
+                        "topic_stats": {},
+                        "last_event_at": None,
+                    },
+                },
+                "data_collected_since": None,
+                "last_updated_at": None,
+            }
+        )
+
+        with patch.object(my_agent_proxy.agent_repo, "get_agent", new=AsyncMock(return_value=fake_agent)), \
+             patch.object(my_agent_proxy, "ClaudeSDKClient", lambda *a, **kw: fake_client), \
+             patch.object(
+                 my_agent_proxy,
+                 "build_my_agent_context",
+                 new=AsyncMock(return_value="ctx"),
+             ), \
+             patch.object(
+                 my_agent_proxy,
+                 "get_story_memory_prompt",
+                 new=AsyncMock(return_value=""),
+             ), \
+             patch.object(
+                 my_agent_proxy.preference_repo,
+                 "get_profile_with_metadata",
+                 new=pref_mock,
+             ), \
+             patch(
+                 "backend.src.agents.my_agent_proxy.check_content_safety.handler",
+                 new=AsyncMock(return_value=safe_envelope),
+             ):
+            async for _ in my_agent_proxy.stream_my_agent_chat(
+                user_id=_TEST_USER_ID,
+                child_id=_TEST_CHILD_ID,
+                message="hi",
+            ):
+                pass
+
+        pref_mock.assert_awaited_once()
+        args, kwargs = pref_mock.call_args
+        if args:
+            assert args[0] == _TEST_CHILD_ID
+        else:
+            assert kwargs.get("child_id") == _TEST_CHILD_ID
+        assert kwargs.get("user_id") == _TEST_USER_ID

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -578,7 +578,7 @@ Remembers each child's creation history and preferences to enable content contin
 - ✅ **Cross-story memory**: `story_memory.py` injects recent 3 story summaries into agent prompts, supporting cross-story references
 - ✅ **Memory API exposure**: `GET/DELETE /api/v1/memory/preferences/{child_id}` and `GET /api/v1/memory/characters/{child_id}` implemented
 - 🔲 **Frontend memory consumption**: Frontend does not call memory APIs; no character gallery, no preference display, no theme recommendations
-- 🔲 **Buddy memory wiring (§3.11)**: `my_agent_proxy` does not consume `story_memory.py`, `PreferenceRepository`, or `CharacterRepository` — the buddy cannot say "Remember when you and Sparkle went to the moon?". Tracked under the Buddy Memory Wiring epic.
+- ✅ **Buddy memory wiring (§3.11)**: `my_agent_proxy` now injects episodic memory (story_memory) and factual memory (preferences) into every buddy chat turn so the buddy can say "Remember when you and Sparkle went to the moon?" — closing the §3.5 ↔ §3.11 promise.
 - ✅ **Contract test coverage**: PreferenceRepository, preference scoping, preference retention, story memory, and interactive memory contract tests implemented
 - ✅ **Privacy compliance**: `recent_choices` capped at 50 entries, theme scores decay after 6 months, DELETE endpoint clears SQLite + ChromaDB data
 - 🔲 **Theme recommendation engine**: Preference data has been accumulated but no recommendation algorithm exists; no personalized theme suggestions shown to users


### PR DESCRIPTION
## Summary

Builds on #561 (#558 — story memory). Adds the **factual** memory layer so the buddy sees the child's stable interests + recent themes via a new empty-safe `**What I Know About You**` block.

- New helper `backend/src/services/my_agent_memory.py`:
  - `format_factual_memory(profile)` — pure formatter, returns `""` when there is no signal; caps each bucket (interests / themes / recent_choices) at the top 3 by score so the prompt stays bounded.
  - `build_factual_memory_prompt(user_id, child_id, *, preference_repo)` — fetches the profile and formats it; degrades to `""` on any repo error so a transient failure can never orphan the SSE stream.
- `_build_user_prompt` gains a `factual_memory: str = ""` kwarg, appended next to the existing `story_memory` block.
- `stream_my_agent_chat` now calls the new helper per turn and threads the result through.
- Cross-user isolation precedent (#288, #178) preserved.

## Test plan

- [x] 7 new tests in `test_my_agent_memory_injection.py`:
  - `format_factual_memory` returns `""` on empty profile.
  - Populated profile renders `**What I Know About You**` with interests + themes.
  - Caps each bucket at 3 items (prompt-size bound).
  - Ignores unknown extra fields — guards against accidental persona leakage.
  - Proxy wiring: populated preferences reach SDK prompt.
  - Proxy wiring: empty preferences do not leak header.
  - Proxy wiring: preference fetch is scoped by `user_id` (cross-user isolation).
- [x] 134 related tests pass (`test_my_agent_proxy.py` + `test_my_agent_intent_routing.py` + `test_my_agent_memory_injection.py` + `test_preference_repository_contract.py` + `test_preference_scoping.py`).

## Base branch

This PR targets `feat/558-buddy-episodic-memory` because the two stories share the `_build_user_prompt` signature. Once #561 (the #558 PR) merges to main, GitHub will auto-rebase the base of this PR to main.

## PRD

Marks §3.5 "Buddy memory wiring" gap as resolved.

## Out of Scope

- Frontend recurring-character chip — separate story #560 (PR #562).
- Theme recommendation engine — separate §3.5 item.
- Updating preferences from buddy chat turns (factual memory is read-only).

Fixes #559
Parent Epic: #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)