### PR TITLE
feat(my-agent): chat session columns + repo methods + auto-titling (Story A)

### DIFF
--- a/backend/src/agents/my_agent_proxy.py
+++ b/backend/src/agents/my_agent_proxy.py
@@ -957,13 +957,28 @@ async def stream_my_agent_chat(
     chat_session = await agent_chat_repo.get_or_create_session(
         user_id=user_id, child_id=child_id, session_id=session_id
     )
+    # Auto-title the session from the first user message so the sidebar
+    # (#566) shows something meaningful instead of "My Agent Chat" for
+    # every row. Only fires when the title is still empty, so renames and
+    # later turns are never clobbered.
+    session_title = chat_session.title.strip()
+    if not session_title:
+        derived_title = message.strip()[:60]
+        if derived_title:
+            await agent_chat_repo.rename_session(
+                chat_session.session_id, user_id=user_id, title=derived_title
+            )
+            session_title = derived_title
     await agent_chat_repo.add_message(
         session_id=chat_session.session_id, role="user", text=message
     )
 
     yield _sse(
         "session",
-        {"session_id": chat_session.session_id, "story_title": "My Agent Chat"},
+        {
+            "session_id": chat_session.session_id,
+            "story_title": session_title or "My Agent Chat",
+        },
     )
     yield _sse("status", {"status": "started", "message": "Your buddy is thinking..."})
 

--- a/backend/src/services/database/agent_chat_repository.py
+++ b/backend/src/services/database/agent_chat_repository.py
@@ -19,6 +19,14 @@ class AgentChatSession:
     sdk_session_id: Optional[str]
     created_at: str
     updated_at: str
+    title: str = ""
+    last_message_preview: str = ""
+    archived_at: Optional[str] = None
+
+
+# Bound on the assistant-reply snippet stored for the sidebar (#566).
+# Keeps the list query light and the row preview short.
+_PREVIEW_MAX_CHARS = 120
 
 
 @dataclass
@@ -67,6 +75,9 @@ class AgentChatRepository:
             sdk_session_id=None,
             created_at=now,
             updated_at=now,
+            title="",
+            last_message_preview="",
+            archived_at=None,
         )
 
     async def get_session(
@@ -75,7 +86,8 @@ class AgentChatRepository:
         if user_id:
             row = await self._db.fetchone(
                 """
-                SELECT session_id, user_id, child_id, sdk_session_id, created_at, updated_at
+                SELECT session_id, user_id, child_id, sdk_session_id,
+                       title, last_message_preview, archived_at, created_at, updated_at
                 FROM agent_chat_sessions
                 WHERE session_id = ? AND user_id = ?
                 """,
@@ -84,13 +96,140 @@ class AgentChatRepository:
         else:
             row = await self._db.fetchone(
                 """
-                SELECT session_id, user_id, child_id, sdk_session_id, created_at, updated_at
+                SELECT session_id, user_id, child_id, sdk_session_id,
+                       title, last_message_preview, archived_at, created_at, updated_at
                 FROM agent_chat_sessions
                 WHERE session_id = ?
                 """,
                 (session_id,),
             )
         return self._row_to_session(row) if row else None
+
+    async def list_sessions_for_user(
+        self,
+        user_id: str,
+        child_id: Optional[str] = None,
+        *,
+        include_archived: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[AgentChatSession]:
+        """List a user's chat sessions, most-recently-updated first.
+
+        Always scoped by ``user_id`` (required) — cross-user isolation
+        precedent #288 / #178. ``child_id`` narrows further when the
+        active child profile is known. Archived rows are hidden unless
+        ``include_archived`` is set.
+        """
+        clauses = ["user_id = ?"]
+        params: list[Any] = [user_id]
+        if child_id:
+            clauses.append("child_id = ?")
+            params.append(child_id)
+        if not include_archived:
+            clauses.append("archived_at IS NULL")
+        where = " AND ".join(clauses)
+        params.extend([limit, offset])
+        rows = await self._db.fetchall(
+            f"""
+            SELECT session_id, user_id, child_id, sdk_session_id,
+                   title, last_message_preview, archived_at, created_at, updated_at
+            FROM agent_chat_sessions
+            WHERE {where}
+            ORDER BY updated_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            tuple(params),
+        )
+        return [self._row_to_session(row) for row in rows]
+
+    async def list_messages(
+        self,
+        session_id: str,
+        *,
+        user_id: str,
+        limit: int = 200,
+        before_created_at: Optional[str] = None,
+    ) -> list[AgentChatMessage]:
+        """Return a session's full history in chronological order.
+
+        Auth-checked: a session that does not belong to ``user_id``
+        yields ``[]`` (never another user's history). We resolve the
+        owner with one cheap lookup rather than a JOIN so the isolation
+        rule stays obvious at the call site.
+        """
+        owner = await self.get_session(session_id, user_id=user_id)
+        if owner is None:
+            return []
+        if before_created_at:
+            rows = await self._db.fetchall(
+                """
+                SELECT message_id, session_id, role, text, result_metadata, created_at
+                FROM agent_chat_messages
+                WHERE session_id = ? AND created_at < ?
+                ORDER BY created_at ASC
+                LIMIT ?
+                """,
+                (session_id, before_created_at, limit),
+            )
+        else:
+            rows = await self._db.fetchall(
+                """
+                SELECT message_id, session_id, role, text, result_metadata, created_at
+                FROM agent_chat_messages
+                WHERE session_id = ?
+                ORDER BY created_at ASC
+                LIMIT ?
+                """,
+                (session_id, limit),
+            )
+        return [self._row_to_message(row) for row in rows]
+
+    async def rename_session(
+        self, session_id: str, *, user_id: str, title: str
+    ) -> bool:
+        """Set a session's title. No-ops (returns False) for a foreign
+        user_id so a cross-tenant request can never mutate another's row.
+
+        Safety validation of ``title`` is the route layer's job (#568);
+        the repo trusts its caller.
+        """
+        cursor = await self._db.execute(
+            """
+            UPDATE agent_chat_sessions
+            SET title = ?, updated_at = ?
+            WHERE session_id = ? AND user_id = ?
+            """,
+            (title, datetime.now().isoformat(), session_id, user_id),
+        )
+        await self._db.commit()
+        return bool(getattr(cursor, "rowcount", 0))
+
+    async def archive_session(
+        self, session_id: str, *, user_id: str, archived: bool = True
+    ) -> bool:
+        """Soft-hide (or restore) a session. Scoped by user_id."""
+        archived_at = datetime.now().isoformat() if archived else None
+        cursor = await self._db.execute(
+            """
+            UPDATE agent_chat_sessions
+            SET archived_at = ?, updated_at = ?
+            WHERE session_id = ? AND user_id = ?
+            """,
+            (archived_at, datetime.now().isoformat(), session_id, user_id),
+        )
+        await self._db.commit()
+        return bool(getattr(cursor, "rowcount", 0))
+
+    async def delete_session(self, session_id: str, *, user_id: str) -> bool:
+        """Hard-delete a session. Messages cascade via the FK. Scoped by
+        user_id — a foreign request no-ops (returns False)."""
+        cursor = await self._db.execute(
+            "DELETE FROM agent_chat_sessions WHERE session_id = ? AND user_id = ?",
+            (session_id, user_id),
+        )
+        await self._db.commit()
+        return bool(getattr(cursor, "rowcount", 0))
 
     async def set_sdk_session_id(self, session_id: str, sdk_session_id: str) -> None:
         await self._db.execute(
@@ -129,10 +268,23 @@ class AgentChatRepository:
                 now,
             ),
         )
-        await self._db.execute(
-            "UPDATE agent_chat_sessions SET updated_at = ? WHERE session_id = ?",
-            (now, session_id),
-        )
+        # Keep the sidebar preview in sync, but only for buddy replies —
+        # the preview answers "what did my buddy last say?", so user
+        # turns should not overwrite it.
+        if role == "assistant":
+            await self._db.execute(
+                """
+                UPDATE agent_chat_sessions
+                SET updated_at = ?, last_message_preview = ?
+                WHERE session_id = ?
+                """,
+                (now, text[:_PREVIEW_MAX_CHARS], session_id),
+            )
+        else:
+            await self._db.execute(
+                "UPDATE agent_chat_sessions SET updated_at = ? WHERE session_id = ?",
+                (now, session_id),
+            )
         await self._db.commit()
         return AgentChatMessage(
             message_id=message_id,
@@ -167,6 +319,9 @@ class AgentChatRepository:
             sdk_session_id=row.get("sdk_session_id"),
             created_at=row["created_at"],
             updated_at=row["updated_at"],
+            title=row.get("title") or "",
+            last_message_preview=row.get("last_message_preview") or "",
+            archived_at=row.get("archived_at"),
         )
 
     @staticmethod

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -346,6 +346,9 @@ CREATE TABLE IF NOT EXISTS agent_chat_sessions (
     user_id TEXT NOT NULL,
     child_id TEXT NOT NULL,
     sdk_session_id TEXT,
+    title TEXT NOT NULL DEFAULT '',
+    last_message_preview TEXT NOT NULL DEFAULT '',
+    archived_at TEXT,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     FOREIGN KEY(user_id) REFERENCES users(user_id) ON DELETE CASCADE
@@ -574,6 +577,7 @@ async def init_schema(db: "DatabaseManager") -> None:
     await _migrate_create_user_agents_table(db)
     await _migrate_add_user_agent_config_columns(db)
     await _migrate_create_agent_chat_tables(db)
+    await _migrate_add_agent_chat_session_columns(db)
     await _migrate_create_hub_groups_table(db)
     await _migrate_create_hub_group_memberships_table(db)
     await _migrate_create_hub_posts_table(db)
@@ -997,6 +1001,25 @@ async def _migrate_create_agent_chat_tables(db: "DatabaseManager") -> None:
             except Exception:
                 pass
     await db.commit()
+
+
+async def _migrate_add_agent_chat_session_columns(db: "DatabaseManager") -> None:
+    """Migration: Add multi-topic session columns to agent_chat_sessions (#566)."""
+    columns = [
+        ("title", "ALTER TABLE agent_chat_sessions ADD COLUMN title TEXT NOT NULL DEFAULT ''"),
+        ("last_message_preview", "ALTER TABLE agent_chat_sessions ADD COLUMN last_message_preview TEXT NOT NULL DEFAULT ''"),
+        ("archived_at", "ALTER TABLE agent_chat_sessions ADD COLUMN archived_at TEXT"),
+    ]
+    added = False
+    for column_name, ddl in columns:
+        if not await column_exists(db, "agent_chat_sessions", column_name):
+            if not added:
+                print("Migrating agent_chat_sessions: adding multi-topic session columns...")
+                added = True
+            await db.execute(ddl)
+    if added:
+        await db.commit()
+        print("Agent chat session columns migration completed")
 
 
 async def _migrate_create_hub_groups_table(db: "DatabaseManager") -> None:

--- a/backend/tests/contracts/test_agent_chat_repository_contract.py
+++ b/backend/tests/contracts/test_agent_chat_repository_contract.py
@@ -1,0 +1,242 @@
+"""AgentChatRepository session-management contract tests (#566).
+
+Locks the repository layer that powers the multi-topic chat sessions
+sidebar (PRD §3.11.8). The contract:
+
+  - `agent_chat_sessions` carries `title`, `last_message_preview`, and
+    `archived_at` after migration.
+  - `list_sessions_for_user` is scoped by user_id (required) + optional
+    child_id, sorted by `updated_at DESC`, and excludes archived rows by
+    default. Cross-user isolation precedent: #288 / #178.
+  - `list_messages` is auth-checked — a foreign user_id gets `[]`, never
+    another user's history.
+  - `rename_session` / `archive_session` / `delete_session` no-op
+    silently for non-matching user_id (never raise, never mutate).
+  - `add_message` keeps `last_message_preview` in sync for assistant
+    rows only.
+
+Parent Epic: #565
+Issue: #566
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database.agent_chat_repository import (
+    AgentChatRepository,
+)
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.sql_compat import column_exists
+
+
+_USER_A = "user_a"
+_USER_B = "user_b"
+_CHILD_1 = "child_1"
+_CHILD_2 = "child_2"
+
+
+@pytest_asyncio.fixture
+async def repo():
+    db = DatabaseManager(":memory:")
+    await db.connect()
+    await init_schema(db)
+    # Seed two users (FK on agent_chat_sessions.user_id).
+    from datetime import datetime as _dt
+
+    now = _dt.now().isoformat()
+    for uid in (_USER_A, _USER_B):
+        await db.execute(
+            """
+            INSERT INTO users (
+                user_id, username, email, password_hash, display_name,
+                is_active, is_verified, role,
+                membership_tier, referral_code, referred_by,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                uid, uid, f"{uid}@test.com", "h", uid, 1, 1, "child",
+                "free", f"REF_{uid}", None, now, now,
+            ),
+        )
+    await db.commit()
+    yield AgentChatRepository(db=db)
+    await db.disconnect()
+
+
+class TestSchemaColumns:
+    @pytest.mark.asyncio
+    async def test_session_columns_exist_after_migration(self, repo):
+        db = repo._db
+        assert await column_exists(db, "agent_chat_sessions", "title")
+        assert await column_exists(db, "agent_chat_sessions", "last_message_preview")
+        assert await column_exists(db, "agent_chat_sessions", "archived_at")
+
+
+class TestListSessionsForUser:
+    @pytest.mark.asyncio
+    async def test_returns_only_callers_sessions(self, repo):
+        a = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.get_or_create_session(user_id=_USER_B, child_id=_CHILD_1)
+
+        a_sessions = await repo.list_sessions_for_user(_USER_A)
+        ids = {s.session_id for s in a_sessions}
+        assert a.session_id in ids
+        assert len(ids) == 1  # user B's session is not visible to A
+
+    @pytest.mark.asyncio
+    async def test_optional_child_id_filter(self, repo):
+        await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_2)
+
+        only_c1 = await repo.list_sessions_for_user(_USER_A, child_id=_CHILD_1)
+        assert {s.child_id for s in only_c1} == {_CHILD_1}
+
+        both = await repo.list_sessions_for_user(_USER_A)
+        assert {s.child_id for s in both} == {_CHILD_1, _CHILD_2}
+
+    @pytest.mark.asyncio
+    async def test_sorted_by_updated_at_desc(self, repo):
+        first = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        second = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        # Touch `first` so it becomes most-recently updated.
+        await repo.add_message(session_id=first.session_id, role="user", text="hi")
+
+        sessions = await repo.list_sessions_for_user(_USER_A)
+        assert sessions[0].session_id == first.session_id
+        assert sessions[1].session_id == second.session_id
+
+    @pytest.mark.asyncio
+    async def test_excludes_archived_by_default(self, repo):
+        live = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        gone = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.archive_session(gone.session_id, user_id=_USER_A)
+
+        default_list = await repo.list_sessions_for_user(_USER_A)
+        assert {s.session_id for s in default_list} == {live.session_id}
+
+        with_archived = await repo.list_sessions_for_user(
+            _USER_A, include_archived=True
+        )
+        assert {s.session_id for s in with_archived} == {
+            live.session_id,
+            gone.session_id,
+        }
+
+    @pytest.mark.asyncio
+    async def test_pagination(self, repo):
+        created = [
+            await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+            for _ in range(5)
+        ]
+        assert created  # silence linters
+        page = await repo.list_sessions_for_user(_USER_A, limit=2, offset=0)
+        assert len(page) == 2
+        page2 = await repo.list_sessions_for_user(_USER_A, limit=2, offset=2)
+        assert len(page2) == 2
+        # No overlap between pages.
+        assert {s.session_id for s in page}.isdisjoint(
+            {s.session_id for s in page2}
+        )
+
+
+class TestListMessages:
+    @pytest.mark.asyncio
+    async def test_returns_chronological_history(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.add_message(session_id=s.session_id, role="user", text="first")
+        await repo.add_message(session_id=s.session_id, role="assistant", text="second")
+
+        msgs = await repo.list_messages(s.session_id, user_id=_USER_A)
+        assert [m.text for m in msgs] == ["first", "second"]
+
+    @pytest.mark.asyncio
+    async def test_foreign_user_gets_empty_list(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.add_message(session_id=s.session_id, role="user", text="secret")
+
+        leaked = await repo.list_messages(s.session_id, user_id=_USER_B)
+        assert leaked == []
+
+
+class TestAutoTitleAndPreview:
+    @pytest.mark.asyncio
+    async def test_new_session_has_empty_title_and_preview(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        assert s.title == ""
+        assert s.last_message_preview == ""
+        assert s.archived_at is None
+
+    @pytest.mark.asyncio
+    async def test_rename_sets_title(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.rename_session(s.session_id, user_id=_USER_A, title="Dinosaur story")
+        reloaded = await repo.get_session(s.session_id, user_id=_USER_A)
+        assert reloaded.title == "Dinosaur story"
+
+    @pytest.mark.asyncio
+    async def test_add_message_updates_preview_for_assistant_only(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.add_message(session_id=s.session_id, role="user", text="user text")
+        after_user = await repo.get_session(s.session_id, user_id=_USER_A)
+        assert after_user.last_message_preview == ""  # user msgs don't set preview
+
+        await repo.add_message(
+            session_id=s.session_id, role="assistant", text="buddy reply here"
+        )
+        after_assistant = await repo.get_session(s.session_id, user_id=_USER_A)
+        assert after_assistant.last_message_preview == "buddy reply here"
+
+    @pytest.mark.asyncio
+    async def test_preview_truncated_to_120_chars(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        long_reply = "x" * 200
+        await repo.add_message(
+            session_id=s.session_id, role="assistant", text=long_reply
+        )
+        reloaded = await repo.get_session(s.session_id, user_id=_USER_A)
+        assert len(reloaded.last_message_preview) == 120
+
+
+class TestArchiveAndDelete:
+    @pytest.mark.asyncio
+    async def test_archive_then_unarchive(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.archive_session(s.session_id, user_id=_USER_A)
+        archived = await repo.get_session(s.session_id, user_id=_USER_A)
+        assert archived.archived_at is not None
+
+        await repo.archive_session(s.session_id, user_id=_USER_A, archived=False)
+        live = await repo.get_session(s.session_id, user_id=_USER_A)
+        assert live.archived_at is None
+
+    @pytest.mark.asyncio
+    async def test_delete_cascades_to_messages(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.add_message(session_id=s.session_id, role="user", text="hi")
+        await repo.delete_session(s.session_id, user_id=_USER_A)
+
+        assert await repo.get_session(s.session_id, user_id=_USER_A) is None
+        # Messages gone via FK cascade.
+        rows = await repo._db.fetchall(
+            "SELECT message_id FROM agent_chat_messages WHERE session_id = ?",
+            (s.session_id,),
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_foreign_user_cannot_rename_archive_or_delete(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+
+        await repo.rename_session(s.session_id, user_id=_USER_B, title="hijack")
+        await repo.archive_session(s.session_id, user_id=_USER_B)
+        await repo.delete_session(s.session_id, user_id=_USER_B)
+
+        # Untouched: still owned by A, no title, not archived, still exists.
+        survivor = await repo.get_session(s.session_id, user_id=_USER_A)
+        assert survivor is not None
+        assert survivor.title == ""
+        assert survivor.archived_at is None


### PR DESCRIPTION
## Summary

Story A of epic #565 (Multi-Topic Chat Sessions) — the unblocking backend foundation. Adds the schema columns and repository methods the upcoming endpoints (#567 read, #568 write) and frontend store (#569) depend on.

- **Schema**: `title`, `last_message_preview`, `archived_at` on `agent_chat_sessions` — added to the `CREATE TABLE` (fresh installs) and via an idempotent `ALTER` migration (`_migrate_add_agent_chat_session_columns`) for existing DBs.
- **Repository** (`AgentChatRepository`):
  - `list_sessions_for_user(user_id, child_id?, *, include_archived=False, limit=50, offset=0)` — user-scoped, sorted `updated_at DESC`, archived hidden by default, paginated.
  - `list_messages(session_id, *, user_id, ...)` — auth-checked chronological history; foreign user → `[]`.
  - `rename_session`, `archive_session`, `delete_session` — all no-op for a foreign `user_id`.
  - `add_message` keeps `last_message_preview` in sync for assistant rows only.
- **Proxy**: `stream_my_agent_chat` auto-titles a session from the first user message (60-char cap) when the title is empty, and surfaces the real title in the SSE `session` event.

## Test plan

- [x] New `test_agent_chat_repository_contract.py` — 15 tests: schema columns, user-scope isolation, child filter, sort order, archived filter, pagination, message history + foreign-user `[]`, auto-title/preview, archive round-trip, FK cascade on delete, foreign-user no-op for rename/archive/delete.
- [x] Proxy + memory + intent tests still green (110 passed).
- [x] **Pre-existing failures unrelated to this PR**: `test_agent_endpoint_contract.py` + `test_default_child_id_contract.py` fail with `CHILD_PROFILE_NOT_FOUND` on clean `main` too (verified by stashing this PR's changes) — caused by the recently-landed child-profile-ownership feature, not this story.

## Cross-user isolation

Every new query is scoped by `user_id` (precedent #288 / #178). A dedicated test asserts user B cannot read, rename, archive, or delete user A's session.

## Unblocks

- #567 (GET endpoints), #568 (write endpoints) can now build on these repo methods.

Fixes #566
Parent Epic: #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)