### PR TITLE
feat(my-agent): POST/PATCH/DELETE chat session endpoints (Story C)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -1037,6 +1037,18 @@ class AgentChatMessagesResponse(BaseModel):
     messages: List[AgentChatMessageItem] = Field(default_factory=list)
 
 
+class CreateAgentChatSessionRequest(BaseModel):
+    """POST /me/agent/sessions body — start a fresh empty session (#568)."""
+    child_id: str = Field(..., min_length=1, description="Child profile this session belongs to")
+    title: Optional[str] = Field(None, max_length=60, description="Optional initial title")
+
+
+class UpdateAgentChatSessionRequest(BaseModel):
+    """PATCH /me/agent/sessions/{id} body — rename and/or archive (#568)."""
+    title: Optional[str] = Field(None, max_length=60, description="New title; safety-checked when present")
+    archived: Optional[bool] = Field(None, description="Set true to archive, false to restore")
+
+
 # ---------------------------------------------------------------------------
 # Content Hub — groups (#448)
 # ---------------------------------------------------------------------------

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -33,6 +33,8 @@ from ..models import (
     AgentChatSessionListResponse,
     AgentChatSessionSummary,
     AgentResponse,
+    CreateAgentChatSessionRequest,
+    UpdateAgentChatSessionRequest,
     UpsertAgentRequest,
 )
 from ...agents.my_agent_proxy import stream_my_agent_chat
@@ -495,3 +497,124 @@ async def get_agent_session_messages(
             for m in messages
         ],
     )
+
+
+# ---------------------------------------------------------------------------
+# Multi-topic chat sessions — write endpoints (#568)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/sessions",
+    response_model=AgentChatSessionSummary,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a fresh buddy chat session",
+    description="Starts an empty session for (current_user, child_id) before the first message.",
+)
+async def create_agent_session(
+    request: CreateAgentChatSessionRequest,
+    user: UserData = Depends(get_current_user),
+):
+    """Create an empty session. The optional title is safety-checked like
+    a rename so a child cannot seed an unsafe title at creation time."""
+    await require_owned_child_profile(user, request.child_id)
+
+    session = await agent_chat_repo.get_or_create_session(
+        user_id=user.user_id, child_id=request.child_id
+    )
+    title = (request.title or "").strip()
+    if title:
+        await _guard_session_title(title)
+        await agent_chat_repo.rename_session(
+            session.session_id, user_id=user.user_id, title=title
+        )
+        session = await agent_chat_repo.get_session(
+            session.session_id, user_id=user.user_id
+        )
+    return _session_to_summary(session)
+
+
+@router.patch(
+    "/sessions/{session_id}",
+    response_model=AgentChatSessionSummary,
+    summary="Rename and/or archive a buddy chat session",
+    description="Renames (safety-checked) and/or archives a session the caller owns.",
+)
+async def update_agent_session(
+    session_id: str,
+    request: UpdateAgentChatSessionRequest,
+    user: UserData = Depends(get_current_user),
+):
+    """Rename / archive. A foreign or unknown session 404s before any
+    mutation, so a cross-tenant request can never touch another's row."""
+    owner = await agent_chat_repo.get_session(session_id, user_id=user.user_id)
+    if owner is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "SESSION_NOT_FOUND"},
+        )
+
+    if request.title is not None:
+        title = request.title.strip()
+        if not title:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"code": "INVALID_SESSION_TITLE"},
+            )
+        await _guard_session_title(title)
+        await agent_chat_repo.rename_session(
+            session_id, user_id=user.user_id, title=title
+        )
+
+    if request.archived is not None:
+        await agent_chat_repo.archive_session(
+            session_id, user_id=user.user_id, archived=request.archived
+        )
+
+    updated = await agent_chat_repo.get_session(session_id, user_id=user.user_id)
+    return _session_to_summary(updated)
+
+
+@router.delete(
+    "/sessions/{session_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete a buddy chat session",
+    description="Hard-deletes a session the caller owns; messages cascade via FK.",
+)
+async def delete_agent_session(
+    session_id: str,
+    user: UserData = Depends(get_current_user),
+):
+    """Hard delete. A foreign or unknown session 404s; otherwise the row
+    and its messages are removed via the ON DELETE CASCADE FK."""
+    deleted = await agent_chat_repo.delete_session(session_id, user_id=user.user_id)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "SESSION_NOT_FOUND"},
+        )
+    return None
+
+
+async def _guard_session_title(title: str) -> None:
+    """Run the shared safety check on a user-supplied session title.
+
+    Reuses the agent-persona safety bar (0.85) so a session title can't
+    sneak content the persona name couldn't. Fails closed on MCP outage.
+    """
+    try:
+        score = await _run_safety_check(title)
+    except _SafetyUnavailableError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail={"code": "SAFETY_UNAVAILABLE"},
+        )
+    if score < _SAFETY_THRESHOLD:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "code": "UNSAFE_SESSION_TITLE",
+                "reason": "Title did not pass content safety check",
+                "score": score,
+            },
+        )

--- a/backend/tests/contracts/test_agent_chat_sessions_endpoint_contract.py
+++ b/backend/tests/contracts/test_agent_chat_sessions_endpoint_contract.py
@@ -17,6 +17,9 @@ Parent Epic: #565
 
 from __future__ import annotations
 
+import json
+from unittest.mock import AsyncMock, patch
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
@@ -196,4 +199,161 @@ class TestGetSessionMessages:
     @pytest.mark.asyncio
     async def test_unknown_session_returns_404(self, client):
         r = await client.get("/api/v1/me/agent/sessions/does_not_exist/messages")
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Write endpoints (#568)
+# ---------------------------------------------------------------------------
+
+
+def _safety_envelope(score: float) -> dict:
+    return {"content": [{"type": "text", "text": json.dumps({"safety_score": score})}]}
+
+
+class TestCreateSession:
+    @pytest.mark.asyncio
+    async def test_creates_empty_session(self, client):
+        r = await client.post(
+            "/api/v1/me/agent/sessions", json={"child_id": _CHILD_A}
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["child_id"] == _CHILD_A
+        assert body["title"] == ""
+
+    @pytest.mark.asyncio
+    async def test_create_with_unowned_child_404s(self, client):
+        r = await client.post(
+            "/api/v1/me/agent/sessions", json={"child_id": "not_mine"}
+        )
+        assert r.status_code == 404
+        assert r.json()["detail"]["code"] == "CHILD_PROFILE_NOT_FOUND"
+
+    @pytest.mark.asyncio
+    async def test_create_with_safe_title(self, client):
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety.handler",
+            new=AsyncMock(return_value=_safety_envelope(0.99)),
+        ):
+            r = await client.post(
+                "/api/v1/me/agent/sessions",
+                json={"child_id": _CHILD_A, "title": "Dinosaur story"},
+            )
+        assert r.status_code == 201, r.text
+        assert r.json()["title"] == "Dinosaur story"
+
+
+class TestRenameSession:
+    @pytest.mark.asyncio
+    async def test_rename_safe_title(self, client):
+        s = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_A.user_id, child_id=_CHILD_A
+        )
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety.handler",
+            new=AsyncMock(return_value=_safety_envelope(0.99)),
+        ):
+            r = await client.patch(
+                f"/api/v1/me/agent/sessions/{s.session_id}",
+                json={"title": "Space adventure"},
+            )
+        assert r.status_code == 200, r.text
+        assert r.json()["title"] == "Space adventure"
+
+    @pytest.mark.asyncio
+    async def test_unsafe_title_rejected_422_no_mutation(self, client):
+        s = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_A.user_id, child_id=_CHILD_A
+        )
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety.handler",
+            new=AsyncMock(return_value=_safety_envelope(0.10)),
+        ):
+            r = await client.patch(
+                f"/api/v1/me/agent/sessions/{s.session_id}",
+                json={"title": "something scary"},
+            )
+        assert r.status_code == 422
+        assert r.json()["detail"]["code"] == "UNSAFE_SESSION_TITLE"
+        # Title unchanged.
+        reloaded = await agent_chat_repo.get_session(s.session_id, user_id=_USER_A.user_id)
+        assert reloaded.title == ""
+
+    @pytest.mark.asyncio
+    async def test_foreign_session_rename_404(self, client):
+        b_session = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_B.user_id, child_id="other_child"
+        )
+        with patch(
+            "backend.src.api.routes.agents.check_content_safety.handler",
+            new=AsyncMock(return_value=_safety_envelope(0.99)),
+        ):
+            r = await client.patch(
+                f"/api/v1/me/agent/sessions/{b_session.session_id}",
+                json={"title": "hijack"},
+            )
+        assert r.status_code == 404
+        # B's session is untouched.
+        survivor = await agent_chat_repo.get_session(
+            b_session.session_id, user_id=_USER_B.user_id
+        )
+        assert survivor.title == ""
+
+
+class TestArchiveSession:
+    @pytest.mark.asyncio
+    async def test_archive_round_trip(self, client):
+        s = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_A.user_id, child_id=_CHILD_A
+        )
+        r = await client.patch(
+            f"/api/v1/me/agent/sessions/{s.session_id}", json={"archived": True}
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["archived_at"] is not None
+
+        r2 = await client.patch(
+            f"/api/v1/me/agent/sessions/{s.session_id}", json={"archived": False}
+        )
+        assert r2.status_code == 200
+        assert r2.json()["archived_at"] is None
+
+
+class TestDeleteSession:
+    @pytest.mark.asyncio
+    async def test_delete_cascades_to_messages(self, client):
+        s = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_A.user_id, child_id=_CHILD_A
+        )
+        await agent_chat_repo.add_message(
+            session_id=s.session_id, role="user", text="hi"
+        )
+        r = await client.delete(f"/api/v1/me/agent/sessions/{s.session_id}")
+        assert r.status_code == 204
+
+        assert await agent_chat_repo.get_session(
+            s.session_id, user_id=_USER_A.user_id
+        ) is None
+        rows = await agent_chat_repo._db.fetchall(
+            "SELECT message_id FROM agent_chat_messages WHERE session_id = ?",
+            (s.session_id,),
+        )
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_foreign_session_delete_404_no_mutation(self, client):
+        b_session = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_B.user_id, child_id="other_child"
+        )
+        r = await client.delete(f"/api/v1/me/agent/sessions/{b_session.session_id}")
+        assert r.status_code == 404
+        # B's session survives.
+        assert await agent_chat_repo.get_session(
+            b_session.session_id, user_id=_USER_B.user_id
+        ) is not None
+
+    @pytest.mark.asyncio
+    async def test_unknown_session_delete_404(self, client):
+        r = await client.delete("/api/v1/me/agent/sessions/nope")
         assert r.status_code == 404


### PR DESCRIPTION
## Summary

Story C of epic #565 — the write endpoints for session management.

- `POST /me/agent/sessions` — create an empty session for `(current_user, child_id)`; optional `title` is safety-checked.
- `PATCH /me/agent/sessions/{id}` — rename (safety-checked at the 0.85 persona bar) and/or archive/restore. Unsafe title → 422 `UNSAFE_SESSION_TITLE` with no mutation.
- `DELETE /me/agent/sessions/{id}` — hard delete; messages cascade via FK.
- All three return 404 `SESSION_NOT_FOUND` for a foreign/unknown session **before any mutation**.
- New request models: `CreateAgentChatSessionRequest`, `UpdateAgentChatSessionRequest`.

## Test plan

- [x] 10 new tests in `test_agent_chat_sessions_endpoint_contract.py` (16 total in file): create empty / unowned-child 404 / safe title; rename safe / unsafe-422-no-mutation / foreign-404-no-mutation; archive round-trip; delete cascade / foreign-404 / unknown-404.
- [x] Regression: sessions + repo + proxy green (62 passed).

## Depends on

#566 (Story A) and #567 (Story B), both merged to main. Built off fresh main — no stacking.

## Note

Reuses the existing `_run_safety_check` / `_SAFETY_THRESHOLD` so a session title can't sneak content the persona name couldn't. Kept `HTTP_422_UNPROCESSABLE_ENTITY` to match the dominant codebase convention (main.py, kids_daily.py).

Fixes #568
Parent Epic: #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)