### PR TITLE
feat(my-agent): useAgentChatStore + session service methods (Story D)

### DIFF
--- a/frontend/src/api/services/agentService.ts
+++ b/frontend/src/api/services/agentService.ts
@@ -12,7 +12,12 @@ import { AxiosError } from "axios";
 import apiClient from "../client";
 import { consumeSSEStream } from "../utils/sseStream";
 import { getFreshAuthHeaders } from "../authUtils";
-import type { StreamCallbacks } from "@/types/api";
+import type {
+  AgentChatMessagesResponse,
+  AgentChatSessionListResponse,
+  AgentChatSessionSummary,
+  StreamCallbacks,
+} from "@/types/api";
 import type { Agent, AgentChatPayload, UpsertAgentPayload } from "@/types/agent";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "/api/v1";
@@ -93,4 +98,85 @@ export async function streamAgentChat(
   await consumeSSEStream(response, callbacks);
 }
 
-export const agentService = { getAgent, putAgent, streamAgentChat };
+// ---------------------------------------------------------------------------
+// Multi-topic chat sessions (#569). apiClient prefixes /api/v1.
+// ---------------------------------------------------------------------------
+
+export async function listAgentSessions(
+  childId?: string,
+  opts?: { includeArchived?: boolean; limit?: number; offset?: number },
+): Promise<AgentChatSessionListResponse> {
+  const params: Record<string, string | number | boolean> = {};
+  if (childId) params.child_id = childId;
+  if (opts?.includeArchived) params.include_archived = true;
+  if (opts?.limit != null) params.limit = opts.limit;
+  if (opts?.offset != null) params.offset = opts.offset;
+  const r = await apiClient.get<AgentChatSessionListResponse>(
+    "/me/agent/sessions",
+    { params },
+  );
+  return r.data;
+}
+
+export async function getAgentSessionMessages(
+  sessionId: string,
+  opts?: { limit?: number; beforeCreatedAt?: string },
+): Promise<AgentChatMessagesResponse> {
+  const params: Record<string, string | number> = {};
+  if (opts?.limit != null) params.limit = opts.limit;
+  if (opts?.beforeCreatedAt) params.before_created_at = opts.beforeCreatedAt;
+  const r = await apiClient.get<AgentChatMessagesResponse>(
+    `/me/agent/sessions/${sessionId}/messages`,
+    { params },
+  );
+  return r.data;
+}
+
+export async function createAgentSession(
+  childId: string,
+  title?: string,
+): Promise<AgentChatSessionSummary> {
+  const r = await apiClient.post<AgentChatSessionSummary>(
+    "/me/agent/sessions",
+    { child_id: childId, title: title ?? undefined },
+  );
+  return r.data;
+}
+
+export async function renameAgentSession(
+  sessionId: string,
+  title: string,
+): Promise<AgentChatSessionSummary> {
+  const r = await apiClient.patch<AgentChatSessionSummary>(
+    `/me/agent/sessions/${sessionId}`,
+    { title },
+  );
+  return r.data;
+}
+
+export async function archiveAgentSession(
+  sessionId: string,
+  archived: boolean,
+): Promise<AgentChatSessionSummary> {
+  const r = await apiClient.patch<AgentChatSessionSummary>(
+    `/me/agent/sessions/${sessionId}`,
+    { archived },
+  );
+  return r.data;
+}
+
+export async function deleteAgentSession(sessionId: string): Promise<void> {
+  await apiClient.delete(`/me/agent/sessions/${sessionId}`);
+}
+
+export const agentService = {
+  getAgent,
+  putAgent,
+  streamAgentChat,
+  listAgentSessions,
+  getAgentSessionMessages,
+  createAgentSession,
+  renameAgentSession,
+  archiveAgentSession,
+  deleteAgentSession,
+};

--- a/frontend/src/store/__tests__/useAgentChatStore.test.ts
+++ b/frontend/src/store/__tests__/useAgentChatStore.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/services/agentService", () => ({
+  agentService: {
+    listAgentSessions: vi.fn(),
+    getAgentSessionMessages: vi.fn(),
+    createAgentSession: vi.fn(),
+    renameAgentSession: vi.fn(),
+    archiveAgentSession: vi.fn(),
+    deleteAgentSession: vi.fn(),
+  },
+}));
+
+import { agentService } from "@/api/services/agentService";
+import useAgentChatStore from "../useAgentChatStore";
+import type { AgentChatSessionSummary } from "@/types/api";
+
+const mocked = agentService as unknown as Record<string, ReturnType<typeof vi.fn>>;
+
+function session(
+  id: string,
+  overrides: Partial<AgentChatSessionSummary> = {},
+): AgentChatSessionSummary {
+  return {
+    session_id: id,
+    child_id: "c1",
+    title: id,
+    last_message_preview: "",
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00",
+    updated_at: "2026-01-01T00:00:00",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  useAgentChatStore.getState().reset();
+});
+
+afterEach(() => {
+  Object.values(mocked).forEach((fn) => fn.mockReset());
+});
+
+describe("loadSessions", () => {
+  it("populates and sorts sessions by updated_at desc", async () => {
+    mocked.listAgentSessions.mockResolvedValueOnce({
+      sessions: [
+        session("a", { updated_at: "2026-01-01T00:00:00" }),
+        session("b", { updated_at: "2026-03-01T00:00:00" }),
+      ],
+    });
+    await useAgentChatStore.getState().loadSessions("c1");
+    const ids = useAgentChatStore.getState().sessions.map((s) => s.session_id);
+    expect(ids).toEqual(["b", "a"]);
+  });
+
+  it("records an error message on failure", async () => {
+    mocked.listAgentSessions.mockRejectedValueOnce(new Error("boom"));
+    await expect(
+      useAgentChatStore.getState().loadSessions("c1"),
+    ).rejects.toThrow("boom");
+    expect(useAgentChatStore.getState().error).toBe("boom");
+  });
+});
+
+describe("selectSession", () => {
+  it("loads messages and sets currentSessionId", async () => {
+    mocked.getAgentSessionMessages.mockResolvedValueOnce({
+      session_id: "s1",
+      messages: [
+        { message_id: "m1", role: "user", text: "hi", result_metadata: {}, created_at: "t1" },
+        { message_id: "m2", role: "assistant", text: "hello", result_metadata: {}, created_at: "t2" },
+      ],
+    });
+    await useAgentChatStore.getState().selectSession("s1");
+    const st = useAgentChatStore.getState();
+    expect(st.currentSessionId).toBe("s1");
+    expect(st.messages.map((m) => m.text)).toEqual(["hi", "hello"]);
+  });
+});
+
+describe("newSession", () => {
+  it("prepends the created session, selects it, and clears messages", async () => {
+    useAgentChatStore.setState({
+      sessions: [session("old")],
+      messages: [{ id: "x", role: "user", text: "stale" }],
+    });
+    mocked.createAgentSession.mockResolvedValueOnce(session("new"));
+    const created = await useAgentChatStore.getState().newSession("c1");
+    const st = useAgentChatStore.getState();
+    expect(created.session_id).toBe("new");
+    expect(st.sessions[0].session_id).toBe("new");
+    expect(st.currentSessionId).toBe("new");
+    expect(st.messages).toEqual([]);
+  });
+});
+
+describe("renameSession", () => {
+  it("optimistically updates then commits server value", async () => {
+    useAgentChatStore.setState({ sessions: [session("s1", { title: "old" })] });
+    mocked.renameAgentSession.mockResolvedValueOnce(session("s1", { title: "New Title" }));
+    await useAgentChatStore.getState().renameSession("s1", "New Title");
+    expect(useAgentChatStore.getState().sessions[0].title).toBe("New Title");
+  });
+
+  it("rolls back on failure", async () => {
+    useAgentChatStore.setState({ sessions: [session("s1", { title: "old" })] });
+    mocked.renameAgentSession.mockRejectedValueOnce(new Error("nope"));
+    await expect(
+      useAgentChatStore.getState().renameSession("s1", "bad"),
+    ).rejects.toThrow("nope");
+    expect(useAgentChatStore.getState().sessions[0].title).toBe("old");
+  });
+});
+
+describe("archiveSession", () => {
+  it("optimistically removes an archived session from the list", async () => {
+    useAgentChatStore.setState({ sessions: [session("s1"), session("s2")] });
+    mocked.archiveAgentSession.mockResolvedValueOnce(session("s1", { archived_at: "now" }));
+    await useAgentChatStore.getState().archiveSession("s1", true);
+    const ids = useAgentChatStore.getState().sessions.map((s) => s.session_id);
+    expect(ids).toEqual(["s2"]);
+  });
+
+  it("rolls back on failure", async () => {
+    useAgentChatStore.setState({ sessions: [session("s1"), session("s2")] });
+    mocked.archiveAgentSession.mockRejectedValueOnce(new Error("x"));
+    await expect(
+      useAgentChatStore.getState().archiveSession("s1", true),
+    ).rejects.toThrow("x");
+    expect(useAgentChatStore.getState().sessions.map((s) => s.session_id)).toEqual([
+      "s1",
+      "s2",
+    ]);
+  });
+});
+
+describe("deleteSession", () => {
+  it("removes the session and falls back to the next when deleting current", async () => {
+    useAgentChatStore.setState({
+      sessions: [session("s1"), session("s2")],
+      currentSessionId: "s1",
+      messages: [{ id: "m", role: "user", text: "hi" }],
+    });
+    mocked.deleteAgentSession.mockResolvedValueOnce(undefined);
+    mocked.getAgentSessionMessages.mockResolvedValueOnce({
+      session_id: "s2",
+      messages: [],
+    });
+    await useAgentChatStore.getState().deleteSession("s1");
+    const st = useAgentChatStore.getState();
+    expect(st.sessions.map((s) => s.session_id)).toEqual(["s2"]);
+    expect(st.currentSessionId).toBe("s2");
+  });
+
+  it("falls back to null when the last session is deleted", async () => {
+    useAgentChatStore.setState({
+      sessions: [session("only")],
+      currentSessionId: "only",
+    });
+    mocked.deleteAgentSession.mockResolvedValueOnce(undefined);
+    await useAgentChatStore.getState().deleteSession("only");
+    const st = useAgentChatStore.getState();
+    expect(st.sessions).toEqual([]);
+    expect(st.currentSessionId).toBeNull();
+    expect(st.messages).toEqual([]);
+  });
+
+  it("rolls back on failure", async () => {
+    useAgentChatStore.setState({
+      sessions: [session("s1"), session("s2")],
+      currentSessionId: "s1",
+    });
+    mocked.deleteAgentSession.mockRejectedValueOnce(new Error("fail"));
+    await expect(
+      useAgentChatStore.getState().deleteSession("s1"),
+    ).rejects.toThrow("fail");
+    expect(useAgentChatStore.getState().sessions.map((s) => s.session_id)).toEqual([
+      "s1",
+      "s2",
+    ]);
+  });
+});
+
+describe("streaming pipeline", () => {
+  it("appends user message, streams deltas, then settles", () => {
+    const store = useAgentChatStore.getState();
+    store.appendUserMessage("hello buddy");
+    store.appendStreamingDelta("Hi ");
+    store.appendStreamingDelta("there!");
+    let msgs = useAgentChatStore.getState().messages;
+    expect(msgs.map((m) => m.text)).toEqual(["hello buddy", "Hi there!"]);
+    expect(msgs[1].streaming).toBe(true);
+
+    store.settleAssistantMessage("");
+    msgs = useAgentChatStore.getState().messages;
+    expect(msgs[1].streaming).toBe(false);
+  });
+});
+
+describe("adoptServerSession", () => {
+  it("sets currentSessionId only when none is selected", () => {
+    useAgentChatStore.getState().adoptServerSession("server_1");
+    expect(useAgentChatStore.getState().currentSessionId).toBe("server_1");
+    // Does not clobber an existing selection.
+    useAgentChatStore.getState().adoptServerSession("server_2");
+    expect(useAgentChatStore.getState().currentSessionId).toBe("server_1");
+  });
+});
+
+describe("reset", () => {
+  it("clears all state", () => {
+    useAgentChatStore.setState({
+      sessions: [session("s1")],
+      currentSessionId: "s1",
+      messages: [{ id: "m", role: "user", text: "hi" }],
+    });
+    useAgentChatStore.getState().reset();
+    const st = useAgentChatStore.getState();
+    expect(st.sessions).toEqual([]);
+    expect(st.currentSessionId).toBeNull();
+    expect(st.messages).toEqual([]);
+  });
+});

--- a/frontend/src/store/useAgentChatStore.ts
+++ b/frontend/src/store/useAgentChatStore.ts
@@ -1,0 +1,219 @@
+/**
+ * Multi-topic buddy chat session store (#569, epic #565 §3.11.8).
+ *
+ * Owns the session list, the currently-selected session, and that
+ * session's message list. The streaming pipeline in AgentChatPanel
+ * pushes deltas here via appendStreamingDelta / settleAssistantMessage
+ * so the visible history always belongs to exactly one session.
+ *
+ * Mutations are optimistic where the UX benefits (rename, archive,
+ * delete) and roll back to the prior snapshot on API failure — the
+ * sidebar should never show a state the server rejected.
+ */
+
+import { create } from "zustand";
+import { agentService } from "@/api/services/agentService";
+import type { AgentChatSessionSummary } from "@/types/api";
+import {
+  appendAssistantDelta,
+  settleAssistantMessage,
+  type ChatMessage,
+} from "@/pages/MyAgentPage/chatMessageState";
+
+interface AgentChatState {
+  sessions: AgentChatSessionSummary[];
+  currentSessionId: string | null;
+  messages: ChatMessage[];
+  isLoadingSessions: boolean;
+  isLoadingMessages: boolean;
+  error: string | null;
+
+  loadSessions: (childId: string) => Promise<void>;
+  selectSession: (sessionId: string) => Promise<void>;
+  newSession: (childId: string) => Promise<AgentChatSessionSummary>;
+  renameSession: (sessionId: string, title: string) => Promise<void>;
+  archiveSession: (sessionId: string, archived: boolean) => Promise<void>;
+  deleteSession: (sessionId: string) => Promise<void>;
+  // Streaming pipeline hooks (called by AgentChatPanel).
+  appendStreamingDelta: (delta: string) => void;
+  settleAssistantMessage: (text: string) => void;
+  appendUserMessage: (text: string) => void;
+  // Reconcile the server-issued session id from the first SSE `session`
+  // event when the turn started without a selected session.
+  adoptServerSession: (sessionId: string) => void;
+  reset: () => void;
+}
+
+let _counter = 0;
+function nextId(prefix: string): string {
+  _counter += 1;
+  return `${prefix}_${Date.now()}_${_counter}`;
+}
+const nextAssistantId = () => nextId("assistant");
+
+function sortByUpdatedDesc(
+  sessions: AgentChatSessionSummary[],
+): AgentChatSessionSummary[] {
+  return [...sessions].sort((a, b) =>
+    (b.updated_at ?? "").localeCompare(a.updated_at ?? ""),
+  );
+}
+
+const useAgentChatStore = create<AgentChatState>((set, get) => ({
+  sessions: [],
+  currentSessionId: null,
+  messages: [],
+  isLoadingSessions: false,
+  isLoadingMessages: false,
+  error: null,
+
+  loadSessions: async (childId) => {
+    set({ isLoadingSessions: true, error: null });
+    try {
+      const res = await agentService.listAgentSessions(childId);
+      set({ sessions: sortByUpdatedDesc(res.sessions) });
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Failed to load sessions" });
+      throw err;
+    } finally {
+      set({ isLoadingSessions: false });
+    }
+  },
+
+  selectSession: async (sessionId) => {
+    set({ currentSessionId: sessionId, isLoadingMessages: true, error: null });
+    try {
+      const res = await agentService.getAgentSessionMessages(sessionId);
+      // Guard against a race: a newer selectSession may have won while
+      // this request was in flight. Only apply if still current.
+      if (get().currentSessionId !== sessionId) return;
+      set({
+        messages: res.messages.map((m) => ({
+          id: m.message_id,
+          role: m.role,
+          text: m.text,
+        })),
+      });
+    } catch (err) {
+      set({ error: err instanceof Error ? err.message : "Failed to load messages" });
+      throw err;
+    } finally {
+      if (get().currentSessionId === sessionId) {
+        set({ isLoadingMessages: false });
+      }
+    }
+  },
+
+  newSession: async (childId) => {
+    const created = await agentService.createAgentSession(childId);
+    set((state) => ({
+      sessions: [created, ...state.sessions],
+      currentSessionId: created.session_id,
+      messages: [],
+    }));
+    return created;
+  },
+
+  renameSession: async (sessionId, title) => {
+    const prev = get().sessions;
+    // Optimistic: reflect the new title immediately.
+    set({
+      sessions: prev.map((s) =>
+        s.session_id === sessionId ? { ...s, title } : s,
+      ),
+    });
+    try {
+      const updated = await agentService.renameAgentSession(sessionId, title);
+      set((state) => ({
+        sessions: state.sessions.map((s) =>
+          s.session_id === sessionId ? updated : s,
+        ),
+      }));
+    } catch (err) {
+      set({ sessions: prev, error: err instanceof Error ? err.message : "Rename failed" });
+      throw err;
+    }
+  },
+
+  archiveSession: async (sessionId, archived) => {
+    const prev = get().sessions;
+    // Optimistic: archived sessions drop out of the default list.
+    set({
+      sessions: archived
+        ? prev.filter((s) => s.session_id !== sessionId)
+        : prev,
+    });
+    try {
+      await agentService.archiveAgentSession(sessionId, archived);
+    } catch (err) {
+      set({ sessions: prev, error: err instanceof Error ? err.message : "Archive failed" });
+      throw err;
+    }
+  },
+
+  deleteSession: async (sessionId) => {
+    const prev = get().sessions;
+    const wasCurrent = get().currentSessionId === sessionId;
+    const remaining = prev.filter((s) => s.session_id !== sessionId);
+    // Optimistic removal; if we deleted the active session, fall back to
+    // the next one in the list (or an empty "new chat" state).
+    const nextCurrent = wasCurrent
+      ? remaining[0]?.session_id ?? null
+      : get().currentSessionId;
+    set({
+      sessions: remaining,
+      currentSessionId: nextCurrent,
+      messages: wasCurrent ? [] : get().messages,
+    });
+    try {
+      await agentService.deleteAgentSession(sessionId);
+      // If we fell back to another session, load its history.
+      if (wasCurrent && nextCurrent) {
+        await get().selectSession(nextCurrent);
+      }
+    } catch (err) {
+      set({
+        sessions: prev,
+        currentSessionId: get().currentSessionId,
+        error: err instanceof Error ? err.message : "Delete failed",
+      });
+      throw err;
+    }
+  },
+
+  appendUserMessage: (text) => {
+    set((state) => ({
+      messages: [...state.messages, { id: nextId("user"), role: "user", text }],
+    }));
+  },
+
+  appendStreamingDelta: (delta) => {
+    set((state) => ({
+      messages: appendAssistantDelta(state.messages, delta, nextAssistantId),
+    }));
+  },
+
+  settleAssistantMessage: (text) => {
+    set((state) => ({
+      messages: settleAssistantMessage(state.messages, text, nextAssistantId),
+    }));
+  },
+
+  adoptServerSession: (sessionId) => {
+    if (!get().currentSessionId) {
+      set({ currentSessionId: sessionId });
+    }
+  },
+
+  reset: () =>
+    set({
+      sessions: [],
+      currentSessionId: null,
+      messages: [],
+      isLoadingSessions: false,
+      isLoadingMessages: false,
+      error: null,
+    }),
+}));
+
+export default useAgentChatStore;

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -181,6 +181,8 @@ export type VideoStatus = "pending" | "processing" | "completed" | "failed";
 export interface VideoJobRequest {
   story_id: string;
   style?: VideoStyle;
+  provider?: string | null;
+  model?: string | null;
   include_audio?: boolean;
   duration_seconds?: number;
 }
@@ -631,4 +633,35 @@ export interface StreamCallbacks {
   onComplete?: (data: SSEStatusData) => void;
   onError?: (data: SSEErrorData) => void;
   onLaunchFlow?: (data: SSELaunchFlowData) => void;
+}
+
+// ============================================================================
+// My Agent — multi-topic chat sessions (#565 §3.11.8)
+// ============================================================================
+
+export interface AgentChatSessionSummary {
+  session_id: string;
+  child_id: string;
+  title: string;
+  last_message_preview: string;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgentChatSessionListResponse {
+  sessions: AgentChatSessionSummary[];
+}
+
+export interface AgentChatMessageItem {
+  message_id: string;
+  role: "user" | "assistant";
+  text: string;
+  result_metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface AgentChatMessagesResponse {
+  session_id: string;
+  messages: AgentChatMessageItem[];
 }


### PR DESCRIPTION
## Summary

Story D of epic #565 — the frontend store + service layer the sidebar (Story E) will consume.

- **agentService** gains six session methods typed against the #567/#568 contracts: `listAgentSessions`, `getAgentSessionMessages`, `createAgentSession`, `renameAgentSession`, `archiveAgentSession`, `deleteAgentSession`.
- **types/api.ts**: `AgentChatSessionSummary`, `AgentChatSessionListResponse`, `AgentChatMessageItem`, `AgentChatMessagesResponse`.
- **useAgentChatStore** (Zustand): `sessions` + `currentSessionId` + `messages` with actions for load/select/new/rename/archive/delete. Rename/archive/delete are optimistic and roll back on failure. Deleting the current session falls back to the next (or empty). Streaming hooks reuse the existing `chatMessageState` helpers; `adoptServerSession` reconciles the server-issued id from the first SSE `session` event; `reset()` clears state on active-child switch.

## Test plan

- [x] 14 store unit tests: load+sort, select, new, rename (commit + rollback), archive (remove + rollback), delete (fallback-to-next + fallback-to-null + rollback), streaming pipeline, adoptServerSession guard, reset.
- [x] `npx tsc --noEmit` clean.
- [x] Store + agentService + MyAgentPage suites green (34 tests).

## Depends on

#567, #568 (endpoints), both merged to main.

## Unblocks

#570 (sidebar UI) consumes this store; #571 (tests) extends it.

Fixes #569
Parent Epic: #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)