### PR TITLE
feat(my-agent): session sidebar + chat panel store wiring (Story E)

### DIFF
--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -34,21 +34,18 @@ import {
 import { agentService } from "@/api/services/agentService";
 import { memoryService } from "@/api/services/memoryService";
 import { useLaunchFlowNavigation } from "@/hooks/useLaunchFlowNavigation";
+import useAgentChatStore from "@/store/useAgentChatStore";
 import type { Agent } from "@/types/agent";
 import type { AgeGroup, MemoryCharacter } from "@/types/api";
 import type {
   SSEErrorData,
   SSELaunchFlowData,
+  SSESessionData,
   SSEStatusData,
   SSEThinkingData,
   SSEToolResultData,
   SSEToolUseData,
 } from "@/types/api";
-import {
-  appendAssistantDelta,
-  settleAssistantMessage,
-  type ChatMessage,
-} from "./chatMessageState";
 import {
   chipPrefillForCharacter,
   pickRecurringCharacter,
@@ -75,12 +72,6 @@ const STARTER_PROMPTS: string[] = [
   "What's in the news today for kids?",
   "Let's make an interactive choose-your-own adventure",
 ];
-
-function nextMessageId(prefix: string): string {
-  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
-}
-
-const nextAssistantId = () => nextMessageId("assistant");
 
 function avatarGlyph(agent: Agent): string {
   return agent.agent_avatar_id.startsWith("emoji:")
@@ -128,8 +119,15 @@ export default function AgentChatPanel({
 }: Props) {
   const [draft, setDraft] = useState("");
   const [image, setImage] = useState<File | null>(null);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
-  const [sessionId, setSessionId] = useState<string | null>(null);
+  // Messages + the active session id live in the shared store (#569) so
+  // the sidebar (#570) and this panel stay in lock-step when the user
+  // switches topics.
+  const messages = useAgentChatStore((s) => s.messages);
+  const sessionId = useAgentChatStore((s) => s.currentSessionId);
+  const appendUserMessage = useAgentChatStore((s) => s.appendUserMessage);
+  const appendStreamingDelta = useAgentChatStore((s) => s.appendStreamingDelta);
+  const settleAssistant = useAgentChatStore((s) => s.settleAssistantMessage);
+  const adoptServerSession = useAgentChatStore((s) => s.adoptServerSession);
   const [isStreaming, setIsStreaming] = useState(false);
   const [statusText, setStatusText] = useState<string | null>(null);
   const [toolText, setToolText] = useState<string | null>(null);
@@ -137,6 +135,10 @@ export default function AgentChatPanel({
   const [recurringCharacter, setRecurringCharacter] =
     useState<MemoryCharacter | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  // The session id the in-flight stream belongs to. Lets us tell a
+  // user-initiated session switch (abort) apart from the proxy adopting
+  // a server-issued session mid-stream (do not abort).
+  const streamSessionRef = useRef<string | null>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -150,6 +152,25 @@ export default function AgentChatPanel({
   useEffect(() => {
     return () => abortRef.current?.abort();
   }, []);
+
+  // Abort an in-flight stream when the user switches to a *different*
+  // session than the stream belongs to, so partial deltas don't bleed
+  // into the newly selected session's history (#570). A mid-stream
+  // adopt of the server session keeps streamSessionRef in sync, so that
+  // case does not trip this guard.
+  useEffect(() => {
+    if (
+      abortRef.current &&
+      streamSessionRef.current !== null &&
+      sessionId !== streamSessionRef.current
+    ) {
+      abortRef.current.abort();
+      abortRef.current = null;
+      setIsStreaming(false);
+      setStatusText(null);
+      setToolText(null);
+    }
+  }, [sessionId]);
 
   // Fetch recurring characters for the active child to surface a
   // "Remember…" chip above the composer (#560). Cancelled on
@@ -216,6 +237,7 @@ export default function AgentChatPanel({
   const cancelStream = () => {
     abortRef.current?.abort();
     abortRef.current = null;
+    streamSessionRef.current = null;
     setIsStreaming(false);
     setToolText(null);
     setStatusText(`${agent.agent_name} stopped.`);
@@ -236,10 +258,8 @@ export default function AgentChatPanel({
     setToolText(null);
     setStatusText(`${agent.agent_name} is thinking...`);
     resetPendingFlow();
-    setMessages((prev) => [
-      ...prev,
-      { id: nextMessageId("user"), role: "user", text: message },
-    ]);
+    appendUserMessage(message);
+    streamSessionRef.current = sessionId;
     setIsStreaming(true);
 
     try {
@@ -253,29 +273,24 @@ export default function AgentChatPanel({
           image: attachedImage,
         },
         {
-          onSession: (data) => setSessionId(data.session_id),
+          onSession: (data: SSESessionData) => {
+            streamSessionRef.current = data.session_id;
+            adoptServerSession(data.session_id);
+          },
           onStatus: (data: SSEStatusData) => setStatusText(data.message),
-          onThinking: (data: SSEThinkingData) =>
-            setMessages((prev) =>
-              appendAssistantDelta(prev, data.content, nextAssistantId),
-            ),
+          onThinking: (data: SSEThinkingData) => appendStreamingDelta(data.content),
           onToolUse: (data: SSEToolUseData) => setToolText(data.message),
           onToolResult: (data: SSEToolResultData) =>
             setToolText(data.message ?? "Specialist finished."),
           onLaunchFlow,
-          onResult: (data) =>
-            setMessages((prev) =>
-              settleAssistantMessage(prev, resultMessage(data), nextAssistantId),
-            ),
+          onResult: (data) => settleAssistant(resultMessage(data)),
           onError: (data: SSEErrorData) => {
             setErrorText(data.message);
-            setMessages((prev) =>
-              settleAssistantMessage(prev, data.message, nextAssistantId),
-            );
+            settleAssistant(data.message);
           },
           onComplete: (data: SSEStatusData) => {
             setStatusText(data.message);
-            setMessages((prev) => settleAssistantMessage(prev, "", nextAssistantId));
+            settleAssistant("");
           },
         },
         controller.signal,
@@ -287,12 +302,11 @@ export default function AgentChatPanel({
             ? err.message
             : "My Agent chat is temporarily unavailable.";
         setErrorText(messageText);
-        setMessages((prev) =>
-          settleAssistantMessage(prev, messageText, nextAssistantId),
-        );
+        settleAssistant(messageText);
       }
     } finally {
       if (abortRef.current === controller) abortRef.current = null;
+      streamSessionRef.current = null;
       setIsStreaming(false);
     }
   };

--- a/frontend/src/pages/MyAgentPage/AgentSessionListSidebar.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentSessionListSidebar.tsx
@@ -1,0 +1,215 @@
+/**
+ * AgentSessionListSidebar — the multi-topic session list (#570).
+ *
+ * Reads session state from useAgentChatStore. On wide screens the
+ * MyAgentPage renders this as a left column; on small screens it lives
+ * behind a slide-over drawer toggled from the chat header.
+ *
+ * Per-row Rename / Archive / Delete actions are hidden for ages 3-5
+ * (destructive controls are parent-territory for the youngest tier,
+ * per PRD §3.11.8). Delete always confirms before calling the store.
+ *
+ * Parent epic: #565
+ */
+
+import { useState } from "react";
+import { MoreVertical, Pencil, Archive, Trash2, Plus } from "lucide-react";
+import useAgentChatStore from "@/store/useAgentChatStore";
+import type { AgeGroup } from "@/types/api";
+import { relativeTime, sessionDisplayTitle } from "./sessionListHelpers";
+
+interface Props {
+  childId: string;
+  ageGroup?: AgeGroup | null;
+  /** Called after a row is selected — lets the page close the mobile drawer. */
+  onSelected?: () => void;
+}
+
+export default function AgentSessionListSidebar({
+  childId,
+  ageGroup,
+  onSelected,
+}: Props) {
+  const sessions = useAgentChatStore((s) => s.sessions);
+  const currentSessionId = useAgentChatStore((s) => s.currentSessionId);
+  const isLoading = useAgentChatStore((s) => s.isLoadingSessions);
+  const selectSession = useAgentChatStore((s) => s.selectSession);
+  const newSession = useAgentChatStore((s) => s.newSession);
+  const renameSession = useAgentChatStore((s) => s.renameSession);
+  const archiveSession = useAgentChatStore((s) => s.archiveSession);
+  const deleteSession = useAgentChatStore((s) => s.deleteSession);
+
+  const [menuOpenFor, setMenuOpenFor] = useState<string | null>(null);
+  const [confirmDeleteFor, setConfirmDeleteFor] = useState<string | null>(null);
+
+  // Destructive + edit controls are parent-territory for the youngest
+  // tier — hide the kebab entirely for ages 3-5.
+  const showRowActions = ageGroup !== "3-5";
+
+  const handleSelect = (sessionId: string) => {
+    setMenuOpenFor(null);
+    if (sessionId !== currentSessionId) {
+      void selectSession(sessionId);
+    }
+    onSelected?.();
+  };
+
+  const handleNew = () => {
+    setMenuOpenFor(null);
+    void newSession(childId);
+    onSelected?.();
+  };
+
+  const handleRename = (sessionId: string, currentTitle: string) => {
+    setMenuOpenFor(null);
+    const next = window.prompt("Rename this chat", currentTitle);
+    if (next && next.trim()) {
+      void renameSession(sessionId, next.trim());
+    }
+  };
+
+  const handleArchive = (sessionId: string) => {
+    setMenuOpenFor(null);
+    void archiveSession(sessionId, true);
+  };
+
+  const handleDelete = (sessionId: string) => {
+    setConfirmDeleteFor(null);
+    setMenuOpenFor(null);
+    void deleteSession(sessionId);
+  };
+
+  return (
+    <aside className="flex h-full min-h-0 w-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-gray-100 px-3 py-3">
+        <h2 className="text-sm font-semibold text-gray-900">Chats</h2>
+        <button
+          type="button"
+          onClick={handleNew}
+          className="inline-flex items-center gap-1 rounded-full bg-violet-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500"
+          aria-label="New chat"
+          title="New chat"
+        >
+          <Plus size={14} /> New
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-2">
+        {sessions.length === 0 ? (
+          <p className="px-2 py-6 text-center text-xs text-gray-500">
+            {isLoading ? "Loading chats…" : "No chats yet — say hi to start one"}
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-1">
+            {sessions.map((session) => {
+              const active = session.session_id === currentSessionId;
+              return (
+                <li key={session.session_id} className="relative">
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(session.session_id)}
+                    className={[
+                      "w-full rounded-lg px-3 py-2 text-left transition-colors",
+                      active
+                        ? "bg-violet-50 ring-1 ring-violet-200"
+                        : "hover:bg-gray-50",
+                    ].join(" ")}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate text-sm font-medium text-gray-900">
+                        {sessionDisplayTitle(session)}
+                      </span>
+                      <span className="shrink-0 text-[10px] text-gray-400">
+                        {relativeTime(session.updated_at)}
+                      </span>
+                    </div>
+                    {session.last_message_preview && (
+                      <p className="mt-0.5 truncate text-xs text-gray-500">
+                        {session.last_message_preview}
+                      </p>
+                    )}
+                  </button>
+
+                  {showRowActions && (
+                    <div className="absolute right-1 top-1.5">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setMenuOpenFor(
+                            menuOpenFor === session.session_id
+                              ? null
+                              : session.session_id,
+                          );
+                        }}
+                        className="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                        aria-label="Chat options"
+                      >
+                        <MoreVertical size={15} />
+                      </button>
+
+                      {menuOpenFor === session.session_id && (
+                        <div className="absolute right-0 z-10 mt-1 w-36 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              handleRename(
+                                session.session_id,
+                                sessionDisplayTitle(session),
+                              )
+                            }
+                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-gray-700 hover:bg-gray-50"
+                          >
+                            <Pencil size={13} /> Rename
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => handleArchive(session.session_id)}
+                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-gray-700 hover:bg-gray-50"
+                          >
+                            <Archive size={13} /> Archive
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmDeleteFor(session.session_id)}
+                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs text-red-600 hover:bg-red-50"
+                          >
+                            <Trash2 size={13} /> Delete
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+
+                  {confirmDeleteFor === session.session_id && (
+                    <div className="absolute right-0 z-20 mt-1 w-52 rounded-lg border border-gray-200 bg-white p-3 shadow-lg">
+                      <p className="text-xs text-gray-700">
+                        Delete this chat? This can't be undone.
+                      </p>
+                      <div className="mt-2 flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setConfirmDeleteFor(null)}
+                          className="rounded-md px-2 py-1 text-xs text-gray-600 hover:bg-gray-100"
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDelete(session.session_id)}
+                          className="rounded-md bg-red-600 px-2 py-1 text-xs font-medium text-white hover:bg-red-700"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/pages/MyAgentPage/index.tsx
+++ b/frontend/src/pages/MyAgentPage/index.tsx
@@ -18,11 +18,14 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
+import { PanelLeft } from "lucide-react";
 import useChildStore from "@/store/useChildStore";
 import useAuthStore from "@/store/useAuthStore";
+import useAgentChatStore from "@/store/useAgentChatStore";
 import { authService } from "@/api/services/authService";
 import { useAgent } from "@/hooks/useAgent";
 import AgentChatPanel from "./AgentChatPanel";
+import AgentSessionListSidebar from "./AgentSessionListSidebar";
 import OnboardingModal from "./OnboardingModal";
 import PersonaEditorSheet from "./PersonaEditorSheet";
 import { shouldAutoOpenOnboarding } from "./onboardingState";
@@ -49,6 +52,21 @@ export default function MyAgentPage() {
   const [editorOpen, setEditorOpen] = useState(false);
   const [approvalNotice, setApprovalNotice] = useState<string | null>(null);
   const [approvalBusy, setApprovalBusy] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const loadSessions = useAgentChatStore((s) => s.loadSessions);
+  const resetSessions = useAgentChatStore((s) => s.reset);
+
+  // Load (and reset on child switch) the session list whenever the
+  // active child changes. Sessions are scoped to (user, child), so a
+  // child switch must never show the previous child's chats (#570).
+  useEffect(() => {
+    if (!isAuthenticated || !childId) return;
+    resetSessions();
+    loadSessions(childId).catch((err) => {
+      console.error("Failed to load agent chat sessions:", err);
+    });
+  }, [childId, isAuthenticated, loadSessions, resetSessions]);
 
   useEffect(() => {
     if (!isAuthenticated || user?.role !== "parent" || childProfiles.length > 0) {
@@ -227,16 +245,50 @@ export default function MyAgentPage() {
     );
   }
 
-  // --- State 3: Authed + buddy exists → chat + configure --------------
+  // --- State 3: Authed + buddy exists → sessions + chat + configure ---
   return (
-    <div className="mx-auto flex h-[calc(100vh-7rem)] max-w-3xl flex-col gap-4 px-4 pb-4 pt-6">
-      <AgentChatPanel
-        agent={existing}
-        childId={childId}
-        ageGroup={ageGroup}
-        interests={currentChild?.interests ?? []}
-        onConfigure={() => setEditorOpen(true)}
-      />
+    <div className="mx-auto flex h-[calc(100vh-7rem)] max-w-5xl gap-4 px-4 pb-4 pt-6">
+      {/* Desktop sidebar */}
+      <div className="hidden w-64 shrink-0 md:block">
+        <AgentSessionListSidebar childId={childId} ageGroup={ageGroup} />
+      </div>
+
+      {/* Mobile drawer */}
+      {sidebarOpen && (
+        <div className="fixed inset-0 z-40 md:hidden">
+          <div
+            className="absolute inset-0 bg-black/30"
+            onClick={() => setSidebarOpen(false)}
+            aria-hidden="true"
+          />
+          <div className="absolute left-0 top-0 h-full w-72 max-w-[80%] p-3">
+            <AgentSessionListSidebar
+              childId={childId}
+              ageGroup={ageGroup}
+              onSelected={() => setSidebarOpen(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        {/* Mobile-only "open chats" toggle */}
+        <button
+          type="button"
+          onClick={() => setSidebarOpen(true)}
+          className="inline-flex w-fit items-center gap-1.5 rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600 shadow-sm hover:bg-gray-50 md:hidden"
+        >
+          <PanelLeft size={14} /> Chats
+        </button>
+        <AgentChatPanel
+          agent={existing}
+          childId={childId}
+          ageGroup={ageGroup}
+          interests={currentChild?.interests ?? []}
+          onConfigure={() => setEditorOpen(true)}
+        />
+      </div>
+
       <PersonaEditorSheet
         open={editorOpen}
         agent={existing}

--- a/frontend/src/pages/MyAgentPage/sessionListHelpers.test.ts
+++ b/frontend/src/pages/MyAgentPage/sessionListHelpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+
+import { relativeTime, sessionDisplayTitle } from "./sessionListHelpers";
+import type { AgentChatSessionSummary } from "@/types/api";
+
+function s(overrides: Partial<AgentChatSessionSummary> = {}): AgentChatSessionSummary {
+  return {
+    session_id: "s1",
+    child_id: "c1",
+    title: "",
+    last_message_preview: "",
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("sessionDisplayTitle", () => {
+  it("returns the title when present", () => {
+    expect(sessionDisplayTitle(s({ title: "Dinosaur story" }))).toBe("Dinosaur story");
+  });
+  it("falls back to 'New chat' when blank", () => {
+    expect(sessionDisplayTitle(s({ title: "   " }))).toBe("New chat");
+    expect(sessionDisplayTitle(s({ title: "" }))).toBe("New chat");
+  });
+});
+
+describe("relativeTime", () => {
+  const now = Date.parse("2026-05-28T12:00:00Z");
+
+  it("returns 'just now' for very recent", () => {
+    expect(relativeTime("2026-05-28T11:59:40Z", now)).toBe("just now");
+  });
+  it("returns minutes", () => {
+    expect(relativeTime("2026-05-28T11:50:00Z", now)).toBe("10m");
+  });
+  it("returns hours", () => {
+    expect(relativeTime("2026-05-28T09:00:00Z", now)).toBe("3h");
+  });
+  it("returns days", () => {
+    expect(relativeTime("2026-05-26T12:00:00Z", now)).toBe("2d");
+  });
+  it("returns a short date when older than a week", () => {
+    expect(relativeTime("2026-05-01T12:00:00Z", now)).toBe("5/1");
+  });
+  it("returns empty string for an unparseable input", () => {
+    expect(relativeTime("not-a-date", now)).toBe("");
+  });
+});

--- a/frontend/src/pages/MyAgentPage/sessionListHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/sessionListHelpers.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure helpers for the session list sidebar (#570).
+ *
+ * Kept separate from the component so the display logic is unit-testable
+ * without a DOM (the project does not ship @testing-library/react).
+ */
+
+import type { AgentChatSessionSummary } from "@/types/api";
+
+/** Human label for a session row, falling back when untitled. */
+export function sessionDisplayTitle(session: AgentChatSessionSummary): string {
+  const title = (session.title ?? "").trim();
+  return title || "New chat";
+}
+
+/**
+ * Compact relative time ("just now", "5m", "3h", "2d", or a date).
+ * `nowMs` is injectable so tests are deterministic.
+ */
+export function relativeTime(iso: string, nowMs: number = Date.now()): string {
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return "";
+  const diffSec = Math.max(0, Math.floor((nowMs - then) / 1000));
+  if (diffSec < 45) return "just now";
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 7) return `${diffDay}d`;
+  // Older than a week — show a short date.
+  const d = new Date(then);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}


### PR DESCRIPTION
## Summary

Story E of epic #565 — the visible sidebar UI and the AgentChatPanel refactor onto the shared store.

- **AgentSessionListSidebar** — session list from `useAgentChatStore`, "New chat" button, active-row highlight, per-row Rename/Archive/Delete kebab, delete confirmation dialog, empty state ("No chats yet — say hi to start one"). Kebab is hidden for ages 3-5 (destructive controls are parent-territory for the youngest tier, per §3.11.8).
- **sessionListHelpers** — pure `sessionDisplayTitle` + `relativeTime`, unit-tested without a DOM.
- **AgentChatPanel** — `messages` + `currentSessionId` now come from the store; streaming deltas flow through store actions. A `streamSessionRef` distinguishes a user-initiated session switch (abort the in-flight stream) from the proxy adopting a server-issued session id mid-stream (don't abort) — so partial deltas never bleed into a newly selected session.
- **MyAgentPage** — sidebar as a left column on `md+`, slide-over drawer on mobile; loads + resets sessions whenever the active child changes so a child switch never shows another child's chats.

## Test plan

- [x] `sessionListHelpers.test.ts` — 8 tests (title fallback, relative-time buckets, unparseable input).
- [x] Store + MyAgentPage suites green; **full frontend suite: 175 passed**.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` succeeds.
- [ ] **Manual browser verification pending** — this repo has no @testing-library/react, so interactive flows (row select swaps history, drawer open/close, mid-stream session switch abort) are covered by store/helper unit tests rather than RTL. Recommend a manual pass on `/my-agent` with a seeded multi-session child during review.

## Depends on

#569 (store + service), merged to main.

## Unblocks

#571 (cross-user isolation + sidebar interaction tests) can now extend the store/helper coverage.

Fixes #570
Parent Epic: #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)