### PR TITLE
test(my-agent): close session-management coverage gaps (Story F)

### DIFF
--- a/backend/tests/contracts/test_agent_chat_sessions_endpoint_contract.py
+++ b/backend/tests/contracts/test_agent_chat_sessions_endpoint_contract.py
@@ -357,3 +357,43 @@ class TestDeleteSession:
     async def test_unknown_session_delete_404(self, client):
         r = await client.delete("/api/v1/me/agent/sessions/nope")
         assert r.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_double_delete_is_idempotent_404(self, client):
+        """A second DELETE of an already-removed session must 404, not 500."""
+        s = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_A.user_id, child_id=_CHILD_A
+        )
+        first = await client.delete(f"/api/v1/me/agent/sessions/{s.session_id}")
+        assert first.status_code == 204
+        second = await client.delete(f"/api/v1/me/agent/sessions/{s.session_id}")
+        assert second.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (#571) — archive is not delete
+# ---------------------------------------------------------------------------
+
+
+class TestArchivePreservesHistory:
+    @pytest.mark.asyncio
+    async def test_archived_session_history_still_readable(self, client):
+        """Archiving hides a session from the default list but must NOT
+        destroy its messages — archive and delete are distinct (§3.11.8)."""
+        s = await agent_chat_repo.get_or_create_session(
+            user_id=_USER_A.user_id, child_id=_CHILD_A
+        )
+        await agent_chat_repo.add_message(
+            session_id=s.session_id, role="user", text="kept after archive"
+        )
+        await agent_chat_repo.archive_session(s.session_id, user_id=_USER_A.user_id)
+
+        # Excluded from the default list...
+        listed = await client.get("/api/v1/me/agent/sessions")
+        assert s.session_id not in {
+            row["session_id"] for row in listed.json()["sessions"]
+        }
+        # ...but its history is intact and still readable.
+        msgs = await client.get(f"/api/v1/me/agent/sessions/{s.session_id}/messages")
+        assert msgs.status_code == 200
+        assert [m["text"] for m in msgs.json()["messages"]] == ["kept after archive"]

--- a/frontend/src/store/__tests__/useAgentChatStore.test.ts
+++ b/frontend/src/store/__tests__/useAgentChatStore.test.ts
@@ -222,3 +222,29 @@ describe("reset", () => {
     expect(st.messages).toEqual([]);
   });
 });
+
+// #571 — active-child switch isolation. The page does reset() then
+// loadSessions(newChild) when the active child changes; this asserts the
+// store never carries one child's sessions into another's view.
+describe("active-child switch isolation", () => {
+  it("shows only the new child's sessions after reset + reload", async () => {
+    mocked.listAgentSessions.mockResolvedValueOnce({
+      sessions: [session("childA_1", { child_id: "childA" })],
+    });
+    await useAgentChatStore.getState().loadSessions("childA");
+    expect(
+      useAgentChatStore.getState().sessions.map((s) => s.session_id),
+    ).toEqual(["childA_1"]);
+
+    // Simulate the page's child-switch sequence.
+    useAgentChatStore.getState().reset();
+    mocked.listAgentSessions.mockResolvedValueOnce({
+      sessions: [session("childB_1", { child_id: "childB" })],
+    });
+    await useAgentChatStore.getState().loadSessions("childB");
+
+    const ids = useAgentChatStore.getState().sessions.map((s) => s.session_id);
+    expect(ids).toEqual(["childB_1"]);
+    expect(ids).not.toContain("childA_1");
+  });
+});


### PR DESCRIPTION
## Summary

Story F of epic #565 — the cross-user isolation + interaction test consolidation.

**Most of Story F's acceptance criteria were already satisfied** by tests landed during the earlier stories (TDD all the way down):

| AC | Where it's covered |
|---|---|
| Cross-user GET list / GET messages / PATCH / DELETE → 404 | `test_agent_chat_sessions_endpoint_contract.py` (#567/#568) |
| FK cascade leaves zero messages after DELETE | same file + `test_agent_chat_repository_contract.py` (#566) |
| Unsafe rename → 422, no mutation | same file (#568) |
| Store optimistic rollback (rename/archive/delete) | `useAgentChatStore.test.ts` (#569) |
| Delete current session → fallback to next/null | `useAgentChatStore.test.ts` (#569) |

This PR adds the three edges that were **genuinely uncovered**:

- **Store: active-child switch isolation** — after `reset()` + reload, only the new child's sessions are present (no leftover from the prior child). This is the page's child-switch sequence.
- **Endpoint: archive ≠ delete** — an archived session drops out of the default list but its message history stays readable (the distinction §3.11.8 promises).
- **Endpoint: double-delete idempotency** — a second DELETE returns 404, not 500.

## Test plan

- [x] Backend session endpoint contract: 18 passed (was 16, +2).
- [x] Store: 15 passed (was 14, +1).

## Note

I deliberately did **not** duplicate the already-passing isolation tests — adding redundant copies would be churn. The table above maps each AC to its existing guard so reviewers can verify coverage without re-running everything.

Fixes #571
Parent Epic: #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)