### PR TITLE
feat(capture): Take Photo button on touch devices (#580)

### DIFF
--- a/.claude/rules/github-conventions.md
+++ b/.claude/rules/github-conventions.md
@@ -33,6 +33,7 @@ Every issue gets **one label from each required category**.
 - `domain:inspiration` — PRD §3.10 — Daily creative inspiration for kids
 - `domain:my-agent` — PRD §3.11 — Per-user creative buddy agent persona
 - `domain:content-hub` — PRD §3.12 — Group-based community sharing
+- `domain:capture` — PRD §3.15 — Tablet/mobile capture modalities (camera + voice input)
 
 ### Priority (required)
 - `P0:critical` — Blocks launch or breaks safety — fix NOW
@@ -69,6 +70,7 @@ Every issue MUST be assigned to a milestone.
 | #405 | Inspiration Daily — Creative Spark Feed | domain:inspiration | 2 |
 | #436 | My Agent — Personal Creative Buddy with Onboarding & Customization | domain:my-agent | 2 |
 | #437 | Content Hub — Group-Based Community Sharing with Buddy Bylines | domain:content-hub | 2 |
+| #579 | Tablet & Mobile Capture Modalities | domain:capture | 2 |
 
 Every story/bug body MUST include `**Parent Epic**: #<number>`.
 

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -1054,6 +1054,7 @@ Month 3: Child has created 20+ stories, forming their own "story universe"
 - 🔲 Login page mobile logo clipping fix
 - 🔲 Profile page mobile layout fix (Edit Profile button overlap)
 - 🔲 UploadPage React hook order fix (useState called after conditional return, violates React rules, may cause state corruption)
+- 🔲 ImageUploader camera capture on tablets/phones (§3.15)
 
 **Should Have**:
 - 🔲 Library "New" badge expiry rule (auto-disappear after 7 days from creation)
@@ -1063,6 +1064,7 @@ Month 3: Child has created 20+ stories, forming their own "story universe"
 - 🔲 Upload page DOM nesting validation error fix
 - 🔲 StoryPage success banner conditional display (only appears when `justGenerated === true`, not when opened from Library)
 - 🔲 LibraryPage per-tab empty state UI (with CTA guiding to corresponding creation page)
+- 🔲 Voice input on Interactive Story theme + buddy chat (§3.15)
 
 **Could Have**:
 - 🔲 Library/Profile card hover feedback (desktop lift effect)
@@ -1907,6 +1909,50 @@ Phase 3 turns the existing foundations for video, growth metrics, and rewards in
 5. **#536 Add server-owned achievement badge model** (`type:story`, `domain:gamification`, `P1`) — closed
 6. **#537 Render child-safe achievement surfaces** (`type:story`, `domain:gamification`, `P2`) — closed
 7. **#522 Align pitch deck and Phase 3 docs with shipped implementation** (`type:chore`, `domain:my-agent`, `P1`) — PR #554
+
+---
+
+## 3.15 Tablet & Mobile Capture Modalities [Phase 2 — Reach]
+
+Goal: make the kid-facing flows usable on tablets and phones by replacing laptop-only input affordances (file picker, keyboard) with touch-native camera and voice input — without weakening content safety or parental consent.
+
+### 3.15.1 Problem
+The product is positioned for ages 3-12, but the lowest cohort cannot read or type, and tablet/phone users cannot take photos directly. `ImageUploader` (drag-drop only, no `capture` attribute), `InteractiveStoryPage` theme input (50-char free text), and `AgentChatPanel` textarea (buddy chat) are the worst offenders today. Today's UI assumes a laptop with a mouse + keyboard.
+
+### 3.15.2 Solution
+Two parallel tracks:
+- **Camera capture**: tabbed picker ("Take Photo" | "Upload File") in `ImageUploader` defaulting to "Take Photo" on `(pointer: coarse) and (max-width: 1024px)` devices; new `CameraCapture` component using `getUserMedia` + `<canvas>` snapshot; `capture="environment"` fallback on a hidden input for the quick-win path. Captured JPEG flows through the existing `/api/v1/image-to-story` multipart contract with no backend change.
+- **Voice input**: new `backend/src/services/stt_service.py` wrapping OpenAI Whisper (mirrors `tts_service.py` shape), new `POST /api/v1/audio/transcriptions` endpoint, reusable `VoiceInputButton` attached to the `InteractiveStoryPage` theme input and `AgentChatPanel` textarea. Web Speech API is progressive enhancement only — iPad Safari (most likely target device) does not support it, so server-side Whisper is canonical.
+
+**Cross-cutting**: extend `child_profiles` with `camera_consent` and `microphone_consent` booleans, route first-use through the existing `ParentApprovalPage` flow. In-page `PermissionPrompt` component shows a child-friendly explainer before the browser prompt fires.
+
+### 3.15.3 Stories
+1. **Quick-win** — `capture="environment"` fallback + "Take Photo" affordance on touch devices (1-day ship, zero new dependencies)
+2. **CameraCapture component** — live preview, capture, retake, front/back toggle, permission state machine
+3. **ImageUploader tabbed picker** — default-to-camera on touch devices via `(pointer: coarse) and (max-width: 1024px)`
+4. **STT backend** — `STTService` + `POST /api/v1/audio/transcriptions` + contract + API tests
+5. **VoiceInputButton + useVoiceInput** — reusable mic button with waveform animation; state machine (idle → recording → processing → done | error)
+6. **Voice on InteractiveStoryPage** — wire `VoiceInputButton` next to the Story Theme input
+7. **Voice on AgentChatPanel** — wire `VoiceInputButton` next to the buddy chat textarea
+8. **Parental consent** — `camera_consent` + `microphone_consent` on `child_profiles`, parent-only PIN gate via `ParentApprovalPage`
+9. **PermissionPrompt component** — in-page child-friendly permission explainer before browser prompt
+
+### 3.15.4 Acceptance Criteria
+- [ ] "Take Photo" defaults on `(pointer: coarse) and (max-width: 1024px)`; "Upload File" defaults elsewhere
+- [ ] Captured photos are JPEG, upright-normalized, ≤10MB, flow through existing `/api/v1/image-to-story` with no backend change
+- [ ] `POST /api/v1/audio/transcriptions` accepts ≤2MB and ≤30s audio, returns `{text, language, duration_ms, safety_passed}`
+- [ ] Transcribed text passes `check_content_safety` (threshold 0.85) BEFORE insertion into any input
+- [ ] First-time camera/mic use requires `camera_consent` / `microphone_consent = true` (parent-set via `ParentApprovalPage`)
+- [ ] Audio bytes are NOT persisted server-side; only the moderated transcript is stored
+- [ ] Camera-denied state shows file-upload fallback; mic-denied state focuses the textarea
+- [ ] Recording auto-stops at 30s; reduced-motion users get static states (no waveform animation)
+- [ ] Voice recognition achieves ≥90% accuracy on a 20-clip kids-voice test set; transcripts return ≤3s after speech ends
+
+#### Out of Scope
+- Local on-device STT (Whisper.cpp) and Web Speech as the primary path — Web Speech only as progressive enhancement
+- Real-time camera filters, AR overlays, or background blur — capture only
+- Multilingual STT beyond OpenAI Whisper's automatic language detection
+- Native iOS/Android apps — this is a web-only effort targeting tablet/phone browsers
 
 ---
 

--- a/frontend/src/__tests__/components/ImageUploader.test.ts
+++ b/frontend/src/__tests__/components/ImageUploader.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { TOUCH_DEVICE_QUERY } from '@/components/upload/ImageUploader'
+
+describe('ImageUploader: TOUCH_DEVICE_QUERY', () => {
+  it('matches the PRD §3.15 acceptance criterion exactly', () => {
+    expect(TOUCH_DEVICE_QUERY).toBe('(pointer: coarse) and (max-width: 1024px)')
+  })
+
+  it('targets touch-input devices via pointer: coarse', () => {
+    expect(TOUCH_DEVICE_QUERY).toContain('pointer: coarse')
+  })
+
+  it('excludes large desktop displays via max-width breakpoint', () => {
+    expect(TOUCH_DEVICE_QUERY).toContain('max-width: 1024px')
+  })
+})

--- a/frontend/src/components/upload/ImageUploader/index.tsx
+++ b/frontend/src/components/upload/ImageUploader/index.tsx
@@ -1,6 +1,8 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { motion, AnimatePresence } from 'framer-motion'
+
+export const TOUCH_DEVICE_QUERY = '(pointer: coarse) and (max-width: 1024px)'
 
 interface ImageUploaderProps {
   onFileSelect: (file: File) => void
@@ -36,8 +38,58 @@ function ImageUploader({
 
   const hasError = fileRejections.length > 0
 
+  const [isTouchSmall, setIsTouchSmall] = useState(false)
+  const cameraInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia(TOUCH_DEVICE_QUERY)
+    const update = () => setIsTouchSmall(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+
+  const handleCameraClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    cameraInputRef.current?.click()
+  }
+
+  const handleCameraChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file && file.size <= maxSize) {
+      onFileSelect(file)
+    }
+    if (cameraInputRef.current) cameraInputRef.current.value = ''
+  }
+
   return (
     <div className={className}>
+      {isTouchSmall && (
+        <>
+          <motion.button
+            type="button"
+            onClick={handleCameraClick}
+            whileTap={{ scale: 0.97 }}
+            className="w-full mb-3 py-4 px-6 rounded-2xl bg-primary text-white font-bold text-lg flex items-center justify-center gap-2 shadow-md"
+            aria-label="Take a photo with your camera"
+          >
+            <span className="text-2xl" aria-hidden="true">📸</span>
+            <span>Take Photo</span>
+          </motion.button>
+          <input
+            ref={cameraInputRef}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            className="hidden"
+            onChange={handleCameraChange}
+            aria-hidden="true"
+            tabIndex={-1}
+          />
+        </>
+      )}
+
       <motion.div
         whileHover={{ scale: 1.01 }}
         transition={{ duration: 0.2 }}
@@ -110,9 +162,11 @@ function ImageUploader({
 
               <div className="text-center">
                 <p className="text-xl font-bold text-gray-700 mb-2">
-                  Drag image here
+                  {isTouchSmall ? 'Or pick from your photos' : 'Drag image here'}
                 </p>
-                <p className="text-gray-500">or click to select file</p>
+                <p className="text-gray-500">
+                  {isTouchSmall ? 'Tap to choose a file' : 'or click to select file'}
+                </p>
               </div>
 
               <div className="flex items-center gap-2 text-sm text-gray-400 mt-2">


### PR DESCRIPTION
## Summary

- Adds a "Take Photo" button + hidden `<input type="file" capture="environment">` to `ImageUploader` that renders only on touch+small viewports `(pointer: coarse) and (max-width: 1024px)`. Tapping opens the OS camera directly.
- Captured photo flows through the existing `onFileSelect` handler — **zero backend change**.
- Desktop drag-and-drop and file-picker affordances are unchanged.
- Documents epic #579 in PRD §3.15 and registers new `domain:capture` label in conventions.

This is the **quick-win** path of Track A in epic #579 — ~1 day of work, zero new dependencies. Full live-preview `CameraCapture` component is tracked in #581.

## Why

PRD positioned ages 3-12 but `ImageUploader` was drag-drop only with no `capture` attribute, so kids on tablets/phones couldn't take a photo of their drawing directly. The lowest-age cohort (3-5) can't read or type, so this is the first surface to make touch-native.

## Changes

- `frontend/src/components/upload/ImageUploader/index.tsx` — touch detection via `matchMedia`, "Take Photo" button, hidden `capture="environment"` input, copy adaptation
- `frontend/src/__tests__/components/ImageUploader.test.ts` — pins the breakpoint string against the PRD acceptance criterion so future stories in epic #579 reuse the same constant
- `docs/product/PRD.md` — new §3.15 Tablet & Mobile Capture Modalities + Responsive Polish items
- `.claude/rules/github-conventions.md` — registers `domain:capture` label and epic #579

## Test plan

- [x] Vitest unit test passes (`TOUCH_DEVICE_QUERY` matches PRD AC string exactly)
- [x] `tsc -b` clean
- [ ] Manual: iPad Safari — "Take Photo" button visible, tapping opens camera
- [ ] Manual: iPhone Safari — same
- [ ] Manual: Android Chrome — same
- [ ] Manual: Desktop Chrome — button hidden, drag-and-drop + file picker unchanged
- [ ] Manual: file size validation — capturing/picking a >10MB image is rejected

Fixes #580
Parent Epic: #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)