### PR TITLE
feat(capture): camera/microphone consent flags on child_profiles (#587)

### DIFF
--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -880,8 +880,27 @@ class ChildProfileResponse(BaseModel):
     avatar: Optional[str] = None
     is_default: bool = False
     archived_at: Optional[datetime] = None
+    camera_consent: bool = False
+    microphone_consent: bool = False
     created_at: datetime
     updated_at: datetime
+
+
+class ChildProfileConsentUpdateRequest(BaseModel):
+    """Patch camera/microphone consent flags on a child profile (#587).
+
+    At least one field must be supplied; supplying both is allowed.
+    """
+    camera_consent: Optional[bool] = None
+    microphone_consent: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def require_at_least_one_field(self):
+        if self.camera_consent is None and self.microphone_consent is None:
+            raise ValueError(
+                "At least one of camera_consent or microphone_consent must be provided"
+            )
+        return self
 
 
 class ChildProfileListResponse(BaseModel):

--- a/backend/src/api/routes/child_profiles.py
+++ b/backend/src/api/routes/child_profiles.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from ..deps import get_current_user
 from ..models import (
+    ChildProfileConsentUpdateRequest,
     ChildProfileCreateRequest,
     ChildProfileListResponse,
     ChildProfileResponse,
@@ -47,6 +48,8 @@ def _to_response(profile: ChildProfileData) -> ChildProfileResponse:
         avatar=profile.avatar,
         is_default=profile.is_default,
         archived_at=_parse_dt(profile.archived_at),
+        camera_consent=profile.camera_consent,
+        microphone_consent=profile.microphone_consent,
         created_at=datetime.fromisoformat(profile.created_at),
         updated_at=datetime.fromisoformat(profile.updated_at),
     )
@@ -119,6 +122,24 @@ async def set_default_child_profile(
     profile = await child_profile_repo.set_default(
         user_id=user.user_id,
         child_id=child_id,
+    )
+    if profile is None:
+        raise _not_found()
+    return _to_response(profile)
+
+
+@router.patch("/{child_id}/consent", response_model=ChildProfileResponse)
+async def update_child_profile_consent(
+    child_id: str,
+    request: ChildProfileConsentUpdateRequest,
+    user: UserData = Depends(get_current_user),
+):
+    _require_parent(user)
+    profile = await child_profile_repo.update_consent(
+        user_id=user.user_id,
+        child_id=child_id,
+        camera_consent=request.camera_consent,
+        microphone_consent=request.microphone_consent,
     )
     if profile is None:
         raise _not_found()

--- a/backend/src/services/database/child_profile_repository.py
+++ b/backend/src/services/database/child_profile_repository.py
@@ -21,6 +21,8 @@ class ChildProfileData:
     archived_at: Optional[str]
     created_at: str
     updated_at: str
+    camera_consent: bool = False
+    microphone_consent: bool = False
 
 
 class ChildProfileRepository:
@@ -34,7 +36,8 @@ class ChildProfileRepository:
     ) -> list[ChildProfileData]:
         query = """
             SELECT child_id, user_id, name, age_group, interests, avatar,
-                   is_default, archived_at, created_at, updated_at
+                   is_default, archived_at, camera_consent, microphone_consent,
+                   created_at, updated_at
             FROM child_profiles
             WHERE user_id = ?
         """
@@ -51,7 +54,8 @@ class ChildProfileRepository:
     ) -> Optional[ChildProfileData]:
         query = """
             SELECT child_id, user_id, name, age_group, interests, avatar,
-                   is_default, archived_at, created_at, updated_at
+                   is_default, archived_at, camera_consent, microphone_consent,
+                   created_at, updated_at
             FROM child_profiles
             WHERE user_id = ? AND child_id = ?
         """
@@ -115,6 +119,8 @@ class ChildProfileRepository:
             archived_at=None,
             created_at=now,
             updated_at=now,
+            camera_consent=False,
+            microphone_consent=False,
         )
 
     async def update(
@@ -177,6 +183,40 @@ class ChildProfileRepository:
             (now, user_id, child_id),
         )
         await self._sync_user_default(user_id, child_id)
+        await self._db.commit()
+        return await self.get_for_user(user_id, child_id)
+
+    async def update_consent(
+        self,
+        *,
+        user_id: str,
+        child_id: str,
+        camera_consent: Optional[bool] = None,
+        microphone_consent: Optional[bool] = None,
+    ) -> Optional[ChildProfileData]:
+        existing = await self.get_for_user(user_id, child_id)
+        if existing is None:
+            return None
+
+        updates = ["updated_at = ?"]
+        params: list[object] = [datetime.now().isoformat()]
+
+        if camera_consent is not None:
+            updates.append("camera_consent = ?")
+            params.append(1 if camera_consent else 0)
+        if microphone_consent is not None:
+            updates.append("microphone_consent = ?")
+            params.append(1 if microphone_consent else 0)
+
+        params.extend([user_id, child_id])
+        await self._db.execute(
+            f"""
+            UPDATE child_profiles
+            SET {', '.join(updates)}
+            WHERE user_id = ? AND child_id = ? AND archived_at IS NULL
+            """,
+            tuple(params),
+        )
         await self._db.commit()
         return await self.get_for_user(user_id, child_id)
 
@@ -246,6 +286,8 @@ class ChildProfileRepository:
             archived_at=row.get("archived_at"),
             created_at=row["created_at"],
             updated_at=row["updated_at"],
+            camera_consent=bool(row.get("camera_consent", 0)),
+            microphone_consent=bool(row.get("microphone_consent", 0)),
         )
 
 

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -183,6 +183,8 @@ CREATE TABLE IF NOT EXISTS child_profiles (
     avatar TEXT,
     is_default INTEGER DEFAULT 0,
     archived_at TEXT,
+    camera_consent INTEGER DEFAULT 0,
+    microphone_consent INTEGER DEFAULT 0,
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL,
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE,
@@ -574,6 +576,7 @@ async def init_schema(db: "DatabaseManager") -> None:
     await _migrate_add_story_length_mode(db)
     await _migrate_add_onboarding_columns(db)
     await _migrate_create_child_profiles_table(db)
+    await _migrate_add_child_profile_consent_columns(db)
     await _migrate_create_user_agents_table(db)
     await _migrate_add_user_agent_config_columns(db)
     await _migrate_create_agent_chat_tables(db)
@@ -876,6 +879,34 @@ async def _migrate_add_onboarding_columns(db: "DatabaseManager") -> None:
     if added:
         await db.commit()
         print("Users onboarding migration completed")
+
+
+async def _migrate_add_child_profile_consent_columns(db: "DatabaseManager") -> None:
+    """Migration: Add camera_consent and microphone_consent columns to child_profiles (#587).
+
+    Gates camera and microphone surfaces in epic #579 (tablet/mobile capture).
+    Both columns default to 0 (False) because consent must be granted explicitly
+    by a parent — children cannot bootstrap their own consent. Existing rows
+    inherit the default via the column-level DEFAULT, so no backfill is needed.
+
+    Reversal: column-add is non-destructive; reverting the application code
+    leaves the columns intact but unread. A true drop would require a follow-up
+    migration if ever needed.
+    """
+    columns = [
+        ("camera_consent", "ALTER TABLE child_profiles ADD COLUMN camera_consent INTEGER DEFAULT 0"),
+        ("microphone_consent", "ALTER TABLE child_profiles ADD COLUMN microphone_consent INTEGER DEFAULT 0"),
+    ]
+    added = False
+    for column_name, ddl in columns:
+        if not await column_exists(db, "child_profiles", column_name):
+            if not added:
+                print("Migrating child_profiles table: adding consent columns (#587)...")
+                added = True
+            await db.execute(ddl)
+    if added:
+        await db.commit()
+        print("Child profile consent migration completed")
 
 
 async def _migrate_create_child_profiles_table(db: "DatabaseManager") -> None:

--- a/backend/tests/contracts/test_child_profile_consent_contract.py
+++ b/backend/tests/contracts/test_child_profile_consent_contract.py
@@ -1,0 +1,278 @@
+"""
+Child Profile Consent Contract Tests (#587)
+
+Locks the backend contract for camera_consent and microphone_consent flags
+on child_profiles, including the PATCH /consent endpoint and the schema
+migration that adds the columns.
+
+Reasons these tests exist:
+  - Consent flags gate camera/mic surfaces (epic #579, PRD §3.15) — UI
+    treats them as the source of truth, so the API response shape must
+    include them and default to false.
+  - Only parent-role users may flip the flags. A forged request from a
+    child-role token must be rejected with the same PARENT_ROLE_REQUIRED
+    code the rest of the child-profile API uses.
+  - Cross-account access must return generic CHILD_PROFILE_NOT_FOUND so
+    parent IDs can't be enumerated.
+"""
+
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from backend.src.api.deps import get_current_user
+from backend.src.main import app
+from backend.src.services.database import child_profile_repo, db_manager
+from backend.src.services.database.child_profile_repository import ChildProfileRepository
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.database.sql_compat import column_exists
+from backend.src.services.database.user_repository import UserData
+
+
+PARENT_A = UserData(
+    user_id="consent_parent_a",
+    username="consent_parent_a",
+    email="parent-a@consent-test.com",
+    password_hash="h",
+    display_name="Parent A",
+    role="parent",
+    created_at="",
+    updated_at="",
+)
+
+PARENT_B = UserData(
+    user_id="consent_parent_b",
+    username="consent_parent_b",
+    email="parent-b@consent-test.com",
+    password_hash="h",
+    display_name="Parent B",
+    role="parent",
+    created_at="",
+    updated_at="",
+)
+
+CHILD_USER = UserData(
+    user_id="consent_child_user",
+    username="consent_child_user",
+    email="child@consent-test.com",
+    password_hash="h",
+    display_name="Child",
+    role="child",
+    parent_email="parent@test.com",
+    consent_status="pending_parent_consent",
+    created_at="",
+    updated_at="",
+)
+
+_current_user = {"user": PARENT_A}
+
+
+async def _override_current_user() -> UserData:
+    return _current_user["user"]
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    fresh = DatabaseManager(":memory:")
+    await fresh.connect()
+    await init_schema(fresh)
+
+    saved_adapter = db_manager._adapter
+    db_manager._adapter = fresh._adapter
+
+    now = datetime.now().isoformat()
+    for user in (PARENT_A, PARENT_B, CHILD_USER):
+        await db_manager.execute(
+            """
+            INSERT INTO users (
+                user_id, username, email, password_hash, display_name,
+                is_active, is_verified, role, parent_email, consent_status,
+                membership_tier, referral_code, referred_by,
+                created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                user.user_id,
+                user.username,
+                user.email,
+                user.password_hash,
+                user.display_name,
+                1,
+                1,
+                user.role,
+                user.parent_email,
+                user.consent_status,
+                "free",
+                f"{user.user_id[-8:]:0<8}"[:8],
+                None,
+                now,
+                now,
+            ),
+        )
+    await db_manager.commit()
+
+    yield fresh
+
+    db_manager._adapter = saved_adapter
+    await fresh.disconnect()
+
+
+@pytest_asyncio.fixture
+async def client(test_db):
+    _current_user["user"] = PARENT_A
+    app.dependency_overrides[get_current_user] = _override_current_user
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest_asyncio.fixture
+async def child_profile(test_db):
+    repo = ChildProfileRepository(db_manager)
+    return await repo.create(
+        user_id=PARENT_A.user_id,
+        child_id="child_consent_alpha",
+        name="Ada",
+        age_group="6-8",
+        is_default=True,
+    )
+
+
+class TestSchemaContract:
+    @pytest.mark.asyncio
+    async def test_camera_consent_column_exists(self, test_db):
+        assert await column_exists(test_db, "child_profiles", "camera_consent")
+
+    @pytest.mark.asyncio
+    async def test_microphone_consent_column_exists(self, test_db):
+        assert await column_exists(test_db, "child_profiles", "microphone_consent")
+
+    @pytest.mark.asyncio
+    async def test_create_defaults_both_flags_to_false(self, test_db, child_profile):
+        assert child_profile.camera_consent is False
+        assert child_profile.microphone_consent is False
+
+
+class TestConsentResponseShape:
+    @pytest.mark.asyncio
+    async def test_get_includes_consent_flags(self, client, child_profile):
+        listing = await client.get("/api/v1/child-profiles")
+        assert listing.status_code == 200
+        item = listing.json()["items"][0]
+        assert item["camera_consent"] is False
+        assert item["microphone_consent"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_response_includes_consent_flags(self, client, test_db):
+        created = await client.post(
+            "/api/v1/child-profiles",
+            json={
+                "child_id": "child_consent_beta",
+                "name": "Bea",
+                "age_group": "6-8",
+                "interests": [],
+                "is_default": True,
+            },
+        )
+        assert created.status_code == 201, created.text
+        payload = created.json()
+        assert payload["camera_consent"] is False
+        assert payload["microphone_consent"] is False
+
+
+class TestConsentPatchEndpoint:
+    @pytest.mark.asyncio
+    async def test_parent_can_grant_camera_consent(self, client, child_profile):
+        response = await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={"camera_consent": True},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["camera_consent"] is True
+        assert body["microphone_consent"] is False
+
+    @pytest.mark.asyncio
+    async def test_parent_can_grant_microphone_consent(self, client, child_profile):
+        response = await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={"microphone_consent": True},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["microphone_consent"] is True
+        assert body["camera_consent"] is False
+
+    @pytest.mark.asyncio
+    async def test_partial_update_preserves_other_flag(self, client, child_profile):
+        first = await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={"camera_consent": True},
+        )
+        assert first.status_code == 200
+        assert first.json()["camera_consent"] is True
+
+        second = await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={"microphone_consent": True},
+        )
+        assert second.status_code == 200, second.text
+        body = second.json()
+        assert body["camera_consent"] is True
+        assert body["microphone_consent"] is True
+
+    @pytest.mark.asyncio
+    async def test_parent_can_revoke_camera_consent(self, client, child_profile):
+        await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={"camera_consent": True},
+        )
+        revoked = await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={"camera_consent": False},
+        )
+        assert revoked.status_code == 200, revoked.text
+        assert revoked.json()["camera_consent"] is False
+
+    @pytest.mark.asyncio
+    async def test_empty_body_rejected(self, client, child_profile):
+        response = await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_child_role_cannot_update_consent(self, client, child_profile):
+        _current_user["user"] = CHILD_USER
+        response = await client.patch(
+            f"/api/v1/child-profiles/{child_profile.child_id}/consent",
+            json={"camera_consent": True},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "PARENT_ROLE_REQUIRED"
+
+    @pytest.mark.asyncio
+    async def test_cross_account_consent_returns_generic_not_found(self, client, child_profile):
+        other_repo = ChildProfileRepository(db_manager)
+        await other_repo.create(
+            user_id=PARENT_B.user_id,
+            child_id="child_owned_by_b",
+            name="Other",
+            age_group="6-8",
+            is_default=True,
+        )
+
+        response = await client.patch(
+            "/api/v1/child-profiles/child_owned_by_b/consent",
+            json={"camera_consent": True},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"]["code"] == "CHILD_PROFILE_NOT_FOUND"
+
+        other = await other_repo.get_for_user(PARENT_B.user_id, "child_owned_by_b")
+        assert other.camera_consent is False

--- a/frontend/src/__tests__/store/useChildStore.test.ts
+++ b/frontend/src/__tests__/store/useChildStore.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/api/services/childProfileService", () => ({
     update: vi.fn(),
     archive: vi.fn(),
     setDefault: vi.fn(),
+    updateConsent: vi.fn(),
   },
 }));
 
@@ -146,5 +147,78 @@ describe("useChildStore child profile hydration", () => {
     expect(childProfileService.list).toHaveBeenCalledTimes(1);
     expect(useChildStore.getState().childProfiles).toHaveLength(1);
     expect(useChildStore.getState().currentChild?.child_id).toBe("child-1");
+  });
+});
+
+describe("useChildStore.updateConsent (#587)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  it("merges the updated consent flags into childProfiles", async () => {
+    const initial = profile("child-1", {
+      camera_consent: false,
+      microphone_consent: false,
+    });
+    useChildStore.getState().setChildProfiles([initial]);
+
+    vi.mocked(childProfileService.updateConsent).mockResolvedValueOnce({
+      ...initial,
+      camera_consent: true,
+    });
+
+    const returned = await useChildStore
+      .getState()
+      .updateConsent("child-1", { camera_consent: true });
+
+    expect(childProfileService.updateConsent).toHaveBeenCalledWith("child-1", {
+      camera_consent: true,
+    });
+    expect(returned.camera_consent).toBe(true);
+    expect(useChildStore.getState().childProfiles[0].camera_consent).toBe(true);
+  });
+
+  it("updates currentChild when the target is the active profile", async () => {
+    const active = profile("child-active", {
+      camera_consent: false,
+      microphone_consent: false,
+    });
+    useChildStore.getState().setChildProfiles([active]);
+
+    vi.mocked(childProfileService.updateConsent).mockResolvedValueOnce({
+      ...active,
+      microphone_consent: true,
+    });
+
+    await useChildStore
+      .getState()
+      .updateConsent("child-active", { microphone_consent: true });
+
+    expect(useChildStore.getState().currentChild?.microphone_consent).toBe(true);
+  });
+
+  it("leaves currentChild untouched when updating a different profile", async () => {
+    const active = profile("child-active", { camera_consent: false });
+    const other = profile("child-other", { camera_consent: false });
+    useChildStore.getState().setChildProfiles([active, other]);
+    useChildStore.getState().switchActiveChild("child-active");
+
+    vi.mocked(childProfileService.updateConsent).mockResolvedValueOnce({
+      ...other,
+      camera_consent: true,
+    });
+
+    await useChildStore
+      .getState()
+      .updateConsent("child-other", { camera_consent: true });
+
+    expect(useChildStore.getState().currentChild?.child_id).toBe("child-active");
+    expect(useChildStore.getState().currentChild?.camera_consent).toBe(false);
+    const otherInStore = useChildStore
+      .getState()
+      .childProfiles.find((p) => p.child_id === "child-other");
+    expect(otherInStore?.camera_consent).toBe(true);
   });
 });

--- a/frontend/src/api/services/childProfileService.test.ts
+++ b/frontend/src/api/services/childProfileService.test.ts
@@ -48,6 +48,26 @@ describe("childProfileService", () => {
     });
   });
 
+  it("patches consent flags through /consent (#587)", async () => {
+    const profile = {
+      child_id: "child-1",
+      name: "Milo",
+      age_group: "6-8" as const,
+      interests: [],
+      camera_consent: true,
+      microphone_consent: false,
+    };
+    vi.mocked(apiClient.patch).mockResolvedValueOnce({ data: profile });
+
+    await expect(
+      childProfileService.updateConsent("child-1", { camera_consent: true }),
+    ).resolves.toBe(profile);
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      "/child-profiles/child-1/consent",
+      { camera_consent: true },
+    );
+  });
+
   it("updates, defaults, and archives encoded child ids", async () => {
     const profile = {
       child_id: "child alpha",

--- a/frontend/src/api/services/childProfileService.ts
+++ b/frontend/src/api/services/childProfileService.ts
@@ -1,6 +1,7 @@
 import apiClient from "../client";
 import type {
   ChildProfile,
+  ChildProfileConsentUpdateRequest,
   ChildProfileCreateRequest,
   ChildProfileListResponse,
   ChildProfileUpdateRequest,
@@ -45,6 +46,17 @@ export const childProfileService = {
   async archive(childId: string): Promise<ChildProfile> {
     const response = await apiClient.post<ChildProfile>(
       `${CHILD_PROFILE_BASE}/${encodeURIComponent(childId)}/archive`,
+    );
+    return response.data;
+  },
+
+  async updateConsent(
+    childId: string,
+    payload: ChildProfileConsentUpdateRequest,
+  ): Promise<ChildProfile> {
+    const response = await apiClient.patch<ChildProfile>(
+      `${CHILD_PROFILE_BASE}/${encodeURIComponent(childId)}/consent`,
+      payload,
     );
     return response.data;
   },

--- a/frontend/src/store/useChildStore.ts
+++ b/frontend/src/store/useChildStore.ts
@@ -4,6 +4,7 @@ import { childProfileService } from '@/api/services/childProfileService'
 import type {
   AgeGroup,
   ChildProfile,
+  ChildProfileConsentUpdateRequest,
   ChildProfileCreateRequest,
   ChildProfileUpdateRequest,
 } from '@/types/api'
@@ -43,6 +44,7 @@ interface ChildState {
   saveChildProfile: (childId: string, payload: ChildProfileUpdateRequest) => Promise<ChildProfile>
   archiveChildProfile: (childId: string) => Promise<ChildProfile>
   setDefaultChildProfile: (childId: string) => Promise<ChildProfile>
+  updateConsent: (childId: string, payload: ChildProfileConsentUpdateRequest) => Promise<ChildProfile>
   switchActiveChild: (childId: string) => void
 }
 
@@ -228,6 +230,17 @@ const useChildStore = create<ChildState>()(
         }))
         get().setChildProfiles(mergeProfile(profiles, updated))
         get().switchActiveChild(updated.child_id)
+        return updated
+      },
+
+      updateConsent: async (childId, payload) => {
+        const updated = await childProfileService.updateConsent(childId, payload)
+        const merged = mergeProfile(get().childProfiles, updated)
+        const isCurrent = get().currentChild?.child_id === updated.child_id
+        set({
+          childProfiles: merged,
+          currentChild: isCurrent ? updated : get().currentChild,
+        })
         return updated
       },
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -517,6 +517,8 @@ export interface ChildProfile {
   avatar?: string | null;
   is_default?: boolean;
   archived_at?: string | null;
+  camera_consent?: boolean;
+  microphone_consent?: boolean;
   created_at?: string;
   updated_at?: string;
 }
@@ -537,6 +539,14 @@ export interface ChildProfileUpdateRequest {
   age_group?: AgeGroup;
   interests?: string[];
   avatar?: string | null;
+}
+
+// PATCH /child-profiles/{child_id}/consent (#587).
+// At least one of camera_consent or microphone_consent must be supplied; the
+// backend rejects an empty body with 422.
+export interface ChildProfileConsentUpdateRequest {
+  camera_consent?: boolean;
+  microphone_consent?: boolean;
 }
 
 // Upload status


### PR DESCRIPTION
## Summary

Adds the gating story for epic #579 (Tablet & Mobile Capture Modalities):
- New `camera_consent` and `microphone_consent` boolean columns on `child_profiles`, defaulting to `false`.
- Parent-only `PATCH /api/v1/child-profiles/{child_id}/consent` endpoint that toggles either or both flags.
- Frontend types, service, and `useChildStore.updateConsent` action to surface the flags.

Children cannot bootstrap their own consent — a parent must grant it explicitly. The schema migration uses the existing `column_exists()` guard so it's idempotent and reversible.

Unblocks server-side enforcement on `/transcriptions` (#583) and the consent gates in #585/#586.

## Why

PRD §3.15 requires that camera/mic surfaces are gated by parent consent before the browser permission prompt ever fires. Today there's no place to store that consent — this PR adds the storage and the parent-only API to flip it. The browser-side gate UI is deferred to the stories that consume the flags (#581 CameraCapture, #584 VoiceInputButton) so we don't ship unused UI.

## Changes

### Backend (commit 1)
- `backend/src/services/database/schema.py` — `camera_consent INTEGER DEFAULT 0` and `microphone_consent INTEGER DEFAULT 0` added to `CHILD_PROFILES_TABLE`; new `_migrate_add_child_profile_consent_columns()` registered in `init_schema()`.
- `backend/src/services/database/child_profile_repository.py` — `ChildProfileData` gains two bool fields; row mapping reads them; new `update_consent()` method with partial PATCH semantics.
- `backend/src/api/models.py` — `ChildProfileResponse` gains both flags; new `ChildProfileConsentUpdateRequest` with `model_validator` that rejects empty bodies (422).
- `backend/src/api/routes/child_profiles.py` — new `PATCH /{child_id}/consent` handler reusing `_require_parent` and `_not_found` for consistency with sibling endpoints.
- `backend/tests/contracts/test_child_profile_consent_contract.py` — 12 new contract tests.

### Frontend (commit 2)
- `frontend/src/types/api.ts` — `ChildProfile` gains optional consent flags; new `ChildProfileConsentUpdateRequest`.
- `frontend/src/api/services/childProfileService.ts` — new `updateConsent()` method.
- `frontend/src/store/useChildStore.ts` — new `updateConsent()` action that merges into `childProfiles` and updates `currentChild` only when the target is active.
- Tests in `useChildStore.test.ts` and `childProfileService.test.ts`.

## Test plan

- [x] `pytest backend/tests/contracts/test_child_profile_consent_contract.py` → 12/12 pass
- [x] `pytest backend/tests/contracts/test_child_profiles_contract.py` → 6/6 pass (no regressions)
- [x] `vitest run` → 183/183 frontend tests pass
- [x] `tsc -b` → clean
- [ ] Manual: parent grants camera consent → response shows `camera_consent: true`, microphone untouched
- [ ] Manual: parent revokes consent → flag flips back to `false`
- [ ] Manual: child-role token attempts PATCH → 403 with `PARENT_ROLE_REQUIRED`

## Notes / heads-up

- `backend/tests/contracts/test_default_child_id_contract.py` has 2 failing tests on this branch — verified they also fail on `main` (pre-existing, unrelated to this PR).
- Server-side enforcement of `microphone_consent` on the transcription endpoint is intentionally deferred to #583, which owns that route.
- Consent revocation UI is deferred — the PATCH endpoint already supports `false`, so it's a UI-only follow-up.
- The original story plan named the consent gate `PermissionPrompt` and pointed it at `ParentApprovalPage`, but `/parent-approval` is an email-token landing page. The gate component will be designed as `ParentConsentGate` (in-app modal) by the consumer stories (#581/#584/#588).

Fixes #587
Parent Epic: #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)