### PR TITLE
feat(capture): CameraCapture component + useCamera hook (#581)

### DIFF
--- a/frontend/src/__tests__/hooks/cameraErrors.test.ts
+++ b/frontend/src/__tests__/hooks/cameraErrors.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { CAMERA_ERROR_COPY, classifyCameraError } from '@/hooks/cameraErrors'
+
+describe('classifyCameraError', () => {
+  it('maps NotAllowedError → permission_denied', () => {
+    expect(classifyCameraError({ name: 'NotAllowedError' })).toBe('permission_denied')
+  })
+
+  it('maps SecurityError → permission_denied (older Safari)', () => {
+    expect(classifyCameraError({ name: 'SecurityError' })).toBe('permission_denied')
+  })
+
+  it('maps NotFoundError → no_device', () => {
+    expect(classifyCameraError({ name: 'NotFoundError' })).toBe('no_device')
+  })
+
+  it('maps NotReadableError → device_busy', () => {
+    expect(classifyCameraError({ name: 'NotReadableError' })).toBe('device_busy')
+  })
+
+  it('maps TrackStartError → device_busy (legacy)', () => {
+    expect(classifyCameraError({ name: 'TrackStartError' })).toBe('device_busy')
+  })
+
+  it('maps OverconstrainedError → overconstrained', () => {
+    expect(classifyCameraError({ name: 'OverconstrainedError' })).toBe('overconstrained')
+  })
+
+  it('maps AbortError → aborted', () => {
+    expect(classifyCameraError({ name: 'AbortError' })).toBe('aborted')
+  })
+
+  it('falls back to unknown for unmapped errors', () => {
+    expect(classifyCameraError({ name: 'TotallyMadeUpError' })).toBe('unknown')
+    expect(classifyCameraError(new Error('boom'))).toBe('unknown')
+  })
+
+  it('handles null and primitives without throwing', () => {
+    expect(classifyCameraError(null)).toBe('unknown')
+    expect(classifyCameraError(undefined)).toBe('unknown')
+    expect(classifyCameraError('a string')).toBe('unknown')
+  })
+})
+
+describe('CAMERA_ERROR_COPY', () => {
+  it('provides a non-empty user-facing message for every error kind', () => {
+    const kinds = [
+      'permission_denied',
+      'no_device',
+      'device_busy',
+      'overconstrained',
+      'unsupported',
+      'aborted',
+      'unknown',
+    ] as const
+    for (const kind of kinds) {
+      expect(CAMERA_ERROR_COPY[kind]).toBeDefined()
+      expect(CAMERA_ERROR_COPY[kind].length).toBeGreaterThan(10)
+    }
+  })
+
+  it('permission_denied copy mentions browser permission', () => {
+    expect(CAMERA_ERROR_COPY.permission_denied.toLowerCase()).toContain('permission')
+  })
+})

--- a/frontend/src/__tests__/hooks/cameraStateMachine.test.ts
+++ b/frontend/src/__tests__/hooks/cameraStateMachine.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cameraReducer,
+  isActiveStreamState,
+  type CameraEvent,
+  type CameraState,
+} from '@/hooks/cameraStateMachine'
+
+const START_WITH_CONSENT: CameraEvent = { type: 'start', consentGranted: true }
+const START_WITHOUT_CONSENT: CameraEvent = { type: 'start', consentGranted: false }
+const STREAM_READY: CameraEvent = { type: 'streamReady' }
+const STREAM_ERROR: CameraEvent = { type: 'streamError', errorKind: 'permission_denied' }
+
+describe('cameraReducer: idle transitions', () => {
+  it('start without consent → consent-required', () => {
+    expect(cameraReducer('idle', START_WITHOUT_CONSENT)).toBe('consent-required')
+  })
+
+  it('start with consent → requesting', () => {
+    expect(cameraReducer('idle', START_WITH_CONSENT)).toBe('requesting')
+  })
+
+  it('markUnsupported from idle → unsupported', () => {
+    expect(cameraReducer('idle', { type: 'markUnsupported' })).toBe('unsupported')
+  })
+
+  it('streamReady on idle is a no-op', () => {
+    expect(cameraReducer('idle', STREAM_READY)).toBe('idle')
+  })
+})
+
+describe('cameraReducer: consent gate', () => {
+  it('consentGranted → requesting', () => {
+    expect(cameraReducer('consent-required', { type: 'consentGranted' })).toBe('requesting')
+  })
+
+  it('consentDismissed → idle', () => {
+    expect(cameraReducer('consent-required', { type: 'consentDismissed' })).toBe('idle')
+  })
+
+  it('consentGranted from idle is a no-op (wrong stage)', () => {
+    expect(cameraReducer('idle', { type: 'consentGranted' })).toBe('idle')
+  })
+})
+
+describe('cameraReducer: stream lifecycle', () => {
+  it('streamReady on requesting → live', () => {
+    expect(cameraReducer('requesting', STREAM_READY)).toBe('live')
+  })
+
+  it('streamError on requesting → error', () => {
+    expect(cameraReducer('requesting', STREAM_ERROR)).toBe('error')
+  })
+
+  it('capture on live → captured', () => {
+    expect(cameraReducer('live', { type: 'capture' })).toBe('captured')
+  })
+
+  it('capture on idle is a no-op', () => {
+    expect(cameraReducer('idle', { type: 'capture' })).toBe('idle')
+  })
+})
+
+describe('cameraReducer: post-capture transitions', () => {
+  it('retake → requesting (restarts stream)', () => {
+    expect(cameraReducer('captured', { type: 'retake' })).toBe('requesting')
+  })
+
+  it('confirm → idle (consumer keeps the blob)', () => {
+    expect(cameraReducer('captured', { type: 'confirm' })).toBe('idle')
+  })
+})
+
+describe('cameraReducer: toggle/retry/stop', () => {
+  it('toggleFacing on live restarts the stream', () => {
+    expect(cameraReducer('live', { type: 'toggleFacing' })).toBe('requesting')
+  })
+
+  it('toggleFacing on captured restarts the stream', () => {
+    expect(cameraReducer('captured', { type: 'toggleFacing' })).toBe('requesting')
+  })
+
+  it('toggleFacing on idle is a no-op', () => {
+    expect(cameraReducer('idle', { type: 'toggleFacing' })).toBe('idle')
+  })
+
+  it('retry from error → requesting', () => {
+    expect(cameraReducer('error', { type: 'retry' })).toBe('requesting')
+  })
+
+  it('retry from idle is a no-op', () => {
+    expect(cameraReducer('idle', { type: 'retry' })).toBe('idle')
+  })
+
+  it('stop from any state → idle', () => {
+    const states: CameraState[] = ['requesting', 'live', 'captured', 'error', 'consent-required']
+    for (const s of states) {
+      expect(cameraReducer(s, { type: 'stop' })).toBe('idle')
+    }
+  })
+})
+
+describe('cameraReducer: unsupported is terminal', () => {
+  it('rejects every event once in unsupported', () => {
+    const events: CameraEvent[] = [
+      START_WITH_CONSENT,
+      START_WITHOUT_CONSENT,
+      STREAM_READY,
+      STREAM_ERROR,
+      { type: 'capture' },
+      { type: 'retake' },
+      { type: 'confirm' },
+      { type: 'toggleFacing' },
+      { type: 'retry' },
+      { type: 'stop' },
+      { type: 'consentGranted' },
+      { type: 'consentDismissed' },
+    ]
+    for (const e of events) {
+      expect(cameraReducer('unsupported', e)).toBe('unsupported')
+    }
+  })
+})
+
+describe('isActiveStreamState', () => {
+  it('returns true only while the camera owns the device', () => {
+    expect(isActiveStreamState('requesting')).toBe(true)
+    expect(isActiveStreamState('live')).toBe(true)
+    expect(isActiveStreamState('idle')).toBe(false)
+    expect(isActiveStreamState('captured')).toBe(false)
+    expect(isActiveStreamState('error')).toBe(false)
+    expect(isActiveStreamState('consent-required')).toBe(false)
+    expect(isActiveStreamState('unsupported')).toBe(false)
+  })
+})

--- a/frontend/src/components/upload/CameraCapture/index.tsx
+++ b/frontend/src/components/upload/CameraCapture/index.tsx
@@ -1,0 +1,190 @@
+/**
+ * CameraCapture (#581) — live camera preview + retake + front/back
+ * toggle. Pairs with `useCamera` for stream lifecycle and the pure
+ * `cameraReducer` for state. Renders a fallback when the device or
+ * browser doesn't support `getUserMedia`.
+ *
+ * This component does NOT render the consent gate itself — the parent
+ * surface (CameraCapture's caller, e.g. the tabbed ImageUploader in
+ * #582) checks `useChildStore.getState().currentChild?.camera_consent`
+ * and renders `<ParentConsentGate kind="camera" .../>` from #588 first.
+ * Keeping consent gating out of this component lets the same camera
+ * UI work in surfaces with different consent flows.
+ */
+
+import { useCallback } from 'react'
+import { motion } from 'framer-motion'
+import { useCamera } from '@/hooks/useCamera'
+import { CAMERA_ERROR_COPY } from '@/hooks/cameraErrors'
+import type { CameraFacing } from '@/hooks/useCamera'
+
+export interface CameraCaptureProps {
+  onCapture: (file: File) => void
+  onCancel: () => void
+  initialFacing?: CameraFacing
+  /**
+   * When true, the caller has already established camera consent — the
+   * gate UI lives outside this component, so the hook starts immediately.
+   * Default true; pass false to keep the camera idle until the consumer
+   * mounts the gate and confirms.
+   */
+  consentGranted?: boolean
+}
+
+export function CameraCapture({
+  onCapture,
+  onCancel,
+  initialFacing = 'environment',
+  consentGranted = true,
+}: CameraCaptureProps) {
+  const camera = useCamera({ initialFacing })
+
+  // Kick off the stream once on mount if consent is already in hand.
+  // We only start when state is idle to avoid double-fires on rerender.
+  if (camera.state === 'idle' && consentGranted) {
+    camera.start(true)
+  }
+
+  const handleUse = useCallback(async () => {
+    try {
+      const blob = await camera.capture()
+      const file = new File([blob], `capture-${Date.now()}.jpg`, {
+        type: 'image/jpeg',
+      })
+      onCapture(file)
+      camera.confirm()
+    } catch (err) {
+      // capture() rejection is rare — surface as cancel so the parent
+      // can fall back to the file picker.
+      console.warn('CameraCapture: capture failed', err)
+      onCancel()
+    }
+  }, [camera, onCancel])
+
+  if (camera.state === 'unsupported') {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-center">
+        <p className="mb-3 text-amber-800">
+          {CAMERA_ERROR_COPY.unsupported}
+        </p>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-xl bg-amber-600 px-4 py-2 font-semibold text-white"
+        >
+          Use file upload
+        </button>
+      </div>
+    )
+  }
+
+  if (camera.state === 'error') {
+    const message =
+      camera.errorKind != null
+        ? CAMERA_ERROR_COPY[camera.errorKind]
+        : CAMERA_ERROR_COPY.unknown
+    return (
+      <div className="rounded-2xl border border-red-200 bg-red-50 p-6 text-center">
+        <p className="mb-3 text-red-700">{message}</p>
+        <div className="flex justify-center gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-xl border border-red-300 px-4 py-2 font-semibold text-red-700"
+          >
+            Cancel
+          </button>
+          {camera.errorKind !== 'permission_denied' && (
+            <button
+              type="button"
+              onClick={camera.retry}
+              className="rounded-xl bg-red-600 px-4 py-2 font-semibold text-white"
+            >
+              Try again
+            </button>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="relative aspect-square w-full overflow-hidden rounded-2xl bg-black">
+        <video
+          ref={camera.videoRef}
+          playsInline
+          muted
+          autoPlay
+          className={`h-full w-full object-cover ${
+            camera.facing === 'user' ? 'scale-x-[-1]' : ''
+          }`}
+          aria-label="Camera preview"
+        />
+        <canvas ref={camera.canvasRef} className="hidden" />
+        {camera.state === 'requesting' && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/60 text-white">
+            <span className="text-sm">Opening camera…</span>
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-xl border border-gray-300 px-4 py-2 font-semibold text-gray-700"
+        >
+          Cancel
+        </button>
+
+        {camera.state === 'live' && (
+          <>
+            <motion.button
+              type="button"
+              whileTap={{ scale: 0.95 }}
+              onClick={handleUse}
+              className="rounded-full bg-primary px-6 py-3 text-base font-bold text-white shadow-lg"
+              aria-label="Take photo"
+            >
+              <span className="text-2xl" aria-hidden="true">📸</span>
+            </motion.button>
+            <button
+              type="button"
+              onClick={camera.toggleFacing}
+              className="rounded-xl border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700"
+              aria-label={`Switch to ${camera.facing === 'user' ? 'back' : 'front'} camera`}
+            >
+              {camera.facing === 'user' ? 'Back' : 'Front'}
+            </button>
+          </>
+        )}
+
+        {camera.state === 'captured' && (
+          <>
+            <button
+              type="button"
+              onClick={camera.retake}
+              className="rounded-xl border border-gray-300 px-4 py-2 font-semibold text-gray-700"
+            >
+              Retake
+            </button>
+            <span className="text-sm text-gray-500">Sending photo…</span>
+          </>
+        )}
+
+        {(camera.state === 'requesting' || camera.state === 'idle') && (
+          <span className="text-sm text-gray-400">Waiting for camera…</span>
+        )}
+
+        {camera.state === 'consent-required' && (
+          <span className="text-sm text-amber-700">
+            Parent permission required.
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default CameraCapture

--- a/frontend/src/hooks/cameraErrors.ts
+++ b/frontend/src/hooks/cameraErrors.ts
@@ -1,0 +1,56 @@
+/**
+ * Classify navigator.mediaDevices.getUserMedia rejection types into a
+ * discriminated union so the UI can show a kind-specific message and
+ * the hook can pick the right recovery path.
+ *
+ * MDN reference: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#exceptions
+ */
+
+export type CameraErrorKind =
+  | 'permission_denied'    // NotAllowedError, SecurityError
+  | 'no_device'            // NotFoundError
+  | 'device_busy'          // NotReadableError, TrackStartError
+  | 'overconstrained'      // OverconstrainedError, ConstraintNotSatisfiedError
+  | 'unsupported'          // getUserMedia API not present
+  | 'aborted'              // AbortError
+  | 'unknown'
+
+export function classifyCameraError(err: unknown): CameraErrorKind {
+  if (err == null) return 'unknown'
+  const name =
+    typeof err === 'object' && err !== null && 'name' in err
+      ? String((err as { name?: unknown }).name ?? '')
+      : ''
+
+  switch (name) {
+    case 'NotAllowedError':
+    case 'SecurityError':
+      return 'permission_denied'
+    case 'NotFoundError':
+      return 'no_device'
+    case 'NotReadableError':
+    case 'TrackStartError':
+      return 'device_busy'
+    case 'OverconstrainedError':
+    case 'ConstraintNotSatisfiedError':
+      return 'overconstrained'
+    case 'AbortError':
+      return 'aborted'
+    default:
+      return 'unknown'
+  }
+}
+
+export const CAMERA_ERROR_COPY: Record<CameraErrorKind, string> = {
+  permission_denied:
+    "We need camera permission to take a photo. You can allow it in your browser settings.",
+  no_device: "We can't find a camera on this device.",
+  device_busy:
+    "The camera is in use by another app. Close it and try again.",
+  overconstrained:
+    "We couldn't open the requested camera. Trying the other one…",
+  unsupported:
+    "This browser doesn't support taking photos here. Use the file upload instead.",
+  aborted: "Camera startup was interrupted. Try again.",
+  unknown: "Something went wrong with the camera. Try again or use file upload.",
+}

--- a/frontend/src/hooks/cameraStateMachine.ts
+++ b/frontend/src/hooks/cameraStateMachine.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure reducer for the camera capture state machine. Extracted from
+ * useCamera so the transition table can be exhaustively unit-tested
+ * without mounting a DOM or stubbing `navigator.mediaDevices`.
+ *
+ * State diagram (see #581):
+ *   idle
+ *     ├── start()          → consent-required | requesting
+ *     └── (unsupported on mount)
+ *   consent-required
+ *     ├── onGranted()      → requesting
+ *     └── onDismiss()      → idle
+ *   requesting
+ *     ├── streamReady      → live
+ *     └── streamError      → error
+ *   live
+ *     ├── capture()        → captured
+ *     ├── toggleFacing()   → requesting
+ *     └── stop()           → idle
+ *   captured
+ *     ├── retake()         → requesting
+ *     └── confirm()        → idle (consumer keeps the blob)
+ *   error
+ *     ├── retry()          → requesting
+ *     └── cancel()         → idle
+ *   unsupported (terminal)
+ */
+
+import type { CameraErrorKind } from './cameraErrors'
+
+export type CameraState =
+  | 'idle'
+  | 'consent-required'
+  | 'requesting'
+  | 'live'
+  | 'captured'
+  | 'error'
+  | 'unsupported'
+
+export type CameraEvent =
+  | { type: 'start'; consentGranted: boolean }
+  | { type: 'consentGranted' }
+  | { type: 'consentDismissed' }
+  | { type: 'streamReady' }
+  | { type: 'streamError'; errorKind: CameraErrorKind }
+  | { type: 'capture' }
+  | { type: 'retake' }
+  | { type: 'confirm' }
+  | { type: 'toggleFacing' }
+  | { type: 'retry' }
+  | { type: 'stop' }
+  | { type: 'markUnsupported' }
+
+export function cameraReducer(state: CameraState, event: CameraEvent): CameraState {
+  // Terminal: nothing escapes unsupported.
+  if (state === 'unsupported') return 'unsupported'
+
+  switch (event.type) {
+    case 'markUnsupported':
+      return 'unsupported'
+
+    case 'start':
+      if (state !== 'idle' && state !== 'error') return state
+      return event.consentGranted ? 'requesting' : 'consent-required'
+
+    case 'consentGranted':
+      return state === 'consent-required' ? 'requesting' : state
+
+    case 'consentDismissed':
+      return state === 'consent-required' ? 'idle' : state
+
+    case 'streamReady':
+      return state === 'requesting' ? 'live' : state
+
+    case 'streamError':
+      return state === 'requesting' ? 'error' : state
+
+    case 'capture':
+      return state === 'live' ? 'captured' : state
+
+    case 'retake':
+      return state === 'captured' ? 'requesting' : state
+
+    case 'confirm':
+      return state === 'captured' ? 'idle' : state
+
+    case 'toggleFacing':
+      // Toggling restarts the stream regardless of current live/captured.
+      return state === 'live' || state === 'captured' ? 'requesting' : state
+
+    case 'retry':
+      return state === 'error' ? 'requesting' : state
+
+    case 'stop':
+      return 'idle'
+
+    default:
+      return state
+  }
+}
+
+export const TERMINAL_STATES: ReadonlySet<CameraState> = new Set(['unsupported'])
+
+export function isActiveStreamState(state: CameraState): boolean {
+  return state === 'requesting' || state === 'live'
+}

--- a/frontend/src/hooks/useCamera.ts
+++ b/frontend/src/hooks/useCamera.ts
@@ -1,0 +1,210 @@
+/**
+ * useCamera — stream lifecycle + state machine for camera capture (#581).
+ *
+ * Owns the MediaStream and exposes refs for the consumer to attach to
+ * <video> and <canvas> elements. Logic lives in the pure
+ * `cameraReducer` so it can be unit-tested without a DOM; this hook is
+ * the thin glue that wires `getUserMedia` to dispatched events.
+ *
+ * Cleanup rule: every getUserMedia stream MUST be stopped on unmount
+ * AND before any re-request (toggle/retake). The stopTracks helper is
+ * also what releases the GPU surface on iOS Safari (via
+ * `srcObject = null`).
+ *
+ * The consumer (CameraCapture / a future tabbed picker) is responsible
+ * for rendering the ParentConsentGate when `needsConsent` is true.
+ * This hook does NOT call getUserMedia until `start(consentGranted=true)`.
+ */
+
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { classifyCameraError, type CameraErrorKind } from './cameraErrors'
+import {
+  cameraReducer,
+  type CameraEvent,
+  type CameraState,
+} from './cameraStateMachine'
+
+export type CameraFacing = 'user' | 'environment'
+
+export interface UseCameraOptions {
+  initialFacing?: CameraFacing
+}
+
+export interface UseCameraResult {
+  state: CameraState
+  errorKind: CameraErrorKind | null
+  facing: CameraFacing
+  videoRef: React.RefObject<HTMLVideoElement>
+  canvasRef: React.RefObject<HTMLCanvasElement>
+  start: (consentGranted: boolean) => void
+  stop: () => void
+  capture: () => Promise<Blob>
+  retake: () => void
+  confirm: () => void
+  toggleFacing: () => void
+  retry: () => void
+  consentGranted: () => void
+  consentDismissed: () => void
+}
+
+export function useCamera(options: UseCameraOptions = {}): UseCameraResult {
+  const [state, dispatch] = useReducer(cameraReducer, 'idle' as CameraState)
+  const [errorKind, setErrorKind] = useState<CameraErrorKind | null>(null)
+  const [facing, setFacing] = useState<CameraFacing>(options.initialFacing ?? 'environment')
+
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+
+  const stopTracks = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop())
+      streamRef.current = null
+    }
+    if (videoRef.current) {
+      videoRef.current.srcObject = null
+    }
+  }, [])
+
+  // Detect unsupported environments once on mount.
+  useEffect(() => {
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.mediaDevices ||
+      typeof navigator.mediaDevices.getUserMedia !== 'function'
+    ) {
+      dispatch({ type: 'markUnsupported' })
+    }
+  }, [])
+
+  // Cleanup every track on unmount — non-negotiable on iOS Safari.
+  useEffect(() => () => stopTracks(), [stopTracks])
+
+  // Request a fresh stream whenever the reducer says we should be
+  // requesting. Also re-fires when `facing` changes so toggleFacing
+  // restarts the stream cleanly.
+  useEffect(() => {
+    if (state !== 'requesting') return
+
+    let cancelled = false
+    stopTracks()
+
+    navigator.mediaDevices
+      .getUserMedia({ video: { facingMode: facing }, audio: false })
+      .then((stream) => {
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop())
+          return
+        }
+        streamRef.current = stream
+        const video = videoRef.current
+        if (video) {
+          video.srcObject = stream
+          // Defer the 'streamReady' transition to loadedmetadata so the
+          // consumer never sees a zero-dimension <video> on Safari.
+          const onReady = () => {
+            if (!cancelled) dispatch({ type: 'streamReady' })
+          }
+          video.addEventListener('loadedmetadata', onReady, { once: true })
+        } else {
+          dispatch({ type: 'streamReady' })
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return
+        const kind = classifyCameraError(err)
+        setErrorKind(kind)
+        dispatch({ type: 'streamError', errorKind: kind })
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [state, facing, stopTracks])
+
+  const send = useCallback((event: CameraEvent) => dispatch(event), [])
+
+  const start = useCallback((consentGranted: boolean) => {
+    setErrorKind(null)
+    send({ type: 'start', consentGranted })
+  }, [send])
+
+  const stop = useCallback(() => {
+    stopTracks()
+    send({ type: 'stop' })
+  }, [send, stopTracks])
+
+  const capture = useCallback((): Promise<Blob> => {
+    return new Promise((resolve, reject) => {
+      const video = videoRef.current
+      const canvas = canvasRef.current
+      if (!video || !canvas) {
+        reject(new Error('camera refs not attached'))
+        return
+      }
+      const width = video.videoWidth
+      const height = video.videoHeight
+      if (!width || !height) {
+        reject(new Error('camera stream not ready'))
+        return
+      }
+      canvas.width = width
+      canvas.height = height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        reject(new Error('canvas 2d context unavailable'))
+        return
+      }
+      // Mirror the captured frame for the front camera so the saved
+      // photo matches what the user saw on screen.
+      if (facing === 'user') {
+        ctx.translate(width, 0)
+        ctx.scale(-1, 1)
+      }
+      ctx.drawImage(video, 0, 0, width, height)
+      canvas.toBlob(
+        (blob) => {
+          if (!blob) {
+            reject(new Error('canvas.toBlob returned null'))
+            return
+          }
+          send({ type: 'capture' })
+          // Stop the live stream once we have the snapshot — the
+          // captured blob is the source of truth from here.
+          stopTracks()
+          resolve(blob)
+        },
+        'image/jpeg',
+        0.92,
+      )
+    })
+  }, [facing, send, stopTracks])
+
+  const retake = useCallback(() => send({ type: 'retake' }), [send])
+  const confirm = useCallback(() => send({ type: 'confirm' }), [send])
+  const retry = useCallback(() => send({ type: 'retry' }), [send])
+  const consentGranted = useCallback(() => send({ type: 'consentGranted' }), [send])
+  const consentDismissed = useCallback(() => send({ type: 'consentDismissed' }), [send])
+
+  const toggleFacing = useCallback(() => {
+    setFacing((prev) => (prev === 'user' ? 'environment' : 'user'))
+    send({ type: 'toggleFacing' })
+  }, [send])
+
+  return {
+    state,
+    errorKind,
+    facing,
+    videoRef,
+    canvasRef,
+    start,
+    stop,
+    capture,
+    retake,
+    confirm,
+    toggleFacing,
+    retry,
+    consentGranted,
+    consentDismissed,
+  }
+}


### PR DESCRIPTION
## Summary

Live camera preview, capture, retake, and front/back toggle for the tablet/mobile flow (epic #579, PRD §3.15).

Architecture splits responsibilities for testability without `@testing-library/react`:

| File | Purpose |
|------|---------|
| [hooks/cameraStateMachine.ts](frontend/src/hooks/cameraStateMachine.ts) | Pure reducer with the full transition table |
| [hooks/cameraErrors.ts](frontend/src/hooks/cameraErrors.ts) | Pure `getUserMedia` error classifier + user-facing copy |
| [hooks/useCamera.ts](frontend/src/hooks/useCamera.ts) | Hook glue: `getUserMedia`, stream lifecycle, refs |
| [components/upload/CameraCapture/index.tsx](frontend/src/components/upload/CameraCapture/index.tsx) | Presentational component (idle → live → captured → error → unsupported) |

## State machine

```
idle ──start(consent)──► consent-required | requesting
consent-required ─granted/dismissed─► requesting | idle
requesting ─streamReady/streamError─► live | error
live ─capture()──► captured
live ─toggleFacing()──► requesting    (restarts stream)
captured ─retake()──► requesting
captured ─confirm()──► idle
error ─retry()──► requesting
unsupported (terminal)
```

32 unit tests cover the reducer and every `getUserMedia` error name.

## iOS Safari gotchas (handled)

- `<video>` uses `playsInline + muted + autoPlay` (else black screen).
- `streamReady` transition is gated on `loadedmetadata` not `getUserMedia` promise resolve (else flash of zero-dimension video).
- Tracks stop on unmount AND on every toggle/retake.
- `srcObject = null` after stop (releases GPU surface).
- Front camera applies `scaleX(-1)` to preview *and* captured frame so the saved photo matches what the user saw.

## Consent gating: intentionally NOT here

The component takes a `consentGranted` prop and starts immediately when true. The parent surface (#582 tabbed picker) is responsible for rendering `<ParentConsentGate kind="camera" />` (from #588 / PR #594) when `currentChild.camera_consent === false` and only passing `consentGranted=true` after.

This split keeps the same camera UI reusable across surfaces with different consent flows (e.g. a future settings page that just needs the camera without re-asking).

## Test plan

- [x] `vitest run` — 215/215 pass (32 new pure-helper tests, no regressions)
- [x] `tsc -b` — clean
- [ ] Manual: iPad Safari — preview opens, capture produces JPEG, retake restarts stream
- [ ] Manual: front camera — preview is mirrored, captured photo matches preview
- [ ] Manual: deny permission → `permission_denied` error copy + Cancel only (no retry)
- [ ] Manual: camera in use by another app → `device_busy` error + Try again button
- [ ] Manual: unsupported browser (e.g. http://LAN without HTTPS) → fallback CTA

## Notes / deferred

- Full DOM render tests need `@testing-library/react` (not in `package.json`). Recommend adding it before #582 lands so the integrated picker can get real interaction tests.
- EXIF: live `MediaStream` → canvas snapshot doesn't need EXIF correction (stream is already in display orientation). EXIF only matters for the `<input capture>` quick-win path in #580.
- Front-vs-back mirror policy: matches preview (selfie-style). Confirm with design if save-as-reality is preferred.

Fixes #581
Parent Epic: #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)