### PR TITLE
feat(capture): VoiceInputButton + useVoiceInput hook (#584)

### DIFF
--- a/frontend/src/__tests__/hooks/voiceInputStateMachine.test.ts
+++ b/frontend/src/__tests__/hooks/voiceInputStateMachine.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isBusyState,
+  voiceReducer,
+  type VoiceInputEvent,
+  type VoiceInputState,
+} from '@/hooks/voiceInputStateMachine'
+
+const START_WITH_CONSENT: VoiceInputEvent = { type: 'start', consentGranted: true }
+const START_WITHOUT_CONSENT: VoiceInputEvent = { type: 'start', consentGranted: false }
+
+describe('voiceReducer: idle/start transitions', () => {
+  it('start without consent → consent-required', () => {
+    expect(voiceReducer('idle', START_WITHOUT_CONSENT)).toBe('consent-required')
+  })
+
+  it('start with consent → requesting', () => {
+    expect(voiceReducer('idle', START_WITH_CONSENT)).toBe('requesting')
+  })
+
+  it('start from done re-enters the flow', () => {
+    expect(voiceReducer('done', START_WITH_CONSENT)).toBe('requesting')
+  })
+
+  it('start from rejected re-enters the flow', () => {
+    expect(voiceReducer('rejected', START_WITH_CONSENT)).toBe('requesting')
+  })
+
+  it('start from error re-enters the flow', () => {
+    expect(voiceReducer('error', START_WITH_CONSENT)).toBe('requesting')
+  })
+
+  it('start during recording is a no-op (already busy)', () => {
+    expect(voiceReducer('recording', START_WITH_CONSENT)).toBe('recording')
+  })
+})
+
+describe('voiceReducer: consent gate', () => {
+  it('consentGranted on consent-required → requesting', () => {
+    expect(voiceReducer('consent-required', { type: 'consentGranted' })).toBe('requesting')
+  })
+
+  it('consentDismissed → idle', () => {
+    expect(voiceReducer('consent-required', { type: 'consentDismissed' })).toBe('idle')
+  })
+
+  it('consentGranted from wrong state is a no-op', () => {
+    expect(voiceReducer('idle', { type: 'consentGranted' })).toBe('idle')
+  })
+})
+
+describe('voiceReducer: stream lifecycle', () => {
+  it('streamReady on requesting → recording', () => {
+    expect(voiceReducer('requesting', { type: 'streamReady' })).toBe('recording')
+  })
+
+  it('streamError on requesting → error', () => {
+    expect(voiceReducer('requesting', { type: 'streamError' })).toBe('error')
+  })
+
+  it('stopRecording → processing', () => {
+    expect(voiceReducer('recording', { type: 'stopRecording' })).toBe('processing')
+  })
+
+  it('stopRecording on idle is a no-op', () => {
+    expect(voiceReducer('idle', { type: 'stopRecording' })).toBe('idle')
+  })
+})
+
+describe('voiceReducer: transcription outcomes', () => {
+  it('transcriptionPassed → done', () => {
+    expect(voiceReducer('processing', { type: 'transcriptionPassed' })).toBe('done')
+  })
+
+  it('transcriptionRejected → rejected (safety failed)', () => {
+    expect(voiceReducer('processing', { type: 'transcriptionRejected' })).toBe('rejected')
+  })
+
+  it('transcriptionError → error', () => {
+    expect(voiceReducer('processing', { type: 'transcriptionError' })).toBe('error')
+  })
+
+  it('transcriptionPassed from other states is a no-op', () => {
+    expect(voiceReducer('recording', { type: 'transcriptionPassed' })).toBe('recording')
+  })
+})
+
+describe('voiceReducer: reset + unsupported', () => {
+  it('reset → idle from any state', () => {
+    const states: VoiceInputState[] = [
+      'recording', 'processing', 'done', 'rejected', 'error', 'consent-required',
+    ]
+    for (const s of states) {
+      expect(voiceReducer(s, { type: 'reset' })).toBe('idle')
+    }
+  })
+
+  it('unsupported is terminal', () => {
+    const events: VoiceInputEvent[] = [
+      START_WITH_CONSENT, { type: 'streamReady' }, { type: 'reset' },
+      { type: 'transcriptionPassed' },
+    ]
+    for (const e of events) {
+      expect(voiceReducer('unsupported', e)).toBe('unsupported')
+    }
+  })
+})
+
+describe('isBusyState', () => {
+  it('returns true only when the hook owns hardware or the server', () => {
+    expect(isBusyState('requesting')).toBe(true)
+    expect(isBusyState('recording')).toBe(true)
+    expect(isBusyState('processing')).toBe(true)
+    expect(isBusyState('idle')).toBe(false)
+    expect(isBusyState('done')).toBe(false)
+    expect(isBusyState('rejected')).toBe(false)
+    expect(isBusyState('error')).toBe(false)
+  })
+})

--- a/frontend/src/api/services/transcriptionService.ts
+++ b/frontend/src/api/services/transcriptionService.ts
@@ -1,0 +1,32 @@
+import apiClient from "../client";
+
+export interface TranscriptionResponse {
+  text: string;
+  language: string;
+  duration_ms: number;
+  safety_passed: boolean;
+}
+
+export interface TranscribePayload {
+  audio: Blob;
+  filename: string;
+  targetAge: number;
+  languageHint?: string;
+}
+
+export const transcriptionService = {
+  async transcribe(payload: TranscribePayload): Promise<TranscriptionResponse> {
+    const form = new FormData();
+    form.append("audio", payload.audio, payload.filename);
+    form.append("target_age", String(payload.targetAge));
+    if (payload.languageHint) {
+      form.append("language_hint", payload.languageHint);
+    }
+    const response = await apiClient.post<TranscriptionResponse>(
+      "/audio/transcriptions",
+      form,
+      { headers: { "Content-Type": "multipart/form-data" } },
+    );
+    return response.data;
+  },
+};

--- a/frontend/src/components/common/VoiceInputButton/index.tsx
+++ b/frontend/src/components/common/VoiceInputButton/index.tsx
@@ -1,0 +1,110 @@
+/**
+ * VoiceInputButton (#584) — drop-in mic button that records audio,
+ * posts to /api/v1/audio/transcriptions, and calls onText with the
+ * safety-moderated transcript.
+ *
+ * Designed to sit next to any <input> or <textarea>. The consumer
+ * (e.g. InteractiveStoryPage in #585, AgentChatPanel in #586) decides
+ * what to do with the returned text — append vs replace, truncate vs not.
+ *
+ * Consent gating: the consumer surface is responsible for rendering
+ * <ParentConsentGate kind="microphone" /> (from #588) when
+ * currentChild.microphone_consent is false. This component takes a
+ * consentGranted prop and starts immediately when true.
+ */
+
+import { useCallback } from 'react'
+import { motion } from 'framer-motion'
+import { useVoiceInput, type AgeBand } from '@/hooks/useVoiceInput'
+
+export interface VoiceInputButtonProps {
+  ageGroup: AgeBand
+  onText: (text: string) => void
+  contextHint?: string
+  maxDurationMs?: number
+  /**
+   * When true, the caller has already established mic consent. When
+   * false, the button stays in idle and the consumer should mount the
+   * consent gate, then update this prop.
+   */
+  consentGranted?: boolean
+  className?: string
+}
+
+const STATUS_COPY: Record<string, string> = {
+  idle: 'Tap to speak',
+  'consent-required': 'Parent permission needed',
+  requesting: 'Asking for microphone…',
+  recording: "I'm listening — tap to stop",
+  processing: 'Working on what you said…',
+  done: 'Got it!',
+  rejected: "Didn't catch that. Try again?",
+  error: "Microphone trouble. Try again or type instead.",
+  unsupported: "This browser can't record voice yet.",
+}
+
+export function VoiceInputButton({
+  ageGroup,
+  onText,
+  maxDurationMs,
+  consentGranted = true,
+  className = '',
+}: VoiceInputButtonProps) {
+  const voice = useVoiceInput({ ageGroup, maxDurationMs, onText })
+
+  const handleToggle = useCallback(() => {
+    if (voice.state === 'recording') {
+      voice.stop()
+    } else if (voice.state === 'idle' || voice.state === 'done' || voice.state === 'rejected' || voice.state === 'error') {
+      voice.start(consentGranted)
+    }
+  }, [voice, consentGranted])
+
+  const disabled =
+    voice.state === 'unsupported' ||
+    voice.state === 'requesting' ||
+    voice.state === 'processing' ||
+    voice.state === 'consent-required'
+
+  const recording = voice.state === 'recording'
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      <motion.button
+        type="button"
+        onClick={handleToggle}
+        disabled={disabled}
+        whileTap={disabled ? undefined : { scale: 0.92 }}
+        animate={
+          recording
+            ? { scale: [1, 1.08, 1] }
+            : { scale: 1 }
+        }
+        transition={
+          recording
+            ? { duration: 1, repeat: Infinity }
+            : { duration: 0.2 }
+        }
+        className={`
+          inline-flex h-12 w-12 items-center justify-center rounded-full
+          text-2xl shadow-md transition-colors
+          ${recording ? 'bg-red-500 text-white' : 'bg-primary text-white'}
+          disabled:cursor-not-allowed disabled:opacity-60
+        `}
+        aria-label={recording ? 'Stop recording' : 'Start voice input'}
+        aria-pressed={recording}
+      >
+        <span aria-hidden="true">{recording ? '⏹️' : '🎤'}</span>
+      </motion.button>
+
+      <span
+        aria-live="polite"
+        className="text-sm text-gray-600"
+      >
+        {STATUS_COPY[voice.state] ?? STATUS_COPY.idle}
+      </span>
+    </div>
+  )
+}
+
+export default VoiceInputButton

--- a/frontend/src/hooks/useVoiceInput.ts
+++ b/frontend/src/hooks/useVoiceInput.ts
@@ -1,0 +1,227 @@
+/**
+ * useVoiceInput — records short audio via MediaRecorder, posts to
+ * /api/v1/audio/transcriptions, and returns the safety-moderated
+ * transcript (#584).
+ *
+ * State machine and helpers live in pure modules so they can be unit
+ * tested without DOM. This hook is the thin glue between the reducer,
+ * MediaRecorder, and the transcription service.
+ *
+ * Hard rules from PRD §3.15:
+ *   - Recording auto-stops at maxDurationMs (default 30s).
+ *   - Audio bytes only live in memory; the backend route enforces
+ *     no-disk-persistence on its side.
+ *   - Safety-failed transcripts surface as state='rejected' WITHOUT
+ *     invoking onText, so the input field never gets unsafe content.
+ */
+
+import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import {
+  transcriptionService,
+  type TranscriptionResponse,
+} from '@/api/services/transcriptionService'
+import {
+  voiceReducer,
+  type VoiceInputState,
+} from './voiceInputStateMachine'
+
+export type AgeBand = '3-5' | '6-8' | '9-12'
+
+export interface UseVoiceInputOptions {
+  ageGroup: AgeBand
+  maxDurationMs?: number
+  languageHint?: string
+  onText?: (text: string) => void
+  onRejected?: () => void
+  onError?: (kind: 'denied' | 'unknown') => void
+}
+
+export interface UseVoiceInputResult {
+  state: VoiceInputState
+  partialText: string
+  start: (consentGranted: boolean) => void
+  stop: () => void
+  reset: () => void
+  consentGranted: () => void
+  consentDismissed: () => void
+}
+
+const AGE_TO_TARGET: Record<AgeBand, number> = {
+  '3-5': 4,
+  '6-8': 7,
+  '9-12': 10,
+}
+
+function pickMimeType(): string {
+  if (typeof MediaRecorder === 'undefined') return ''
+  // Prefer webm/opus (Chrome/Firefox/Android) over mp4 (Safari).
+  const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/mpeg']
+  for (const candidate of candidates) {
+    if (MediaRecorder.isTypeSupported?.(candidate)) return candidate
+  }
+  return ''
+}
+
+function filenameFor(mime: string): string {
+  if (mime.includes('mp4')) return 'recording.mp4'
+  if (mime.includes('mpeg')) return 'recording.mp3'
+  return 'recording.webm'
+}
+
+export function useVoiceInput(options: UseVoiceInputOptions): UseVoiceInputResult {
+  const { ageGroup, maxDurationMs = 30_000, languageHint, onText, onRejected, onError } = options
+
+  const [state, dispatch] = useReducer(voiceReducer, 'idle' as VoiceInputState)
+  const [partialText, setPartialText] = useState('')
+
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const stopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Capability check on mount.
+  useEffect(() => {
+    if (
+      typeof navigator === 'undefined' ||
+      !navigator.mediaDevices?.getUserMedia ||
+      typeof MediaRecorder === 'undefined'
+    ) {
+      dispatch({ type: 'markUnsupported' })
+    }
+  }, [])
+
+  const clearTimer = useCallback(() => {
+    if (stopTimerRef.current != null) {
+      clearTimeout(stopTimerRef.current)
+      stopTimerRef.current = null
+    }
+  }, [])
+
+  const stopStream = useCallback(() => {
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop())
+      streamRef.current = null
+    }
+  }, [])
+
+  // Cleanup on unmount.
+  useEffect(() => () => {
+    clearTimer()
+    if (recorderRef.current && recorderRef.current.state !== 'inactive') {
+      try { recorderRef.current.stop() } catch { /* swallow */ }
+    }
+    stopStream()
+  }, [clearTimer, stopStream])
+
+  // Pump the request stage: get mic, start MediaRecorder, schedule the auto-stop.
+  useEffect(() => {
+    if (state !== 'requesting') return
+    let cancelled = false
+
+    navigator.mediaDevices
+      .getUserMedia({ audio: true, video: false })
+      .then((stream) => {
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop())
+          return
+        }
+        streamRef.current = stream
+        const mimeType = pickMimeType()
+        let recorder: MediaRecorder
+        try {
+          recorder = mimeType
+            ? new MediaRecorder(stream, { mimeType })
+            : new MediaRecorder(stream)
+        } catch (err) {
+          dispatch({ type: 'streamError' })
+          onError?.('unknown')
+          return
+        }
+        recorderRef.current = recorder
+        chunksRef.current = []
+        recorder.ondataavailable = (ev) => {
+          if (ev.data && ev.data.size > 0) chunksRef.current.push(ev.data)
+        }
+        recorder.onstop = async () => {
+          const collected = chunksRef.current
+          const effectiveMime = recorder.mimeType || mimeType || 'audio/webm'
+          const blob = new Blob(collected, { type: effectiveMime })
+          stopStream()
+          if (blob.size === 0) {
+            dispatch({ type: 'transcriptionRejected' })
+            onRejected?.()
+            return
+          }
+          try {
+            const result: TranscriptionResponse = await transcriptionService.transcribe({
+              audio: blob,
+              filename: filenameFor(effectiveMime),
+              targetAge: AGE_TO_TARGET[ageGroup],
+              languageHint,
+            })
+            if (!result.safety_passed || !result.text) {
+              setPartialText('')
+              dispatch({ type: 'transcriptionRejected' })
+              onRejected?.()
+              return
+            }
+            setPartialText(result.text)
+            dispatch({ type: 'transcriptionPassed' })
+            onText?.(result.text)
+          } catch (err) {
+            dispatch({ type: 'transcriptionError' })
+            onError?.('unknown')
+          }
+        }
+        recorder.start()
+        dispatch({ type: 'streamReady' })
+        clearTimer()
+        stopTimerRef.current = setTimeout(() => {
+          if (recorderRef.current && recorderRef.current.state === 'recording') {
+            recorderRef.current.stop()
+            dispatch({ type: 'stopRecording' })
+          }
+        }, maxDurationMs)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        const name = (err as { name?: string })?.name
+        const kind = name === 'NotAllowedError' || name === 'SecurityError' ? 'denied' : 'unknown'
+        dispatch({ type: 'streamError' })
+        onError?.(kind)
+      })
+
+    return () => { cancelled = true }
+  }, [state, ageGroup, maxDurationMs, languageHint, clearTimer, stopStream, onText, onRejected, onError])
+
+  const start = useCallback((consentGranted: boolean) => {
+    setPartialText('')
+    dispatch({ type: 'start', consentGranted })
+  }, [])
+
+  const stop = useCallback(() => {
+    clearTimer()
+    if (recorderRef.current && recorderRef.current.state === 'recording') {
+      recorderRef.current.stop()
+      dispatch({ type: 'stopRecording' })
+    }
+  }, [clearTimer])
+
+  const reset = useCallback(() => {
+    setPartialText('')
+    dispatch({ type: 'reset' })
+  }, [])
+
+  const consentGranted = useCallback(() => dispatch({ type: 'consentGranted' }), [])
+  const consentDismissed = useCallback(() => dispatch({ type: 'consentDismissed' }), [])
+
+  return {
+    state,
+    partialText,
+    start,
+    stop,
+    reset,
+    consentGranted,
+    consentDismissed,
+  }
+}

--- a/frontend/src/hooks/voiceInputStateMachine.ts
+++ b/frontend/src/hooks/voiceInputStateMachine.ts
@@ -1,0 +1,94 @@
+/**
+ * Pure reducer for the voice-input state machine (#584).
+ *
+ * Extracted from useVoiceInput so the transition table can be
+ * exhaustively unit-tested without mounting a DOM or stubbing
+ * MediaRecorder.
+ *
+ * States:
+ *   idle             — ready to record
+ *   consent-required — child profile has microphone_consent=false
+ *   requesting       — getUserMedia in flight (browser permission prompt)
+ *   recording        — actively recording audio
+ *   processing       — recording stopped, POSTing to /api/v1/audio/transcriptions
+ *   done             — transcript returned (safety_passed=true, non-empty text)
+ *   rejected         — server returned safety_passed=false (kid-friendly retry)
+ *   error            — anything else (denied, network, provider failure)
+ *   unsupported      — MediaRecorder / getUserMedia not available (terminal)
+ */
+
+export type VoiceInputState =
+  | 'idle'
+  | 'consent-required'
+  | 'requesting'
+  | 'recording'
+  | 'processing'
+  | 'done'
+  | 'rejected'
+  | 'error'
+  | 'unsupported'
+
+export type VoiceInputEvent =
+  | { type: 'start'; consentGranted: boolean }
+  | { type: 'consentGranted' }
+  | { type: 'consentDismissed' }
+  | { type: 'streamReady' }
+  | { type: 'streamError' }
+  | { type: 'stopRecording' }
+  | { type: 'transcriptionPassed' }
+  | { type: 'transcriptionRejected' }
+  | { type: 'transcriptionError' }
+  | { type: 'reset' }
+  | { type: 'markUnsupported' }
+
+export function voiceReducer(
+  state: VoiceInputState,
+  event: VoiceInputEvent,
+): VoiceInputState {
+  if (state === 'unsupported') return 'unsupported'
+
+  switch (event.type) {
+    case 'markUnsupported':
+      return 'unsupported'
+
+    case 'start':
+      if (state !== 'idle' && state !== 'done' && state !== 'rejected' && state !== 'error') {
+        return state
+      }
+      return event.consentGranted ? 'requesting' : 'consent-required'
+
+    case 'consentGranted':
+      return state === 'consent-required' ? 'requesting' : state
+
+    case 'consentDismissed':
+      return state === 'consent-required' ? 'idle' : state
+
+    case 'streamReady':
+      return state === 'requesting' ? 'recording' : state
+
+    case 'streamError':
+      return state === 'requesting' ? 'error' : state
+
+    case 'stopRecording':
+      return state === 'recording' ? 'processing' : state
+
+    case 'transcriptionPassed':
+      return state === 'processing' ? 'done' : state
+
+    case 'transcriptionRejected':
+      return state === 'processing' ? 'rejected' : state
+
+    case 'transcriptionError':
+      return state === 'processing' ? 'error' : state
+
+    case 'reset':
+      return 'idle'
+
+    default:
+      return state
+  }
+}
+
+export function isBusyState(state: VoiceInputState): boolean {
+  return state === 'requesting' || state === 'recording' || state === 'processing'
+}


### PR DESCRIPTION
## Summary

Drop-in mic button for the InteractiveStoryPage theme input (#585) and AgentChatPanel textarea (#586). Records audio via `MediaRecorder`, POSTs to `/api/v1/audio/transcriptions` (from PR #593), and calls `onText` with the safety-moderated transcript.

| File | Purpose |
|------|---------|
| [hooks/voiceInputStateMachine.ts](frontend/src/hooks/voiceInputStateMachine.ts) | Pure reducer (9 states × 12 events) |
| [hooks/useVoiceInput.ts](frontend/src/hooks/useVoiceInput.ts) | Hook glue: `MediaRecorder`, auto-stop timer, upload |
| [api/services/transcriptionService.ts](frontend/src/api/services/transcriptionService.ts) | Multipart POST helper |
| [components/common/VoiceInputButton/index.tsx](frontend/src/components/common/VoiceInputButton/index.tsx) | Mic button + status copy |

## State machine

```
idle ──start(consent)──► consent-required | requesting
consent-required ─granted/dismissed─► requesting | idle
requesting ─streamReady/streamError─► recording | error
recording ─stopRecording()──► processing
recording ─auto-stop timer (30s default)──► processing
processing ─transcriptionPassed──► done       (onText fires)
processing ─transcriptionRejected──► rejected (kid-friendly retry copy)
processing ─transcriptionError──► error
done | rejected | error ─start──► requesting (re-entry)
unsupported (terminal)
```

20 unit tests cover the reducer.

## Hard rules (PRD §3.15)

- **Auto-stop at `maxDurationMs`** (default 30s) via `setTimeout` in the request effect.
- **Safety failure → never invoke `onText`.** When the backend returns `safety_passed=false` or empty text, the state goes to `rejected` and the consumer sees the "Didn't catch that" status copy — the input field stays untouched.
- **Cleanup on unmount**: stops `MediaRecorder` if active + stops every track + clears the auto-stop timer.

## Browser API picks

- `MediaRecorder.isTypeSupported` probes in order: `audio/webm;codecs=opus`, `audio/webm`, `audio/mp4`, `audio/mpeg`. Falls back to default if none match.
- `pickMimeType` returns `''` when MediaRecorder isn't available → reducer goes to `unsupported`.
- Front-end never persists audio anywhere — chunks live in a ref array, get bundled into one Blob on `onstop`, and that Blob is the payload.

## Consent gating: intentionally NOT here

The consumer surface checks `currentChild.microphone_consent`. When false, the consumer mounts `<ParentConsentGate kind="microphone" />` (from #588) and only sets `consentGranted=true` on this button after the gate fires `onGranted`. Same separation pattern as `CameraCapture` (#581).

## Test plan

- [x] `vitest run` — 203/203 pass (20 new state-machine tests)
- [x] `tsc -b` — clean
- [ ] Manual: Chrome/Edge — record, stop, transcript appears in target field
- [ ] Manual: iPad Safari — `audio/mp4` fallback works, recording UI responsive
- [ ] Manual: 30s recording → auto-stops, transcript appears
- [ ] Manual: deny mic permission → error copy, `onText` never fires
- [ ] Manual: safety-failure response → "Didn't catch that" copy, input untouched

## Notes / deferred

- Web Speech API progressive enhancement (live partial results on Chrome) deferred — the server transcript is canonical anyway.
- Full DOM-level render test deferred until `@testing-library/react` lands.
- `transcriptionService` currently has no companion `.test.ts` — the API contract is owned by the backend tests in PR #593. We can add a frontend service mock test as a follow-up if needed.

Depends on: PR #593 (STT backend) landed ✅.

Fixes #584
Parent Epic: #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)