### PR TITLE
feat(capture): tabbed picker in ImageUploader with CameraCapture + consent (#582)

### DIFF
--- a/frontend/src/__tests__/components/ImageUploader.test.ts
+++ b/frontend/src/__tests__/components/ImageUploader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { TOUCH_DEVICE_QUERY } from '@/components/upload/ImageUploader'
+import { pickInitialTab, TOUCH_DEVICE_QUERY } from '@/components/upload/ImageUploader'
 
 describe('ImageUploader: TOUCH_DEVICE_QUERY', () => {
   it('matches the PRD §3.15 acceptance criterion exactly', () => {
@@ -12,5 +12,15 @@ describe('ImageUploader: TOUCH_DEVICE_QUERY', () => {
 
   it('excludes large desktop displays via max-width breakpoint', () => {
     expect(TOUCH_DEVICE_QUERY).toContain('max-width: 1024px')
+  })
+})
+
+describe('ImageUploader: pickInitialTab (#582)', () => {
+  it("defaults to 'camera' on touch+small devices", () => {
+    expect(pickInitialTab(true)).toBe('camera')
+  })
+
+  it("defaults to 'file' on desktop", () => {
+    expect(pickInitialTab(false)).toBe('file')
   })
 })

--- a/frontend/src/components/upload/ImageUploader/index.tsx
+++ b/frontend/src/components/upload/ImageUploader/index.tsx
@@ -1,14 +1,31 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { motion, AnimatePresence } from 'framer-motion'
+import CameraCapture from '@/components/upload/CameraCapture'
+import ParentConsentGate from '@/components/common/ParentConsentGate'
+import useChildStore from '@/store/useChildStore'
+import type { AgeGroup } from '@/types/api'
 
 export const TOUCH_DEVICE_QUERY = '(pointer: coarse) and (max-width: 1024px)'
+
+export type PickerTab = 'camera' | 'file'
 
 interface ImageUploaderProps {
   onFileSelect: (file: File) => void
   accept?: Record<string, string[]>
   maxSize?: number
   className?: string
+  /** When present together with ageGroup, enables the full CameraCapture
+   *  experience (live preview + consent gate). When absent, the camera
+   *  tab uses the quick-win `capture="environment"` fallback that ships
+   *  with PR #589 — preserves backwards compatibility for legacy callers.
+   */
+  childId?: string
+  ageGroup?: AgeGroup
+}
+
+export function pickInitialTab(isTouchSmall: boolean): PickerTab {
+  return isTouchSmall ? 'camera' : 'file'
 }
 
 function ImageUploader({
@@ -18,6 +35,8 @@ function ImageUploader({
   },
   maxSize = 10 * 1024 * 1024, // 10MB
   className = '',
+  childId,
+  ageGroup,
 }: ImageUploaderProps) {
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
@@ -50,6 +69,16 @@ function ImageUploader({
     return () => mq.removeEventListener('change', update)
   }, [])
 
+  // Full camera experience requires both childId (for consent) and ageGroup
+  // (for gate copy). Without them we fall back to the OS-camera quick-win.
+  const fullCameraEnabled = Boolean(childId && ageGroup)
+
+  const [activeTab, setActiveTab] = useState<PickerTab>(() => pickInitialTab(false))
+  useEffect(() => {
+    if (fullCameraEnabled) setActiveTab(pickInitialTab(isTouchSmall))
+  }, [fullCameraEnabled, isTouchSmall])
+
+  // Quick-win (no childId) path: legacy "Take Photo" button + dropzone.
   const handleCameraClick = (e: React.MouseEvent) => {
     e.stopPropagation()
     cameraInputRef.current?.click()
@@ -63,46 +92,41 @@ function ImageUploader({
     if (cameraInputRef.current) cameraInputRef.current.value = ''
   }
 
-  return (
-    <div className={className}>
-      {isTouchSmall && (
-        <>
-          <motion.button
-            type="button"
-            onClick={handleCameraClick}
-            whileTap={{ scale: 0.97 }}
-            className="w-full mb-3 py-4 px-6 rounded-2xl bg-primary text-white font-bold text-lg flex items-center justify-center gap-2 shadow-md"
-            aria-label="Take a photo with your camera"
-          >
-            <span className="text-2xl" aria-hidden="true">📸</span>
-            <span>Take Photo</span>
-          </motion.button>
-          <input
-            ref={cameraInputRef}
-            type="file"
-            accept="image/*"
-            capture="environment"
-            className="hidden"
-            onChange={handleCameraChange}
-            aria-hidden="true"
-            tabIndex={-1}
-          />
-        </>
-      )}
+  // Consent gate state (only relevant when fullCameraEnabled).
+  const currentChild = useChildStore((s) => s.currentChild)
+  const cameraConsent = useMemo(() => {
+    if (!fullCameraEnabled) return true
+    if (currentChild?.child_id !== childId) return false
+    return currentChild?.camera_consent === true
+  }, [fullCameraEnabled, currentChild, childId])
 
-      <motion.div
-        whileHover={{ scale: 1.01 }}
-        transition={{ duration: 0.2 }}
+  const [showConsentGate, setShowConsentGate] = useState(false)
+
+  function handleSelectCameraTab() {
+    setActiveTab('camera')
+    if (fullCameraEnabled && !cameraConsent) {
+      setShowConsentGate(true)
+    }
+  }
+
+  function handleCameraCapture(file: File) {
+    onFileSelect(file)
+  }
+
+  const renderDropzone = () => (
+    <motion.div
+      whileHover={{ scale: 1.01 }}
+      transition={{ duration: 0.2 }}
+    >
+      <div
+        {...getRootProps()}
+        className={`
+          upload-zone
+          ${isDragActive && !isDragReject ? 'upload-zone-active' : ''}
+          ${isDragReject || hasError ? 'border-red-400 bg-red-50' : ''}
+        `}
       >
-        <div
-          {...getRootProps()}
-          className={`
-            upload-zone
-            ${isDragActive && !isDragReject ? 'upload-zone-active' : ''}
-            ${isDragReject || hasError ? 'border-red-400 bg-red-50' : ''}
-          `}
-        >
-          <input {...getInputProps()} />
+        <input {...getInputProps()} />
 
         <AnimatePresence mode="wait">
           {isDragActive && !isDragReject ? (
@@ -142,7 +166,6 @@ function ImageUploader({
               exit={{ opacity: 0 }}
               className="flex flex-col items-center gap-4"
             >
-              {/* Cute image icon */}
               <div className="relative">
                 <motion.span
                   className="text-6xl"
@@ -177,10 +200,112 @@ function ImageUploader({
             </motion.div>
           )}
         </AnimatePresence>
-        </div>
-      </motion.div>
+      </div>
+    </motion.div>
+  )
 
-      {/* Error message */}
+  // Legacy (no childId) quick-win path: show OS-camera button + dropzone.
+  if (!fullCameraEnabled) {
+    return (
+      <div className={className}>
+        {isTouchSmall && (
+          <>
+            <motion.button
+              type="button"
+              onClick={handleCameraClick}
+              whileTap={{ scale: 0.97 }}
+              className="w-full mb-3 py-4 px-6 rounded-2xl bg-primary text-white font-bold text-lg flex items-center justify-center gap-2 shadow-md"
+              aria-label="Take a photo with your camera"
+            >
+              <span className="text-2xl" aria-hidden="true">📸</span>
+              <span>Take Photo</span>
+            </motion.button>
+            <input
+              ref={cameraInputRef}
+              type="file"
+              accept="image/*"
+              capture="environment"
+              className="hidden"
+              onChange={handleCameraChange}
+              aria-hidden="true"
+              tabIndex={-1}
+            />
+          </>
+        )}
+
+        {renderDropzone()}
+
+        {hasError && (
+          <motion.div
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mt-3 p-3 bg-red-100 rounded-lg text-red-600 text-sm"
+          >
+            {fileRejections[0]?.errors[0]?.message === 'File is larger than 10485760 bytes'
+              ? 'File too large, please select an image under 10MB'
+              : 'Upload error, please select another image'}
+          </motion.div>
+        )}
+      </div>
+    )
+  }
+
+  // Full-camera path: tabbed picker + consent gate.
+  return (
+    <div className={className}>
+      <div
+        role="tablist"
+        aria-label="Image source"
+        className="mb-3 inline-flex rounded-full bg-gray-100 p-1"
+      >
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'camera'}
+          onClick={handleSelectCameraTab}
+          className={`px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+            activeTab === 'camera' ? 'bg-white text-primary shadow' : 'text-gray-600'
+          }`}
+        >
+          📸 Take Photo
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeTab === 'file'}
+          onClick={() => setActiveTab('file')}
+          className={`px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
+            activeTab === 'file' ? 'bg-white text-primary shadow' : 'text-gray-600'
+          }`}
+        >
+          📂 Upload File
+        </button>
+      </div>
+
+      {activeTab === 'camera' ? (
+        cameraConsent ? (
+          <CameraCapture
+            onCapture={handleCameraCapture}
+            onCancel={() => setActiveTab('file')}
+          />
+        ) : (
+          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-6 text-center">
+            <p className="mb-3 text-amber-800">
+              Ask a grown-up to allow the camera before you take a photo.
+            </p>
+            <button
+              type="button"
+              onClick={() => setShowConsentGate(true)}
+              className="rounded-xl bg-amber-600 px-4 py-2 font-semibold text-white"
+            >
+              Ask permission
+            </button>
+          </div>
+        )
+      ) : (
+        renderDropzone()
+      )}
+
       {hasError && (
         <motion.div
           initial={{ opacity: 0, y: -10 }}
@@ -191,6 +316,19 @@ function ImageUploader({
             ? 'File too large, please select an image under 10MB'
             : 'Upload error, please select another image'}
         </motion.div>
+      )}
+
+      {showConsentGate && fullCameraEnabled && ageGroup && childId && (
+        <ParentConsentGate
+          kind="camera"
+          ageGroup={ageGroup}
+          childId={childId}
+          onGranted={() => setShowConsentGate(false)}
+          onDismiss={() => {
+            setShowConsentGate(false)
+            setActiveTab('file')
+          }}
+        />
       )}
     </div>
   )

--- a/frontend/src/pages/UploadPage/index.tsx
+++ b/frontend/src/pages/UploadPage/index.tsx
@@ -214,7 +214,11 @@ function UploadPage() {
                   animate={{ opacity: 1, scale: 1 }}
                   exit={{ opacity: 0, scale: 0.95 }}
                 >
-                  <ImageUploader onFileSelect={setSelectedImage} />
+                  <ImageUploader
+                    onFileSelect={setSelectedImage}
+                    childId={currentChild?.child_id}
+                    ageGroup={currentChild?.age_group}
+                  />
                 </motion.div>
               )}
             </AnimatePresence>


### PR DESCRIPTION
## Summary

Replaces the OS-camera quick-win in [ImageUploader](frontend/src/components/upload/ImageUploader/index.tsx) with a full tabbed picker (Take Photo | Upload File) when the caller passes `childId` + `ageGroup`. The Take Photo tab mounts `CameraCapture` (#581) and shows `ParentConsentGate` (#588) on first use when `camera_consent` is false.

## Behaviour

- Default tab: `'camera'` on `(pointer: coarse) and (max-width: 1024px)`, `'file'` on desktop.
- Logic extracted as exported `pickInitialTab()` so the default-selection rule is unit-testable.
- Consent-required state shows an inline "Ask permission" CTA that mounts `ParentConsentGate`. Granting consent advances directly to camera; dismissing falls back to the file tab.

## Backwards compatibility

Legacy callers that don't pass `childId` (e.g. older surfaces or tests) still get the post-#580 quick-win behaviour — OS-camera button on touch + dropzone — because the tabbed path requires both consent props.

[UploadPage](frontend/src/pages/UploadPage/index.tsx#L217) now passes `currentChild.child_id` and `currentChild.age_group` so the gate has its context.

## Test plan

- [x] `vitest run` → 241/241 pass (5 in this file: 3 for `TOUCH_DEVICE_QUERY`, 2 for `pickInitialTab`)
- [x] `tsc -b` → clean
- [ ] Manual on iPad: Take Photo tab default, consent flow on first use, full camera UI after grant
- [ ] Manual on desktop: Upload File tab default, camera tab still available with consent flow
- [ ] Manual: child without consent → "Ask permission" CTA appears

## Deferred

- **AgentChatPanel paperclip** change is intentionally deferred. The chat-panel attach has different consent and modality flows (it's also tied to the voice-input wiring in #586). A focused follow-up PR will handle it.

Fixes #582
Parent Epic: #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)