### PR TITLE
feat(capture): voice input on InteractiveStoryPage theme (#585)

### DIFF
--- a/frontend/src/pages/InteractiveStoryPage/index.tsx
+++ b/frontend/src/pages/InteractiveStoryPage/index.tsx
@@ -3,6 +3,8 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { motion } from "framer-motion";
 import Button from "@/components/common/Button";
 import Card from "@/components/common/Card";
+import VoiceInputButton from "@/components/common/VoiceInputButton";
+import ParentConsentGate from "@/components/common/ParentConsentGate";
 import AgeAwareContent from "@/components/common/AgeAwareContent";
 import EducationalTags from "@/components/story/EducationalTags";
 import StorySegmentDisplay from "@/components/interactive/StorySegmentDisplay";
@@ -71,6 +73,7 @@ function InteractiveStoryPage() {
     currentChild?.interests?.slice(0, 5) || [],
   );
   const [theme, setTheme] = useState("");
+  const [showMicConsentGate, setShowMicConsentGate] = useState(false);
   const [quotaDismissed, setQuotaDismissed] = useState(false);
 
   // Story hook - use streaming versions for better UX
@@ -600,14 +603,47 @@ function InteractiveStoryPage() {
                 (Optional)
               </span>
             </h2>
-            <input
-              type="text"
-              value={theme}
-              onChange={(e) => setTheme(e.target.value)}
-              placeholder="e.g., Finding lost treasure, Space adventure..."
-              className="w-full px-4 py-3 rounded-xl border-2 border-gray-200 focus:border-primary focus:outline-none transition-colors"
-              maxLength={50}
-            />
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={theme}
+                onChange={(e) => setTheme(e.target.value)}
+                placeholder="e.g., Finding lost treasure, Space adventure..."
+                className="flex-1 px-4 py-3 rounded-xl border-2 border-gray-200 focus:border-primary focus:outline-none transition-colors"
+                maxLength={50}
+              />
+              {currentChild?.child_id && currentChild?.age_group && (
+                currentChild.microphone_consent === true ? (
+                  <VoiceInputButton
+                    ageGroup={currentChild.age_group}
+                    consentGranted
+                    onText={(text) => setTheme(text.slice(0, 50))}
+                    className="shrink-0"
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setShowMicConsentGate(true)}
+                    className="shrink-0 inline-flex h-12 items-center gap-1 rounded-full bg-gray-100 px-3 text-sm font-semibold text-gray-700"
+                    aria-label="Ask a grown-up to allow the microphone"
+                  >
+                    <span aria-hidden="true">🎤</span>
+                    <span>Ask permission</span>
+                  </button>
+                )
+              )}
+            </div>
+            {showMicConsentGate &&
+              currentChild?.child_id &&
+              currentChild?.age_group && (
+                <ParentConsentGate
+                  kind="microphone"
+                  ageGroup={currentChild.age_group}
+                  childId={currentChild.child_id}
+                  onGranted={() => setShowMicConsentGate(false)}
+                  onDismiss={() => setShowMicConsentGate(false)}
+                />
+              )}
             <div className="mt-4">
               <SuggestedThemes
                 mode="prompt"


### PR DESCRIPTION
## Summary

Adds a microphone affordance next to the **Story Theme** input on [`InteractiveStoryPage`](frontend/src/pages/InteractiveStoryPage/index.tsx) so kids can speak their theme instead of typing.

## Behaviour

- When `currentChild.microphone_consent === true` → renders [`VoiceInputButton`](frontend/src/components/common/VoiceInputButton/index.tsx) (from PR #596 / #584). Transcribed text replaces the input value, truncated to the existing 50-char cap.
- When consent is missing → renders an "Ask permission" pill. Tapping it mounts [`ParentConsentGate`](frontend/src/components/common/ParentConsentGate/index.tsx) (from PR #594 / #588) with `kind="microphone"`. After grant, the real mic button takes over on the next render.
- When `currentChild` isn't loaded yet → neither button renders (no flash).

## Safety

Safety-failed transcripts never reach `setTheme`. `VoiceInputButton` swallows them at the hook layer and displays kid-friendly retry copy — the input stays untouched.

## Test plan

- [x] `vitest run` → 239/239 pass (no new tests needed; integration uses existing hook + component tests from #595/#596)
- [x] `tsc -b` → clean
- [ ] Manual: child without mic consent → "Ask permission" pill → gate appears → grant → mic button renders → speak → theme populates
- [ ] Manual: 50-char overflow → truncated, not truncated mid-word ideally (current: simple `slice(0, 50)`)
- [ ] Manual: safety-fail transcript → input stays untouched

## Notes

- Depends on PR #596 (#584 VoiceInputButton), PR #594 (#588 ParentConsentGate), and PR #592 (#587 consent flags) — all merged.
- Truncation uses `text.slice(0, 50)` — same hard cap as the existing `maxLength`. Could be improved to word-boundary in a follow-up.

Fixes #585
Parent Epic: #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)