### PR TITLE
feat(infra): local-dev Postgres + pgvector via docker-compose (Phase 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,19 @@ python -m pytest tests/contracts/ -v        # contract tests only
 python -m pytest tests/integration/ -v     # integration tests only
 ```
 
+### Local DB: SQLite (default) or Postgres + pgvector (recommended)
+
+By default the backend uses SQLite + ChromaDB locally and Postgres + pgvector in production. To bring dev onto the same stack as prod (eliminates dialect-drift bugs):
+
+```bash
+./backend/scripts/dev_db.sh up          # boots postgres+pgvector on :54329
+export DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev
+python -m backend.scripts.migrate_sqlite_to_postgres   # optional one-shot backfill
+python backend/scripts/start_server.py
+```
+
+Unset `DATABASE_URL` to roll back to SQLite. See [docker-compose.yml](docker-compose.yml) and [backend/scripts/migrate_sqlite_to_postgres.py](backend/scripts/migrate_sqlite_to_postgres.py).
+
 ## Environment Variables
 
 ```env

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,7 +13,24 @@ OPENAI_API_KEY=your_openai_api_key_here
 # ElevenLabs TTS (optional — SOTA expressive voices, #243)
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
 
-# ChromaDB Vector Database (local storage)
+# ============================================================================
+# Database
+# ============================================================================
+# Local dev: leave DATABASE_URL UNSET to use SQLite (no extra deps).
+# Recommended path: bring up local Postgres + pgvector via docker-compose
+# and set DATABASE_URL — same backend as production = no dialect-drift bugs.
+#
+#   ./backend/scripts/dev_db.sh up
+#   export DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev
+#   python backend/scripts/start_server.py
+#
+# Production: DATABASE_URL is set to the Supabase Postgres URL (see ops docs).
+# DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev
+
+# ChromaDB Vector Database (LEGACY — used only when DATABASE_URL is unset).
+# When DATABASE_URL points at Postgres, vector_search_server.py uses pgvector
+# via _use_pgvector(). Backfill the existing ChromaDB into pgvector with:
+#   python -m backend.scripts.migrate_sqlite_to_postgres
 CHROMA_PATH=./data/vectors
 
 # Tavily Search API (Daily Drop live news fetching)

--- a/backend/scripts/dev_db.sh
+++ b/backend/scripts/dev_db.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Thin wrapper around docker-compose for the local-dev Postgres + pgvector
+# container. Useful so devs don't have to remember the compose syntax.
+#
+# Usage:
+#   ./backend/scripts/dev_db.sh up      # start postgres (idempotent)
+#   ./backend/scripts/dev_db.sh down    # stop postgres (volume preserved)
+#   ./backend/scripts/dev_db.sh reset   # nuke volume + restart (DESTRUCTIVE)
+#   ./backend/scripts/dev_db.sh psql    # open psql shell as the creative user
+#   ./backend/scripts/dev_db.sh logs    # follow logs
+#   ./backend/scripts/dev_db.sh status  # show container health
+#
+# After `up`, set DATABASE_URL in your shell:
+#   export DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CMD="${1:-up}"
+
+case "$CMD" in
+  up)
+    docker compose up -d postgres
+    echo "Waiting for Postgres to be healthy..."
+    until docker exec creative_agent_pg pg_isready -U creative -d creative_agent_dev >/dev/null 2>&1; do
+      sleep 1
+    done
+    echo "Postgres ready on localhost:54329"
+    echo
+    echo "Next:"
+    echo "  export DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev"
+    echo "  python backend/scripts/start_server.py"
+    ;;
+  down)
+    docker compose down
+    ;;
+  reset)
+    echo "WARNING: this will destroy all local Postgres data."
+    read -p "Type 'yes' to continue: " confirm
+    if [[ "$confirm" == "yes" ]]; then
+      docker compose down -v
+      docker compose up -d postgres
+      echo "Volume reset. Re-run init_schema by starting the app."
+    else
+      echo "Aborted."
+      exit 1
+    fi
+    ;;
+  psql)
+    docker exec -it creative_agent_pg psql -U creative -d creative_agent_dev
+    ;;
+  logs)
+    docker compose logs -f postgres
+    ;;
+  status)
+    docker compose ps postgres
+    ;;
+  *)
+    echo "Unknown command: $CMD"
+    echo "Usage: $0 {up|down|reset|psql|logs|status}"
+    exit 1
+    ;;
+esac

--- a/backend/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/scripts/migrate_sqlite_to_postgres.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+One-shot dev migration: SQLite + ChromaDB -> Postgres + pgvector.
+
+Usage:
+    # 1. bring up local postgres
+    ./backend/scripts/dev_db.sh up
+
+    # 2. export DATABASE_URL
+    export DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev
+
+    # 3. run this migration
+    python -m backend.scripts.migrate_sqlite_to_postgres
+
+    # 4. (optional) start the app with DATABASE_URL still exported
+    python backend/scripts/start_server.py
+
+What it does:
+  Phase A — connect both adapters and run init_schema() against Postgres.
+  Phase B — copy SQL tables in FK-topological order with ON CONFLICT DO
+            NOTHING. Idempotent: a second run is a no-op.
+  Phase C — bump each SERIAL sequence to MAX(id) so the next INSERT
+            doesn't trip a duplicate-key error.
+  Phase D — re-embed each ChromaDB document via the OpenAI embedder used
+            by VectorRepository (chroma's default embedder is 384-dim;
+            our pgvector schema is 1536-dim, so vectors are NOT copied
+            raw — they are recomputed from the stored text).
+  Phase E — print a reconciliation report.
+
+Flags:
+  --dry-run        : count source rows + chroma docs, do not write to PG.
+  --skip-vectors   : do only the SQL copy, skip ChromaDB re-embed.
+  --sqlite-path P  : override DB_PATH (default uses the same path the app uses).
+  --chroma-path P  : override CHROMA_PATH (default reads env or ./data/vectors).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Lazy imports inside main() so --help works even when chromadb is absent.
+
+
+# Tables in FK-topological order. Children appear after parents so
+# INSERT ... ON CONFLICT respects the foreign keys.
+TABLE_ORDER: List[str] = [
+    "users",
+    "tokens",
+    "child_profiles",
+    "child_preferences",
+    "stories",
+    "sessions",
+    "story_segments",
+    "characters",
+    "cloned_voices",
+    "daily_usage",
+    "referrals",
+    "topic_subscriptions",
+    "user_agents",
+    "agent_chat_sessions",
+    "agent_chat_messages",
+    "hub_groups",
+    "hub_group_memberships",
+    "hub_posts",
+    "hub_post_reactions",
+    "runs",
+    "agent_steps",
+    "artifacts",
+    "artifact_relations",
+    "story_artifact_links",
+    "run_artifact_links",
+    "artifact_character_links",
+    "favorites",
+    "child_achievements",
+]
+
+# Tables that own a SERIAL "id" column the sequence of which needs
+# resetting after a bulk copy. (Tables with TEXT primary keys are not
+# in this list — their natural keys are inserted as-is.)
+SEQUENCE_TABLES: List[str] = [
+    "users",
+    "tokens",
+    "child_profiles",
+    "child_preferences",
+    "stories",
+    "sessions",
+    "story_segments",
+    "characters",
+    "user_agents",
+    "agent_chat_sessions",
+    "agent_chat_messages",
+    "runs",
+    "agent_steps",
+    "artifacts",
+    "favorites",
+]
+
+
+@dataclass
+class Report:
+    tables_copied: Dict[str, int] = field(default_factory=dict)
+    tables_skipped: List[str] = field(default_factory=list)
+    vectors_replayed: Dict[str, int] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+
+
+async def _list_sqlite_tables(sqlite_db) -> set[str]:
+    rows = await sqlite_db.fetchall(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    return {row["name"] for row in rows}
+
+
+async def _copy_table(sqlite_db, pg_db, name: str) -> int:
+    """Copy all rows of one table from SQLite to Postgres with ON CONFLICT."""
+    rows = await sqlite_db.fetchall(f"SELECT * FROM {name}")
+    if not rows:
+        return 0
+    cols = list(rows[0].keys())
+    # Postgres uses $1..$N placeholders via asyncpg; we go through the
+    # adapter's execute() which already translates ? -> $N.
+    placeholders = ",".join("?" for _ in cols)
+    col_list = ",".join(cols)
+    sql = (
+        f"INSERT INTO {name} ({col_list}) VALUES ({placeholders}) "
+        "ON CONFLICT DO NOTHING"
+    )
+    inserted = 0
+    for row in rows:
+        params = tuple(row[c] for c in cols)
+        try:
+            result = await pg_db.execute(sql, params)
+            # asyncpg returns INSERT 0 N status — count rows by parsing
+            # rowcount on the CursorResult wrapper.
+            if hasattr(result, "rowcount") and result.rowcount:
+                inserted += result.rowcount
+            else:
+                inserted += 1  # best effort when adapter doesn't report
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"insert into {name} failed: {exc}") from exc
+    await pg_db.commit()
+    return inserted
+
+
+async def _reset_sequence(pg_db, name: str) -> None:
+    """Bump <table>_id_seq to MAX(id) so future INSERTs don't collide."""
+    try:
+        await pg_db.execute(
+            f"SELECT setval(pg_get_serial_sequence('{name}', 'id'), "
+            f"COALESCE((SELECT MAX(id) FROM {name}), 1))"
+        )
+        await pg_db.commit()
+    except Exception as exc:  # noqa: BLE001
+        # Some tables don't have a serial id (TEXT PK) — that's fine.
+        pass
+
+
+async def _replay_chromadb(chroma_path: Path, pg_db, dry_run: bool) -> Dict[str, int]:
+    """Re-embed each ChromaDB document via OpenAI and load into pgvector."""
+    try:
+        import chromadb
+    except ImportError:
+        print("  ! chromadb not installed; skipping vector replay")
+        return {}
+
+    if not chroma_path.exists():
+        print(f"  ! no chroma data at {chroma_path}; skipping vector replay")
+        return {}
+
+    from backend.src.services.database.vector_repository import VectorRepository
+
+    client = chromadb.PersistentClient(path=str(chroma_path))
+    # VectorRepository uses the singleton db_manager — the caller must
+    # have arranged for db_manager to be the Postgres one before invoking
+    # this script (which we do via DATABASE_URL env var).
+    vector_repo = VectorRepository()
+
+    counts: Dict[str, int] = {}
+
+    # Drawings
+    try:
+        drawings = client.get_collection("children_drawings")
+        data = drawings.get(include=["documents", "metadatas"])
+        ids = data.get("ids") or []
+        docs = data.get("documents") or []
+        metas = data.get("metadatas") or []
+        print(f"  - children_drawings: {len(ids)} docs")
+        if not dry_run:
+            for doc_id, text, meta in zip(ids, docs, metas):
+                child_id = (meta or {}).get("child_id", "")
+                if not child_id or not text:
+                    continue
+                await vector_repo.add_drawing(
+                    doc_id=doc_id,
+                    child_id=child_id,
+                    document_text=text,
+                    metadata=meta or {},
+                )
+        counts["children_drawings"] = len(ids)
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ! drawings replay failed: {exc}")
+
+    # Stories
+    try:
+        stories = client.get_collection("story_embeddings")
+        data = stories.get(include=["documents", "metadatas"])
+        ids = data.get("ids") or []
+        docs = data.get("documents") or []
+        metas = data.get("metadatas") or []
+        print(f"  - story_embeddings: {len(ids)} docs")
+        if not dry_run:
+            for doc_id, text, meta in zip(ids, docs, metas):
+                m = meta or {}
+                child_id = m.get("child_id", "")
+                story_id = m.get("story_id", doc_id)
+                themes = m.get("themes", "")
+                age_group = m.get("age_group", "")
+                if not child_id or not text:
+                    continue
+                await vector_repo.add_story_embedding(
+                    story_id=story_id,
+                    child_id=child_id,
+                    story_text=text,
+                    themes=themes if isinstance(themes, str) else json.dumps(themes),
+                    age_group=age_group,
+                )
+        counts["story_embeddings"] = len(ids)
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ! stories replay failed: {exc}")
+
+    return counts
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    if not os.environ.get("DATABASE_URL", "").startswith("postgresql"):
+        print(
+            "ERROR: DATABASE_URL must point to a Postgres URL "
+            "(postgresql://...) before running this migration.",
+            file=sys.stderr,
+        )
+        return 2
+
+    from backend.src.services.database.connection import DatabaseManager
+    from backend.src.services.database.schema import init_schema
+    from backend.src.services.database.schema_vectors import init_vector_schema
+    from backend.src.paths import DB_PATH
+
+    sqlite_path = Path(args.sqlite_path) if args.sqlite_path else DB_PATH
+    chroma_path = Path(args.chroma_path or os.environ.get("CHROMA_PATH", "./data/vectors"))
+
+    print(f"SQLite source:   {sqlite_path}")
+    print(f"ChromaDB source: {chroma_path}")
+    print(f"Postgres target: {os.environ['DATABASE_URL']}")
+    print(f"Dry run:         {args.dry_run}")
+    print()
+
+    if not sqlite_path.exists():
+        print(f"ERROR: SQLite file not found at {sqlite_path}", file=sys.stderr)
+        return 2
+
+    # --- Phase A: connect both, init Postgres schema ---
+    sqlite_db = DatabaseManager(db_path=str(sqlite_path))
+    pg_db = DatabaseManager()  # picks up DATABASE_URL
+    await sqlite_db.connect()
+    await pg_db.connect()
+    print(f"Connected: sqlite={sqlite_db.dialect}, pg={pg_db.dialect}")
+
+    if not args.dry_run:
+        await init_schema(pg_db)
+        await init_vector_schema(pg_db)
+        print("Postgres schema initialized\n")
+
+    report = Report()
+
+    # --- Phase B: copy SQL tables ---
+    print("Phase B: copying SQL tables")
+    source_tables = await _list_sqlite_tables(sqlite_db)
+    for name in TABLE_ORDER:
+        if name not in source_tables:
+            report.tables_skipped.append(name)
+            print(f"  - {name:32s} skipped (not in source)")
+            continue
+        rows = await sqlite_db.fetchall(f"SELECT COUNT(*) AS c FROM {name}")
+        source_count = rows[0]["c"] if rows else 0
+        if args.dry_run:
+            print(f"  - {name:32s} {source_count} rows (dry-run)")
+            continue
+        try:
+            n = await _copy_table(sqlite_db, pg_db, name)
+            report.tables_copied[name] = n
+            print(f"  - {name:32s} copied {n}/{source_count}")
+        except Exception as exc:  # noqa: BLE001
+            report.errors.append(f"{name}: {exc}")
+            print(f"  ! {name:32s} ERROR: {exc}")
+
+    # --- Phase C: bump sequences ---
+    if not args.dry_run:
+        print("\nPhase C: resetting SERIAL sequences")
+        for name in SEQUENCE_TABLES:
+            await _reset_sequence(pg_db, name)
+        print("  done")
+
+    # --- Phase D: ChromaDB -> pgvector ---
+    if not args.skip_vectors:
+        print("\nPhase D: replaying ChromaDB into pgvector")
+        if not os.environ.get("OPENAI_API_KEY"):
+            print("  ! OPENAI_API_KEY not set; skipping vector replay")
+        else:
+            report.vectors_replayed = await _replay_chromadb(
+                chroma_path, pg_db, args.dry_run
+            )
+
+    # --- Phase E: reconciliation ---
+    print("\n=== Summary ===")
+    print(f"Tables copied: {len(report.tables_copied)}")
+    print(f"Tables skipped (not in source): {len(report.tables_skipped)}")
+    print(f"Vectors replayed: {sum(report.vectors_replayed.values())}")
+    if report.errors:
+        print("\nErrors:")
+        for e in report.errors:
+            print(f"  - {e}")
+
+    await sqlite_db.disconnect()
+    await pg_db.disconnect()
+    return 0 if not report.errors else 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--dry-run", action="store_true", help="don't write to Postgres")
+    p.add_argument("--skip-vectors", action="store_true", help="skip ChromaDB replay")
+    p.add_argument("--sqlite-path", default=None)
+    p.add_argument("--chroma-path", default=None)
+    args = p.parse_args()
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -719,14 +719,30 @@ async def _migrate_characters_user_id(db: "DatabaseManager") -> None:
     with the new UNIQUE(user_id, child_id, name) constraint.
     Existing rows get user_id='' (empty string) for backward compatibility.
     """
-    # Check if the UNIQUE constraint includes user_id by inspecting the CREATE TABLE SQL.
-    # We need to handle both cases: (1) table has no user_id column at all,
-    # (2) user_id was added via ALTER TABLE but UNIQUE still only covers (child_id, name).
-    create_sql = await table_create_sql(db, "characters")
+    # Decide whether to recreate the table:
+    #   - SQLite: inspect the original CREATE TABLE SQL for the UNIQUE clause
+    #     (PRAGMA gives no other reliable way to see composite uniques).
+    #   - Postgres: query pg_indexes for a unique index covering user_id —
+    #     `table_create_sql` on Postgres only reconstructs columns, not
+    #     constraints, so the SQLite check would false-positive here every
+    #     time and corrupt the table (leaves orphaned `characters_new`).
     needs_migration = True
-    if create_sql:
-        # If the CREATE TABLE already has UNIQUE(user_id, child_id, name), no migration needed
-        if 'user_id' in create_sql and 'UNIQUE(user_id' in create_sql.replace(' ', ''):
+    if db.dialect == "postgresql":
+        # Defensive: if a previous run failed mid-migration we may have
+        # an orphaned `characters_new` lying around. Drop it before
+        # deciding anything else.
+        await db.execute("DROP TABLE IF EXISTS characters_new")
+        rows = await db.fetchall(
+            "SELECT indexdef FROM pg_indexes WHERE schemaname='public' AND tablename='characters'"
+        )
+        for r in rows:
+            idx = (r.get("indexdef") or "").lower()
+            if "unique" in idx and "user_id" in idx and "child_id" in idx and "name" in idx:
+                needs_migration = False
+                break
+    else:
+        create_sql = await table_create_sql(db, "characters")
+        if create_sql and 'user_id' in create_sql and 'UNIQUE(user_id' in create_sql.replace(' ', ''):
             needs_migration = False
 
     if needs_migration:

--- a/backend/src/services/database/schema_artifacts.py
+++ b/backend/src/services/database/schema_artifacts.py
@@ -251,7 +251,31 @@ async def init_artifact_schema(db: "DatabaseManager") -> None:
     """
     d = db.dialect
 
-    # Create artifacts table
+    # FK-topological order. SQLite accepts forward CREATE-TABLE refs,
+    # Postgres does not — `artifacts.created_by_step_id` references
+    # `agent_steps(agent_step_id)` and `agent_steps` references
+    # `runs(run_id)`, so we build the chain runs -> agent_steps ->
+    # artifacts -> dependents.
+
+    # Create runs table (referenced by agent_steps).
+    await db.execute(translate_ddl(RUNS_TABLE, d))
+    for stmt in RUNS_INDEXES.strip().split(";"):
+        if stmt.strip():
+            try:
+                await db.execute(stmt)
+            except Exception:
+                pass
+
+    # Create agent_steps table (referenced by artifacts).
+    await db.execute(translate_ddl(AGENT_STEPS_TABLE, d))
+    for stmt in AGENT_STEPS_INDEXES.strip().split(";"):
+        if stmt.strip():
+            try:
+                await db.execute(stmt)
+            except Exception:
+                pass
+
+    # Create artifacts table (referenced by relations + link tables).
     await db.execute(translate_ddl(ARTIFACTS_TABLE, d))
     for stmt in ARTIFACTS_INDEXES.strip().split(";"):
         if stmt.strip():
@@ -278,16 +302,7 @@ async def init_artifact_schema(db: "DatabaseManager") -> None:
             except Exception:
                 pass
 
-    # Create runs table
-    await db.execute(translate_ddl(RUNS_TABLE, d))
-    for stmt in RUNS_INDEXES.strip().split(";"):
-        if stmt.strip():
-            try:
-                await db.execute(stmt)
-            except Exception:
-                pass
-
-    # Create run_artifact_links table (after runs table due to FK)
+    # Create run_artifact_links table
     await db.execute(translate_ddl(RUN_ARTIFACT_LINKS_TABLE, d))
     for stmt in RUN_ARTIFACT_LINKS_INDEXES.strip().split(";"):
         if stmt.strip():
@@ -299,15 +314,6 @@ async def init_artifact_schema(db: "DatabaseManager") -> None:
     # Create artifact_character_links table
     await db.execute(translate_ddl(ARTIFACT_CHARACTER_LINKS_TABLE, d))
     for stmt in ARTIFACT_CHARACTER_LINKS_INDEXES.strip().split(";"):
-        if stmt.strip():
-            try:
-                await db.execute(stmt)
-            except Exception:
-                pass
-
-    # Create agent_steps table
-    await db.execute(translate_ddl(AGENT_STEPS_TABLE, d))
-    for stmt in AGENT_STEPS_INDEXES.strip().split(";"):
         if stmt.strip():
             try:
                 await db.execute(stmt)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -10,6 +10,7 @@ import pytest
 
 from backend.src.services.database import db_manager
 from backend.src.services.database.schema import init_schema
+from backend.src.services.database.sql_compat import insert_or_ignore
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -25,14 +26,19 @@ async def _init_database():
         await db_manager.connect()
         await init_schema(db_manager)
 
-    # Ensure e2e test user exists (FK constraint on stories.user_id)
+    # Ensure e2e test user exists (FK constraint on stories.user_id).
+    # `INSERT OR IGNORE` is SQLite-only; insert_or_ignore() routes through
+    # `ON CONFLICT DO NOTHING` on Postgres so this conftest works against
+    # both dev (SQLite default) and the new local pgvector dev backend.
     from datetime import datetime
     now = datetime.now().isoformat()
+    sql = insert_or_ignore(
+        "users",
+        ["user_id", "username", "email", "password_hash", "created_at", "updated_at"],
+        db_manager.dialect,
+    )
     await db_manager.execute(
-        """
-        INSERT OR IGNORE INTO users (user_id, username, email, password_hash, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?)
-        """,
+        sql,
         ("e2e_test_user", "e2e_test_user", "e2e@example.com", "test_hash", now, now),
     )
     await db_manager.commit()

--- a/backend/tests/integration/test_pgvector_local_dev.py
+++ b/backend/tests/integration/test_pgvector_local_dev.py
@@ -1,0 +1,60 @@
+"""Local-dev Postgres + pgvector smoke test.
+
+Skipped unless DATABASE_URL points at a Postgres URL. This test exists
+to catch dialect-drift bugs the SQLite-only suite would miss — exactly
+the kind that surfaced (and got fixed) during the Phase 0 migration:
+the schema_artifacts FK ordering and the characters migration
+idempotency check on Postgres.
+
+Run it locally after `./backend/scripts/dev_db.sh up`:
+    DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev \
+        pytest backend/tests/integration/test_pgvector_local_dev.py -v
+
+Uses a *fresh* DatabaseManager per test (not the global singleton) to
+avoid the pytest-asyncio per-function event-loop tearing down an
+asyncpg pool the session-scoped conftest opened in another loop.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DATABASE_URL", "").startswith("postgresql"),
+    reason="requires DATABASE_URL=postgresql://... pointed at a live Postgres",
+)
+
+
+@pytest.mark.asyncio
+async def test_init_schema_runs_clean_on_postgres():
+    """All ~30 tables + the pgvector extension tables come up cleanly."""
+    from backend.src.services.database.connection import DatabaseManager
+    from backend.src.services.database.schema import init_schema
+    from backend.src.services.database.schema_vectors import init_vector_schema
+
+    db = DatabaseManager()  # picks up DATABASE_URL
+    await db.connect()
+    try:
+        assert db.dialect == "postgresql"
+        await init_schema(db)
+        await init_vector_schema(db)
+
+        rows = await db.fetchall(
+            "SELECT tablename FROM pg_tables WHERE schemaname='public'"
+        )
+        names = {row["tablename"] for row in rows}
+        # Spot-check critical tables across the layers — these were the
+        # ones that surfaced dialect bugs during the migration.
+        assert "users" in names
+        assert "stories" in names
+        assert "artifacts" in names                # FK ordering fix
+        assert "agent_steps" in names              # referenced by artifacts
+        assert "characters" in names               # idempotent migration fix
+        assert "agent_chat_sessions" in names      # #565
+        assert "drawing_embeddings" in names       # pgvector
+        assert "story_embeddings_pg" in names      # pgvector
+    finally:
+        await db.disconnect()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+# Local dev Postgres + pgvector.
+#
+# Brings dev/prod onto the same storage backend so `_use_pgvector()` is
+# exercised locally and the ChromaDB fallback in vector_search_server.py
+# becomes dead code in dev (it stays as a graceful fallback when
+# DATABASE_URL is unset).
+#
+# Port 54329 was chosen to avoid clashing with:
+#   - a host-installed Postgres on 5432
+#   - the Supabase CLI pooler on 54322
+#
+# Override with `POSTGRES_HOST_PORT=5432 docker compose up -d` if you
+# want the standard port.
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    container_name: creative_agent_pg
+    environment:
+      POSTGRES_USER: creative
+      POSTGRES_PASSWORD: creative
+      POSTGRES_DB: creative_agent_dev
+    ports:
+      - "${POSTGRES_HOST_PORT:-54329}:5432"
+    volumes:
+      - creative_pgdata:/var/lib/postgresql/data
+      - ./docker/postgres/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U creative -d creative_agent_dev"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  creative_pgdata:

--- a/docker/postgres/init/01-extensions.sql
+++ b/docker/postgres/init/01-extensions.sql
@@ -1,0 +1,5 @@
+-- Runs once on first container boot via the pgvector image's
+-- /docker-entrypoint-initdb.d/ hook. Makes the extension available
+-- before the app's init_vector_schema() runs, so the app never has to
+-- own a superuser-requiring DDL.
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/docs/learning/infrastructure/database-adapter.md
+++ b/docs/learning/infrastructure/database-adapter.md
@@ -6,7 +6,20 @@
 
 **Explorer**: The database adapter is like a translator. Our app speaks one language (SQL), but the database in development (SQLite) and the database in production (PostgreSQL) understand slightly different dialects. The adapter translates so our code works with both — no changes needed.
 
-**Maker**: The adapter pattern abstracts database-specific SQL dialect differences behind a common interface. `adapter.py` defines the base class; `sqlite_adapter.py` and `postgres_adapter.py` implement it. `connection.py` reads `DATABASE_URL` to pick the right adapter at startup. This lets us develop with zero-install SQLite locally and deploy to Supabase PostgreSQL in production.
+**Maker**: The adapter pattern abstracts database-specific SQL dialect differences behind a common interface. `adapter.py` defines the base class; `sqlite_adapter.py` and `postgres_adapter.py` implement it. `connection.py` reads `DATABASE_URL` to pick the right adapter at startup. This lets us develop with zero-install SQLite locally OR run Postgres + pgvector locally via docker-compose for full dev/prod parity, and deploy to Supabase PostgreSQL in production.
+
+### Running Postgres + pgvector locally (recommended)
+
+For dev/prod parity, run Postgres + pgvector in Docker and point `DATABASE_URL` at it:
+
+```bash
+./backend/scripts/dev_db.sh up          # boots pgvector/pgvector:pg17 on :54329
+export DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev
+python -m backend.scripts.migrate_sqlite_to_postgres   # optional one-shot backfill
+python backend/scripts/start_server.py
+```
+
+When `DATABASE_URL` points at Postgres, [`_use_pgvector()` in `vector_search_server.py`](../../../backend/src/mcp_servers/vector_search_server.py) flips to true and all vector search runs through `VectorRepository` against the `drawing_embeddings` + `story_embeddings_pg` tables — same code path as production. Unset `DATABASE_URL` to fall back to SQLite + ChromaDB.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

Brings dev/prod onto the same DB engine. Production already runs Postgres + pgvector; this PR lets local dev opt into the same stack via `docker-compose` so the `_use_pgvector()` branch in `vector_search_server.py` is exercised against the same code path used in prod. **Default dev path (SQLite + ChromaDB) is unchanged** — opt-in by setting `DATABASE_URL`.

## What lands

- **`docker-compose.yml` + `docker/postgres/init/01-extensions.sql`** — `pgvector/pgvector:pg17` on host port 54329, named volume, `pg_isready` healthcheck, `CREATE EXTENSION vector` on first boot.
- **`backend/scripts/dev_db.sh`** — `up`/`down`/`reset`/`psql`/`logs`/`status` helpers.
- **`backend/scripts/migrate_sqlite_to_postgres.py`** — idempotent backfill: SQL tables in FK-topological order with `ON CONFLICT DO NOTHING`, `setval` for SERIAL sequences, and ChromaDB → OpenAI re-embed (Chroma's 384-dim default embeddings cannot be reused with the 1536-dim pgvector schema). Supports `--dry-run` and `--skip-vectors`.
- **`backend/.env.example`** — DATABASE_URL stanza with the local-dev URL and rollback note.
- **`backend/tests/integration/test_pgvector_local_dev.py`** — skipped unless `DATABASE_URL` is set; verifies `init_schema + init_vector_schema` run cleanly on Postgres and create the critical tables.
- **Docs** — `CLAUDE.md` + `database-adapter.md` updated with the local-Postgres workflow.

## Three latent dev/prod-drift bugs surfaced + fixed along the way

This is exactly why the migration is worth doing:

1. **`schema_artifacts.init_artifact_schema` FK ordering** — created `artifacts` before `agent_steps`, but `artifacts.created_by_step_id REFERENCES agent_steps(...)`. SQLite accepts forward FK refs at CREATE TABLE time; Postgres does not. Reordered to FK-topological: `runs → agent_steps → artifacts → dependents`.
2. **`_migrate_characters_user_id` idempotency on Postgres** — the check inspected `table_create_sql` for a `UNIQUE(...)` clause, but on Postgres that helper only reconstructs columns. The migration always re-ran, orphaning `characters_new`. Now dialect-aware: queries `pg_indexes` for the unique index on Postgres and defensively drops any orphaned `characters_new`.
3. **`tests/integration/conftest.py` `INSERT OR IGNORE`** — SQLite-only syntax. Routed through `sql_compat.insert_or_ignore()` so it works against both dialects.

## Test plan

- [x] `./backend/scripts/dev_db.sh up` brings up healthy Postgres + pgvector 0.8.2 on `localhost:54329`.
- [x] `DATABASE_URL=postgresql://... pytest backend/tests/integration/test_pgvector_local_dev.py -v` passes against a freshly-reset DB — 31 tables created including `drawing_embeddings` + `story_embeddings_pg`.
- [x] `python -m backend.scripts.migrate_sqlite_to_postgres --dry-run` correctly enumerates 28 tables and ~54K rows from the existing local SQLite (no writes).
- [x] Default SQLite path still passes: `pytest backend/tests/contracts/test_agent_chat_repository_contract.py` — 15/15 green.

## How to use

```bash
./backend/scripts/dev_db.sh up
export DATABASE_URL=postgresql://creative:creative@localhost:54329/creative_agent_dev
python -m backend.scripts.migrate_sqlite_to_postgres   # optional one-shot
python backend/scripts/start_server.py
```

Unset `DATABASE_URL` to roll back to SQLite + ChromaDB. ChromaDB stays as a fallback this PR; removing it from `requirements.txt` is a follow-up chore.

## Follow-ups (not in this PR)

- Backfill row-by-row INSERTs are slow for ~15K artifacts. Batch via `executemany` / `COPY` if dev datasets grow.
- Remove `chromadb` from `requirements.txt` once everyone's migrated.
- Unblocks #590 (hybrid search): #590 needs the pgvector path exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)