### PR TITLE
fix(capture): differentiate consent-gate error causes (#603)

### DIFF
--- a/frontend/src/__tests__/components/ParentConsentGate.test.ts
+++ b/frontend/src/__tests__/components/ParentConsentGate.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { GATE_COPY } from '@/components/common/ParentConsentGate'
+import {
+  classifyGateError,
+  GATE_COPY,
+  GATE_ERROR_COPY,
+} from '@/components/common/ParentConsentGate'
 import type { AgeGroup } from '@/types/api'
 
 const AGE_GROUPS: AgeGroup[] = ['3-5', '6-8', '9-12']
@@ -45,5 +49,82 @@ describe('ParentConsentGate: GATE_COPY', () => {
         body.includes('grown-up')  // 3-5 deferral copy
       expect(promisesNoStorage).toBe(true)
     }
+  })
+})
+
+describe('ParentConsentGate: classifyGateError (#603)', () => {
+  it('maps 404 from the consent-update endpoint to child_not_found', () => {
+    // The exact shape axios surfaces: err.response.status + err.response.data.detail.code
+    expect(
+      classifyGateError({
+        response: {
+          status: 404,
+          data: { detail: { code: 'CHILD_PROFILE_NOT_FOUND' } },
+        },
+      }),
+    ).toBe('child_not_found')
+  })
+
+  it('maps the bare code without a status to child_not_found', () => {
+    expect(
+      classifyGateError({
+        response: { data: { detail: { code: 'CHILD_PROFILE_NOT_FOUND' } } },
+      }),
+    ).toBe('child_not_found')
+  })
+
+  it('maps 403 PARENT_ROLE_REQUIRED to parent_required', () => {
+    expect(
+      classifyGateError({
+        response: {
+          status: 403,
+          data: { detail: { code: 'PARENT_ROLE_REQUIRED' } },
+        },
+      }),
+    ).toBe('parent_required')
+  })
+
+  it('maps 401 / 400 / 422 to wrong_password', () => {
+    expect(classifyGateError({ response: { status: 401 } })).toBe('wrong_password')
+    expect(classifyGateError({ response: { status: 400 } })).toBe('wrong_password')
+    expect(classifyGateError({ response: { status: 422 } })).toBe('wrong_password')
+  })
+
+  it('maps Supabase "Invalid login credentials" Error to wrong_password', () => {
+    expect(classifyGateError(new Error('Invalid login credentials'))).toBe('wrong_password')
+  })
+
+  it('falls back to unknown for unmapped shapes', () => {
+    expect(classifyGateError({ response: { status: 500 } })).toBe('unknown')
+    expect(classifyGateError(null)).toBe('unknown')
+    expect(classifyGateError(undefined)).toBe('unknown')
+    expect(classifyGateError(new Error('something else entirely'))).toBe('unknown')
+  })
+})
+
+describe('ParentConsentGate: GATE_ERROR_COPY', () => {
+  it('provides non-empty copy for every error kind', () => {
+    const kinds = [
+      'wrong_password',
+      'child_not_found',
+      'parent_required',
+      'missing_email',
+      'unknown',
+    ] as const
+    for (const kind of kinds) {
+      expect(GATE_ERROR_COPY[kind]).toBeDefined()
+      expect(GATE_ERROR_COPY[kind].length).toBeGreaterThan(10)
+    }
+  })
+
+  it('child_not_found copy tells the parent to refresh', () => {
+    // The actionable next step is what makes #603's UX better than
+    // the old generic copy — without it the parent has no idea what
+    // to do.
+    expect(GATE_ERROR_COPY.child_not_found.toLowerCase()).toMatch(/refresh|try again/)
+  })
+
+  it('parent_required copy tells the user to switch accounts', () => {
+    expect(GATE_ERROR_COPY.parent_required.toLowerCase()).toContain('parent')
   })
 })

--- a/frontend/src/components/common/ParentConsentGate/index.tsx
+++ b/frontend/src/components/common/ParentConsentGate/index.tsx
@@ -41,6 +41,47 @@ interface GateCopy {
   body: string
 }
 
+export const GATE_ERROR_COPY = {
+  wrong_password: "That password didn't match. Try again.",
+  child_not_found:
+    "We can't find this child profile. Refresh the page and try again.",
+  parent_required:
+    "Only a parent account can change this. Log out and log in as the parent.",
+  missing_email:
+    "Sign in first, then try again.",
+  unknown:
+    "Something went wrong. Try again or refresh the page.",
+} as const
+
+export type GateErrorKind = keyof typeof GATE_ERROR_COPY
+
+/** Map a thrown error from authService.login OR updateConsent to a
+ *  user-facing copy key. Pure function so we can unit-test the mapping
+ *  without rendering the modal.
+ */
+export function classifyGateError(err: unknown): GateErrorKind {
+  const status =
+    typeof err === 'object' && err !== null && 'response' in err
+      ? (err as { response?: { status?: number } }).response?.status
+      : undefined
+  const code =
+    typeof err === 'object' && err !== null && 'response' in err
+      ? (err as { response?: { data?: { detail?: { code?: string } } } }).response?.data?.detail?.code
+      : undefined
+
+  if (status === 404 || code === 'CHILD_PROFILE_NOT_FOUND') return 'child_not_found'
+  if (status === 403 || code === 'PARENT_ROLE_REQUIRED') return 'parent_required'
+  if (status === 400 || status === 401 || status === 422) return 'wrong_password'
+
+  // Supabase login throws a plain Error with a message — treat as
+  // password-class failure since that's the most common interpretation.
+  if (err instanceof Error && /password|credential|invalid/i.test(err.message)) {
+    return 'wrong_password'
+  }
+
+  return 'unknown'
+}
+
 export const GATE_COPY: Record<ConsentKind, Record<AgeGroup, GateCopy>> = {
   camera: {
     '3-5': {
@@ -108,15 +149,35 @@ export function ParentConsentGate({
 
     setSubmitting(true)
     setError(null)
+
+    // Split the two calls so we can attribute the failure correctly.
+    // Bundling them was the bug behind #603 — a 404 on consent-update
+    // showed up as "password didn't match" and sent users hunting for a
+    // password they hadn't actually mistyped.
     try {
       await authService.login({
         username_or_email: user.email,
         password,
       })
+    } catch (err) {
+      console.warn('ParentConsentGate: login failed', err)
+      const kind = classifyGateError(err)
+      // Login failure is almost always a password mismatch; map other
+      // codes through the classifier in case the auth backend evolves.
+      setError(
+        kind === 'unknown' ? GATE_ERROR_COPY.wrong_password : GATE_ERROR_COPY[kind],
+      )
+      setSubmitting(false)
+      return
+    }
+
+    try {
       await updateConsent(childId, { [consentField]: true })
       onGranted()
     } catch (err) {
-      setError("That password didn't match. Please try again.")
+      console.warn('ParentConsentGate: consent update failed', err)
+      const kind = classifyGateError(err)
+      setError(GATE_ERROR_COPY[kind])
     } finally {
       setSubmitting(false)
     }


### PR DESCRIPTION
## What's broken

`ParentConsentGate` (PR #594 / #588) wrapped `authService.login` AND `useChildStore.updateConsent` in one `try/catch` and showed the same "That password didn't match" copy regardless of which call failed.

Reported during in-session testing: a `PATCH .../consent` response of `404 CHILD_PROFILE_NOT_FOUND` (stale localStorage pointing to an archived child) showed up as a password failure. The parent had no way to tell the password was actually accepted.

## Fix

- **Split the `try/catch`** so login failure is attributable separately from consent-update failure.
- **Pure `classifyGateError(err)`** maps the thrown shape to one of:
  - `wrong_password` (401 / 400 / 422 / Supabase "Invalid login credentials" message)
  - `child_not_found` (404 or `code === 'CHILD_PROFILE_NOT_FOUND'`)
  - `parent_required` (403 or `code === 'PARENT_ROLE_REQUIRED'`)
  - `missing_email`, `unknown`
- **`GATE_ERROR_COPY`** provides actionable copy per kind. 404 → "Refresh the page and try again", 403 → "Log out and log in as the parent."
- **`console.warn`** logs the underlying error for debugging without leaking it to the UI.

## Why the classifier is pure

Extracted as a stand-alone function so the mapping table is exhaustively unit-testable without rendering the modal. Same pattern we used for `classifyCameraError` (#581) and the camera/voice state machines — pure logic stays separable from React glue.

## Test plan

- [x] `vitest run` → 250/250 pass (13 in this file: 4 existing + 9 new)
- [x] `tsc -b` → clean
- [ ] Manual: with stale `child-storage` localStorage entry → 404 → "We can't find this child profile. Refresh the page and try again."
- [ ] Manual: child-role account → 403 → "Only a parent account can change this..."
- [ ] Manual: wrong password → "That password didn't match. Try again."
- [ ] Manual: correct password + valid child + parent role → gate closes, consent flag flips, surface unlocks

Fixes #603
Parent Epic: #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)