### PR TITLE
feat(my-agent): voiceConversationStateMachine + realtimeVoiceService shell (#616)

### DIFF
--- a/frontend/src/__tests__/api/realtimeVoiceService.test.ts
+++ b/frontend/src/__tests__/api/realtimeVoiceService.test.ts
@@ -1,0 +1,84 @@
+/* @vitest-environment node */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import apiClient from '@/api/client'
+import { realtimeVoiceService } from '@/api/services/realtimeVoiceService'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    post: vi.fn(),
+  },
+}))
+
+describe('realtimeVoiceService.startSession (#616)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('POSTs to /me/agent/voice/session with the request shape', async () => {
+    const response = {
+      session_id: 'voice_sess_abc',
+      ephemeral_token: 't'.repeat(32),
+      expires_at: '2026-06-01T00:01:00Z',
+      ws_url: '/api/v1/me/agent/voice/stream',
+      provider_config: {
+        provider: 'mock' as const,
+        sample_rate_hz: 16000,
+        audio_format: 'pcm16' as const,
+      },
+    }
+    vi.mocked(apiClient.post).mockResolvedValueOnce({ data: response })
+
+    const result = await realtimeVoiceService.startSession({
+      child_id: 'child_xyz',
+    })
+
+    expect(result).toBe(response)
+    expect(apiClient.post).toHaveBeenCalledWith('/me/agent/voice/session', {
+      child_id: 'child_xyz',
+    })
+  })
+
+  it('passes the optional persona field through unchanged', async () => {
+    vi.mocked(apiClient.post).mockResolvedValueOnce({
+      data: {
+        session_id: 's',
+        ephemeral_token: 't'.repeat(32),
+        expires_at: '2026-06-01T00:01:00Z',
+        ws_url: '/ws',
+        provider_config: {
+          provider: 'hybrid',
+          sample_rate_hz: 16000,
+          audio_format: 'opus',
+        },
+      },
+    })
+
+    await realtimeVoiceService.startSession({
+      child_id: 'child_xyz',
+      persona: 'buddy_calm',
+    })
+
+    expect(apiClient.post).toHaveBeenCalledWith('/me/agent/voice/session', {
+      child_id: 'child_xyz',
+      persona: 'buddy_calm',
+    })
+  })
+
+  it('surfaces the response.data unchanged (no envelope unwrapping)', async () => {
+    const canned = { session_id: 'unique', ephemeral_token: 'x'.repeat(32), expires_at: '2026-06-01T00:01:00Z', ws_url: '/ws', provider_config: { provider: 'mock', sample_rate_hz: 16000, audio_format: 'pcm16' } }
+    vi.mocked(apiClient.post).mockResolvedValueOnce({ data: canned })
+
+    const out = await realtimeVoiceService.startSession({ child_id: 'c' })
+    expect(out).toEqual(canned)
+  })
+
+  it('rejects when the underlying apiClient rejects', async () => {
+    const err = new Error('501 not implemented')
+    vi.mocked(apiClient.post).mockRejectedValueOnce(err)
+
+    await expect(
+      realtimeVoiceService.startSession({ child_id: 'c' }),
+    ).rejects.toThrow('501 not implemented')
+  })
+})

--- a/frontend/src/__tests__/hooks/voiceConversationStateMachine.test.ts
+++ b/frontend/src/__tests__/hooks/voiceConversationStateMachine.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isActiveSessionState,
+  TERMINAL_STATES,
+  voiceConversationReducer,
+  type VoiceConversationEvent,
+  type VoiceConversationState,
+} from '@/hooks/voiceConversationStateMachine'
+
+const START_WITH_CONSENT: VoiceConversationEvent = {
+  type: 'start',
+  consentGranted: true,
+}
+const START_WITHOUT_CONSENT: VoiceConversationEvent = {
+  type: 'start',
+  consentGranted: false,
+}
+
+describe('voiceConversationReducer: idle entry', () => {
+  it('start with consent → connecting', () => {
+    expect(voiceConversationReducer('idle', START_WITH_CONSENT)).toBe('connecting')
+  })
+
+  it('start without consent stays idle (consent gate is the parent surface)', () => {
+    expect(voiceConversationReducer('idle', START_WITHOUT_CONSENT)).toBe('idle')
+  })
+
+  it('markUnsupported from idle → unsupported', () => {
+    expect(voiceConversationReducer('idle', { type: 'markUnsupported' })).toBe('unsupported')
+  })
+
+  it('events that do not match idle handlers are no-ops', () => {
+    expect(voiceConversationReducer('idle', { type: 'sttPartial' })).toBe('idle')
+    expect(voiceConversationReducer('idle', { type: 'wsOpen' })).toBe('idle')
+  })
+
+  it('endRequested from idle stays idle (no active session to end)', () => {
+    expect(voiceConversationReducer('idle', { type: 'endRequested' })).toBe('idle')
+  })
+})
+
+describe('voiceConversationReducer: connecting → listening', () => {
+  it('tokenReceived stays connecting (WS still opening)', () => {
+    expect(voiceConversationReducer('connecting', { type: 'tokenReceived' })).toBe('connecting')
+  })
+
+  it('wsOpen → listening', () => {
+    expect(voiceConversationReducer('connecting', { type: 'wsOpen' })).toBe('listening')
+  })
+
+  it('streamError during connect → error', () => {
+    expect(voiceConversationReducer('connecting', { type: 'streamError' })).toBe('error')
+  })
+
+  it('wsClose during connect → error (handshake never completed)', () => {
+    expect(voiceConversationReducer('connecting', { type: 'wsClose' })).toBe('error')
+  })
+})
+
+describe('voiceConversationReducer: listening', () => {
+  it('sttPartial keeps listening', () => {
+    expect(voiceConversationReducer('listening', { type: 'sttPartial' })).toBe('listening')
+  })
+
+  it('sttFinal → thinking', () => {
+    expect(voiceConversationReducer('listening', { type: 'sttFinal' })).toBe('thinking')
+  })
+
+  it('streamError → error', () => {
+    expect(voiceConversationReducer('listening', { type: 'streamError' })).toBe('error')
+  })
+})
+
+describe('voiceConversationReducer: thinking → speaking', () => {
+  it('assistantTextDelta stays thinking', () => {
+    expect(voiceConversationReducer('thinking', { type: 'assistantTextDelta' })).toBe('thinking')
+  })
+
+  it('ttsStart → speaking', () => {
+    expect(voiceConversationReducer('thinking', { type: 'ttsStart' })).toBe('speaking')
+  })
+
+  it('streamError from thinking → error', () => {
+    expect(voiceConversationReducer('thinking', { type: 'streamError' })).toBe('error')
+  })
+})
+
+describe('voiceConversationReducer: speaking + barge-in', () => {
+  it('ttsEnd → listening', () => {
+    expect(voiceConversationReducer('speaking', { type: 'ttsEnd' })).toBe('listening')
+  })
+
+  it('bargeIn → interrupted', () => {
+    expect(voiceConversationReducer('speaking', { type: 'bargeIn' })).toBe('interrupted')
+  })
+
+  it('interrupted then sttPartial → listening', () => {
+    expect(voiceConversationReducer('interrupted', { type: 'sttPartial' })).toBe('listening')
+  })
+
+  it('interrupted then wsOpen → listening (server ack received)', () => {
+    expect(voiceConversationReducer('interrupted', { type: 'wsOpen' })).toBe('listening')
+  })
+
+  it('interrupted then streamError → error', () => {
+    expect(voiceConversationReducer('interrupted', { type: 'streamError' })).toBe('error')
+  })
+})
+
+describe('voiceConversationReducer: user-pressed-End is universal', () => {
+  it('endRequested from every active state → ending', () => {
+    const states: VoiceConversationState[] = [
+      'connecting',
+      'listening',
+      'thinking',
+      'speaking',
+      'interrupted',
+    ]
+    for (const s of states) {
+      expect(voiceConversationReducer(s, { type: 'endRequested' })).toBe('ending')
+    }
+  })
+
+  it('ending waits for wsClose then → idle', () => {
+    expect(voiceConversationReducer('ending', { type: 'wsClose' })).toBe('idle')
+  })
+
+  it('ending absorbs late streamError (we are already shutting down)', () => {
+    expect(voiceConversationReducer('ending', { type: 'streamError' })).toBe('ending')
+  })
+
+  it('endRequested from idle stays idle (nothing to end)', () => {
+    expect(voiceConversationReducer('idle', { type: 'endRequested' })).toBe('idle')
+  })
+})
+
+describe('voiceConversationReducer: error + reset + unsupported', () => {
+  it('error absorbs additional events until reset', () => {
+    expect(voiceConversationReducer('error', { type: 'sttPartial' })).toBe('error')
+    expect(voiceConversationReducer('error', { type: 'wsOpen' })).toBe('error')
+  })
+
+  it('reset returns any state to idle', () => {
+    const states: VoiceConversationState[] = [
+      'connecting',
+      'listening',
+      'thinking',
+      'speaking',
+      'interrupted',
+      'ending',
+      'error',
+    ]
+    for (const s of states) {
+      expect(voiceConversationReducer(s, { type: 'reset' })).toBe('idle')
+    }
+  })
+
+  it('unsupported absorbs every event (terminal)', () => {
+    const events: VoiceConversationEvent[] = [
+      START_WITH_CONSENT,
+      { type: 'wsOpen' },
+      { type: 'sttFinal' },
+      { type: 'ttsStart' },
+      { type: 'bargeIn' },
+      { type: 'endRequested' },
+      { type: 'streamError' },
+      { type: 'reset' },
+    ]
+    for (const e of events) {
+      expect(voiceConversationReducer('unsupported', e)).toBe('unsupported')
+    }
+  })
+
+  it('TERMINAL_STATES contains unsupported only', () => {
+    expect(TERMINAL_STATES.size).toBe(1)
+    expect(TERMINAL_STATES.has('unsupported')).toBe(true)
+  })
+})
+
+describe('isActiveSessionState', () => {
+  it('returns true only while a real session exists', () => {
+    expect(isActiveSessionState('connecting')).toBe(true)
+    expect(isActiveSessionState('listening')).toBe(true)
+    expect(isActiveSessionState('thinking')).toBe(true)
+    expect(isActiveSessionState('speaking')).toBe(true)
+    expect(isActiveSessionState('interrupted')).toBe(true)
+    expect(isActiveSessionState('ending')).toBe(true)
+  })
+
+  it('returns false for idle / error / unsupported', () => {
+    expect(isActiveSessionState('idle')).toBe(false)
+    expect(isActiveSessionState('error')).toBe(false)
+    expect(isActiveSessionState('unsupported')).toBe(false)
+  })
+})

--- a/frontend/src/api/services/realtimeVoiceService.ts
+++ b/frontend/src/api/services/realtimeVoiceService.ts
@@ -1,0 +1,47 @@
+/**
+ * Talk-to-Buddy realtime voice service (#616).
+ *
+ * Thin wrapper around `POST /api/v1/me/agent/voice/session`. Mirrors the
+ * `transcriptionService.ts` pattern: no retries, no auth glue beyond
+ * `apiClient`, raw response surfaced unchanged.
+ *
+ * The WebSocket itself is opened by `useVoiceConversation` (#617) — this
+ * service only mints the ephemeral handshake material.
+ */
+
+import apiClient from "../client";
+
+export interface VoiceProviderConfig {
+  provider: "mock" | "hybrid";
+  sample_rate_hz: number;
+  audio_format: "pcm16" | "opus";
+}
+
+export interface VoiceSessionStartRequest {
+  child_id: string;
+  /** Optional persona override; falls back to child_profile.voice_persona. */
+  persona?: string;
+}
+
+export interface VoiceSessionStartResponse {
+  session_id: string;
+  ephemeral_token: string;
+  /** ISO-8601 timestamp. */
+  expires_at: string;
+  ws_url: string;
+  provider_config: VoiceProviderConfig;
+}
+
+export const realtimeVoiceService = {
+  async startSession(
+    payload: VoiceSessionStartRequest,
+  ): Promise<VoiceSessionStartResponse> {
+    const response = await apiClient.post<VoiceSessionStartResponse>(
+      "/me/agent/voice/session",
+      payload,
+    );
+    return response.data;
+  },
+};
+
+export default realtimeVoiceService;

--- a/frontend/src/hooks/voiceConversationStateMachine.ts
+++ b/frontend/src/hooks/voiceConversationStateMachine.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure reducer for the Talk-to-Buddy realtime voice state machine (#616).
+ *
+ * Extracted from useVoiceConversation so the transition table can be
+ * exhaustively unit-tested without mounting a DOM, opening a WebSocket,
+ * or calling getUserMedia. Mirrors the voiceInputStateMachine.ts pattern
+ * shipped in #584.
+ *
+ * State diagram (PRD §3.16):
+ *   idle ─start──► connecting ─tokenReceived──► connecting (WS opens) ─wsOpen──► listening
+ *   listening ─sttPartial──► listening
+ *   listening ─sttFinal──► thinking ─assistantTextDelta──► thinking
+ *   thinking ─ttsStart──► speaking ─ttsEnd──► listening
+ *   speaking ─bargeIn──► interrupted ─wsOpen|sttPartial──► listening
+ *   any ─endRequested──► ending ─wsClose──► idle
+ *   any ─streamError──► error ─reset──► idle
+ *   idle ─markUnsupported──► unsupported (terminal)
+ */
+
+export type VoiceConversationState =
+  | 'idle'
+  | 'connecting'
+  | 'listening'
+  | 'thinking'
+  | 'speaking'
+  | 'interrupted'
+  | 'ending'
+  | 'error'
+  | 'unsupported'
+
+export type VoiceConversationEvent =
+  | { type: 'start'; consentGranted: boolean }
+  | { type: 'consentGranted' }
+  | { type: 'consentDismissed' }
+  | { type: 'tokenReceived' }
+  | { type: 'wsOpen' }
+  | { type: 'wsClose' }
+  | { type: 'sttPartial' }
+  | { type: 'sttFinal' }
+  | { type: 'assistantTextDelta' }
+  | { type: 'ttsStart' }
+  | { type: 'ttsEnd' }
+  | { type: 'bargeIn' }
+  | { type: 'endRequested' }
+  | { type: 'streamError' }
+  | { type: 'markUnsupported' }
+  | { type: 'reset' }
+
+/**
+ * Pure reducer. `(state, event) => next state`.
+ *
+ * Two terminal-ish rules:
+ *   1. `unsupported` absorbs every event (true terminal).
+ *   2. `endRequested` is universal — it always transitions to `ending`
+ *      (except from `unsupported`) because the user-pressed-End signal
+ *      must never be ignored.
+ */
+export function voiceConversationReducer(
+  state: VoiceConversationState,
+  event: VoiceConversationEvent,
+): VoiceConversationState {
+  // Terminal absorption: once unsupported, nothing changes.
+  if (state === 'unsupported') return 'unsupported'
+
+  // User-pressed-End is honored from every active state.
+  if (event.type === 'endRequested') {
+    return state === 'idle' ? 'idle' : 'ending'
+  }
+
+  // markUnsupported also fires unconditionally — only the capability
+  // check can put us here, and once we get the signal we never come back.
+  if (event.type === 'markUnsupported') return 'unsupported'
+
+  // reset returns to idle from any non-terminal state.
+  if (event.type === 'reset') return 'idle'
+
+  // Per-state dispatch table.
+  switch (state) {
+    case 'idle':
+      if (event.type === 'start') {
+        return event.consentGranted ? 'connecting' : 'idle'
+      }
+      return state
+
+    case 'connecting':
+      switch (event.type) {
+        case 'wsOpen':
+          return 'listening'
+        case 'streamError':
+        case 'wsClose':
+          return 'error'
+        case 'tokenReceived':
+          return 'connecting' // self-loop: token in hand, still connecting WS
+        default:
+          return state
+      }
+
+    case 'listening':
+      switch (event.type) {
+        case 'sttPartial':
+          return 'listening'
+        case 'sttFinal':
+          return 'thinking'
+        case 'streamError':
+        case 'wsClose':
+          return 'error'
+        default:
+          return state
+      }
+
+    case 'thinking':
+      switch (event.type) {
+        case 'assistantTextDelta':
+          return 'thinking'
+        case 'ttsStart':
+          return 'speaking'
+        case 'streamError':
+        case 'wsClose':
+          return 'error'
+        default:
+          return state
+      }
+
+    case 'speaking':
+      switch (event.type) {
+        case 'bargeIn':
+          return 'interrupted'
+        case 'ttsEnd':
+          return 'listening'
+        case 'streamError':
+        case 'wsClose':
+          return 'error'
+        default:
+          return state
+      }
+
+    case 'interrupted':
+      // Interrupt cancels the current TTS. Once we hear a partial from
+      // the new utterance OR the WS confirms the cancel landed, return
+      // to listening. Otherwise stay parked.
+      switch (event.type) {
+        case 'sttPartial':
+        case 'wsOpen':
+          return 'listening'
+        case 'streamError':
+        case 'wsClose':
+          return 'error'
+        default:
+          return state
+      }
+
+    case 'ending':
+      // Ending state waits for the server to acknowledge with wsClose.
+      // streamError during shutdown is non-fatal — we're already closing.
+      switch (event.type) {
+        case 'wsClose':
+          return 'idle'
+        default:
+          return state
+      }
+
+    case 'error':
+      // Stay in error until the consumer dispatches reset.
+      return state
+
+    default:
+      return state
+  }
+}
+
+/**
+ * True when the hook owns either the mic stream or the WS connection.
+ * Used by consumers to decide whether cleanup is required on unmount.
+ */
+export function isActiveSessionState(state: VoiceConversationState): boolean {
+  return (
+    state === 'connecting' ||
+    state === 'listening' ||
+    state === 'thinking' ||
+    state === 'speaking' ||
+    state === 'interrupted' ||
+    state === 'ending'
+  )
+}
+
+export const TERMINAL_STATES: ReadonlySet<VoiceConversationState> = new Set([
+  'unsupported',
+])


### PR DESCRIPTION
## Summary

Frontend foundation for Talk to Buddy realtime voice (PRD §3.16). Pure modules only — no hook, no UI, no WebSocket code, no getUserMedia call. Lands in parallel with the just-merged backend foundation #621 because both consume the same Pydantic shapes.

| File | Purpose |
|------|---------|
| [voiceConversationStateMachine.ts](frontend/src/hooks/voiceConversationStateMachine.ts) | Pure reducer — 9 states × 15 events |
| [realtimeVoiceService.ts](frontend/src/api/services/realtimeVoiceService.ts) | Typed startSession() wrapping POST /me/agent/voice/session |

## State machine

- idle ─start(consent)─► connecting
- connecting ─wsOpen─► listening
- listening ─sttFinal─► thinking ─ttsStart─► speaking
- speaking ─bargeIn─► interrupted ─sttPartial|wsOpen─► listening
- speaking ─ttsEnd─► listening
- any active ─endRequested─► ending ─wsClose─► idle
- any active ─streamError|wsClose─► error ─reset─► idle
- idle ─markUnsupported─► unsupported (terminal)

Two structural rules:
- endRequested is **universal** — honored from every active state so the user-pressed-End signal is never ignored
- unsupported absorbs every event (true terminal)
- reset returns any non-terminal state to idle

## Test plan

- [x] vitest run → 34/34 tests pass
- [x] tsc -b → clean (no type drift from PR #621's Pydantic shapes)
- [x] Reducer is a pure function; no side effects
- [x] Service test covers happy path, optional persona, response-data passthrough, rejection propagation

## Independence

This PR ships only types + a pure reducer. No consumer exists yet, so landing it is a zero-runtime change. Sub-stories that depend on it:
- #617 (Phase B2) — useVoiceConversation hook glues reducer + service + MediaRecorder + WebSocket
- #618 (Phase B3) — TalkToBuddyPanel UI consumes the hook
- #619 (Phase B4) — ParentConsentGate voice_conversation variant
- #620 (Phase B5) — AgentChatPanel wiring

## Notes

The service URL /me/agent/voice/session currently returns 501 from the backend (PR #621 foundation). Once #615 lands the real broker, this same service call returns the real ephemeral token + WS URL — no service-side change needed.

Fixes #616
Parent Story: #607
Parent Epic: #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)