### PR TITLE
feat(my-agent): hybrid Whisper+ElevenLabs provider + ephemeral JWT (#614)

### DIFF
--- a/backend/src/services/realtime_voice_service.py
+++ b/backend/src/services/realtime_voice_service.py
@@ -20,10 +20,26 @@ Real network calls land in #614.
 from __future__ import annotations
 
 import asyncio
+import io
+import logging
 import os
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, Optional, Protocol
 from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - import fallback for test env
+    OpenAI = None
+
+try:
+    from elevenlabs.client import AsyncElevenLabs as _elevenlabs_AsyncClient
+    from elevenlabs import VoiceSettings as _elevenlabs_VoiceSettings
+except Exception:  # pragma: no cover - import fallback for test env
+    _elevenlabs_AsyncClient = None
+    _elevenlabs_VoiceSettings = None
 
 
 # ---------------------------------------------------------------------------
@@ -219,6 +235,257 @@ class MockRealtimeVoiceProvider:
 
 
 # ---------------------------------------------------------------------------
+# Hybrid provider — Whisper STT + ElevenLabs Flash TTS (#614)
+# ---------------------------------------------------------------------------
+
+MAX_UTTERANCE_BYTES: int = 2 * 1024 * 1024  # 2 MB
+MAX_UTTERANCE_MS: int = 30_000  # 30 s
+
+_MIME_EXT_MAP: Dict[str, str] = {
+    "audio/webm": "audio.webm",
+    "audio/mp4": "audio.mp4",
+    "audio/mpeg": "audio.mp3",
+    "audio/wav": "audio.wav",
+    "audio/pcm": "audio.wav",
+}
+
+
+def _extension_for(mime_type: str) -> str:
+    """Pick a filename suffix the OpenAI SDK can sniff for Whisper."""
+    base = mime_type.split(";", 1)[0].strip().lower()
+    return _MIME_EXT_MAP.get(base, "audio.bin")
+
+
+# Per-age TTS overrides land in #608 (Phase C). For v1 the provider
+# exposes a global default and the broker can override via constructor.
+DEFAULT_TTS_MODEL: str = "eleven_flash_v2_5"
+DEFAULT_TTS_VOICE_ID: str = "21m00Tcm4TlvDq8ikWAM"  # ElevenLabs "Rachel"
+
+
+class HybridRealtimeVoiceProvider:
+    """Whisper STT + ElevenLabs Flash TTS, brokered in-memory.
+
+    Audio bytes live in ``handle.provider_state["buffer"]`` (bytearray)
+    only — never flushed to disk. ``finalize_utterance`` calls Whisper
+    via the existing OpenAI client pattern (``io.BytesIO`` + ``buffer.name``
+    extension hint) and runs the same safety check as ``stt_service``.
+
+    Graceful degradation:
+      - Missing ``OPENAI_API_KEY`` → ``finalize_utterance`` returns
+        ``success=False, error="provider_unavailable"``. The broker
+        translates to ``VoiceWSErrorEvent(code="provider_unavailable")``.
+      - Missing ``ELEVENLABS_API_KEY`` → ``synthesize_speech`` yields an
+        empty async generator. Session continues; buddy is silent. The
+        broker emits ``assistant_text(is_final=True)`` and skips
+        ``audio_chunk`` events.
+      - SDK import failure → handled the same way.
+
+    Single-tenant — one handle per session. The broker must never share
+    a handle across concurrent coroutines on the same session.
+    """
+
+    name: str = "hybrid"
+    WHISPER_MODEL: str = "whisper-1"
+
+    def __init__(
+        self,
+        *,
+        tts_model: str = DEFAULT_TTS_MODEL,
+        tts_voice_id: str = DEFAULT_TTS_VOICE_ID,
+    ) -> None:
+        self.tts_model = tts_model
+        self.tts_voice_id = tts_voice_id
+
+    @property
+    def _stt_available(self) -> bool:
+        return bool(os.getenv("OPENAI_API_KEY")) and OpenAI is not None
+
+    @property
+    def _tts_available(self) -> bool:
+        return (
+            bool(os.getenv("ELEVENLABS_API_KEY"))
+            and _elevenlabs_AsyncClient is not None
+            and _elevenlabs_VoiceSettings is not None
+        )
+
+    async def start_session(
+        self,
+        *,
+        user_id: str,
+        child_id: str,
+        target_age: int,
+        persona: str = "buddy_default",
+    ) -> SessionHandle:
+        return SessionHandle(
+            session_id=f"voice_hybrid_{uuid4().hex[:12]}",
+            user_id=user_id,
+            child_id=child_id,
+            target_age=target_age,
+            persona=persona,
+            provider_state={
+                "buffer": bytearray(),
+                "bytes_received": 0,
+                "mime_type": "audio/webm",
+                "utterances": 0,
+                "forced_flush": False,
+            },
+        )
+
+    async def push_audio(self, handle: SessionHandle, audio_bytes: bytes) -> None:
+        state = handle.provider_state
+        buffer: bytearray = state["buffer"]
+        buffer.extend(audio_bytes)
+        state["bytes_received"] = len(buffer)
+        if len(buffer) >= MAX_UTTERANCE_BYTES:
+            # Soft signal — broker checks state["forced_flush"] between
+            # pushes if it wants to pre-empt. We never raise.
+            state["forced_flush"] = True
+
+    async def finalize_utterance(self, handle: SessionHandle) -> FinalTranscript:
+        state = handle.provider_state
+        audio_bytes = bytes(state["buffer"])
+        # Reset immediately so a concurrent push (broker bug) doesn't
+        # pollute the next utterance with leftover bytes.
+        state["buffer"] = bytearray()
+        state["bytes_received"] = 0
+        state["forced_flush"] = False
+        state["utterances"] = state.get("utterances", 0) + 1
+
+        if not audio_bytes:
+            return FinalTranscript(
+                success=True, text="", language="en", duration_ms=0,
+                safety_passed=False, error="empty_utterance",
+                provider=self.name,
+            )
+
+        if not self._stt_available:
+            return FinalTranscript(
+                success=False, text="", language="en", duration_ms=0,
+                safety_passed=False, error="provider_unavailable",
+                provider=self.name,
+            )
+
+        mime_type = state.get("mime_type", "audio/webm")
+        api_key = os.getenv("OPENAI_API_KEY")
+
+        def _sync_transcribe() -> Dict[str, Any]:
+            client = OpenAI(api_key=api_key)  # type: ignore[misc]
+            buf = io.BytesIO(audio_bytes)
+            buf.name = _extension_for(mime_type)
+            response = client.audio.transcriptions.create(  # type: ignore[union-attr]
+                model=self.WHISPER_MODEL,
+                file=buf,
+                response_format="verbose_json",
+            )
+            duration_s = float(getattr(response, "duration", 0.0) or 0.0)
+            return {
+                "text": getattr(response, "text", "") or "",
+                "language": getattr(response, "language", "en"),
+                "duration_ms": int(round(duration_s * 1000)),
+            }
+
+        loop = asyncio.get_running_loop()
+        try:
+            result = await loop.run_in_executor(None, _sync_transcribe)
+        except Exception as exc:
+            logger.warning(
+                "[session=%s] Whisper transcribe failed: %s",
+                handle.session_id, exc,
+            )
+            return FinalTranscript(
+                success=False, text="", language="en", duration_ms=0,
+                safety_passed=False, error=f"stt_failed: {exc}",
+                provider=self.name,
+            )
+
+        text = (result.get("text") or "").strip()
+        # Lazy import to avoid circular dependency on stt_service at load.
+        from . import stt_service as _stt
+
+        try:
+            safety_envelope = await _stt._safety_check_text(text, handle.target_age)
+            score = float(safety_envelope.get("safety_score", 0.0))
+        except Exception as exc:
+            logger.warning(
+                "[session=%s] safety check raised; fail-closed: %s",
+                handle.session_id, exc,
+            )
+            return FinalTranscript(
+                success=True, text="", language=result["language"],
+                duration_ms=result["duration_ms"],
+                safety_passed=False, error="safety_check_failed",
+                provider=self.name,
+            )
+
+        safety_passed = score >= SAFETY_THRESHOLD
+        return FinalTranscript(
+            success=True,
+            text=text if safety_passed else "",
+            language=result["language"],
+            duration_ms=result["duration_ms"],
+            safety_passed=safety_passed,
+            provider=self.name,
+        )
+
+    async def synthesize_speech(
+        self,
+        handle: SessionHandle,
+        text: str,
+    ) -> AsyncIterator[bytes]:
+        if not text.strip():
+            async def _empty() -> AsyncIterator[bytes]:
+                if False:  # pragma: no cover
+                    yield b""
+            return _empty()
+
+        if not self._tts_available:
+            logger.info(
+                "[session=%s] TTS unavailable — yielding empty stream",
+                handle.session_id,
+            )
+            async def _silent() -> AsyncIterator[bytes]:
+                if False:  # pragma: no cover
+                    yield b""
+            return _silent()
+
+        api_key = os.getenv("ELEVENLABS_API_KEY")
+        voice_id = self.tts_voice_id
+        model_id = self.tts_model
+
+        async def _stream_chunks() -> AsyncIterator[bytes]:
+            try:
+                client = _elevenlabs_AsyncClient(api_key=api_key)  # type: ignore[misc]
+                voice_settings = _elevenlabs_VoiceSettings(  # type: ignore[misc]
+                    stability=0.5, similarity_boost=0.75, style=0.2,
+                )
+                audio_stream = await client.text_to_speech.convert(
+                    voice_id=voice_id,
+                    text=text,
+                    model_id=model_id,
+                    voice_settings=voice_settings,
+                    output_format="mp3_44100_128",
+                )
+                async for chunk in audio_stream:
+                    if chunk:
+                        yield chunk
+            except Exception as exc:
+                logger.warning(
+                    "[session=%s] ElevenLabs TTS failed mid-stream: %s",
+                    handle.session_id, exc,
+                )
+                return
+
+        return _stream_chunks()
+
+    async def close(self, handle: SessionHandle) -> None:
+        # No persistent connections — Whisper is one-shot, ElevenLabs
+        # stream closes when its iterator exhausts. Clear the buffer
+        # so nothing leaks if a caller holds the handle past close.
+        handle.provider_state.pop("buffer", None)
+        handle.provider_state["closed"] = True
+
+
+# ---------------------------------------------------------------------------
 # Provider selection
 # ---------------------------------------------------------------------------
 
@@ -230,10 +497,10 @@ def _select_provider(
     Priority:
       1. Explicit ``override`` — test injection.
       2. ``REALTIME_VOICE_PROVIDER=mock`` → MockRealtimeVoiceProvider.
-      3. ``REALTIME_VOICE_PROVIDER=hybrid`` → not yet implemented (#614);
-         falls back to Mock with a stderr warning.
+      3. ``REALTIME_VOICE_PROVIDER=hybrid`` → HybridRealtimeVoiceProvider
+         (degrades internally when keys are missing).
       4. Missing ``OPENAI_API_KEY`` → Mock (dev/test env without keys).
-      5. Default → Mock until #614 lands.
+      5. Default → Mock until an operator opts into hybrid.
     """
     if override is not None:
         return override
@@ -243,10 +510,7 @@ def _select_provider(
         return MockRealtimeVoiceProvider()
 
     if requested == "hybrid":
-        # #614 will replace this branch with the real provider. For now
-        # we degrade to Mock so /voice/session never hard-fails on a
-        # half-deployed environment.
-        return MockRealtimeVoiceProvider()
+        return HybridRealtimeVoiceProvider()
 
     if not os.getenv("OPENAI_API_KEY"):
         return MockRealtimeVoiceProvider()

--- a/backend/src/services/voice_ephemeral_token.py
+++ b/backend/src/services/voice_ephemeral_token.py
@@ -1,0 +1,177 @@
+"""
+Ephemeral JWT for Talk-to-Buddy realtime voice handshake (#614).
+
+The REST `/voice/session` endpoint mints one of these for the client.
+The client passes it in the WebSocket query string (`?token=...`); the
+WS broker (#615) calls ``verify_voice_token`` once at handshake time.
+
+Hard rules from PRD §3.16:
+  - Single-use — verifying consumes the ``jti``. A replay returns None.
+  - Short-lived — 60s TTL. Clients must reconnect via REST if the WS
+    drops; there is no refresh.
+  - Purpose-scoped — the ``purpose`` claim distinguishes voice tokens
+    from any other JWT the codebase mints (parent-approval, Supabase
+    session, etc.) so the secret can't be cross-used.
+
+In-memory nonce storage is fine for v1 single-process deploy. A
+``TODO(scale)`` notes the Redis migration path for multi-worker prod.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+import jwt
+
+logger = logging.getLogger(__name__)
+
+# Hard constants from PRD §3.16.4.
+TOKEN_TTL_SECONDS: int = 60
+TOKEN_ALGORITHM: str = "HS256"
+TOKEN_PURPOSE: str = "voice_realtime"
+
+# In-memory nonce set. Maps jti → expiration timestamp (float seconds).
+# Lazy sweep on every verify call keeps the set bounded — entries TTL
+# out in ≤60s so the set can never grow past TOKEN_TTL_SECONDS × mint
+# rate. Bytes-wise this is O(KB) even at 100 req/s.
+#
+# TODO(scale): replace with Redis when we add a second uvicorn worker.
+_USED_JTIS: Dict[str, float] = {}
+
+
+def _signing_secret() -> str:
+    """Resolve the signing key with the same fallback chain as parent-approval JWT.
+
+    Priority:
+      1. VOICE_REALTIME_TOKEN_SECRET — dedicated env var
+      2. SECRET_KEY — general app secret
+      3. dev fallback (logs WARNING once)
+    """
+    secret = os.getenv("VOICE_REALTIME_TOKEN_SECRET") or os.getenv("SECRET_KEY")
+    if secret:
+        return secret
+    if not getattr(_signing_secret, "_warned", False):
+        logger.warning(
+            "voice_ephemeral_token using insecure dev fallback secret — "
+            "set VOICE_REALTIME_TOKEN_SECRET or SECRET_KEY for production"
+        )
+        _signing_secret._warned = True  # type: ignore[attr-defined]
+    return "dev-voice-realtime-secret"
+
+
+@dataclass(frozen=True)
+class VoiceTokenClaims:
+    """Decoded payload — exposed to the broker for downstream auth checks."""
+    session_id: str
+    user_id: str
+    child_id: str
+    purpose: str
+    jti: str
+    iat: int
+    exp: int
+
+
+def mint_voice_token(
+    *,
+    session_id: str,
+    user_id: str,
+    child_id: str,
+    ttl_seconds: int = TOKEN_TTL_SECONDS,
+) -> str:
+    """Create a single-use HS256 token for a fresh voice session.
+
+    The caller (REST `/voice/session` route in #615) should always pair
+    a mint with a `voice_session_repo.create_session(...)` write so the
+    audit row exists when the WS handshake completes.
+    """
+    now = int(time.time())
+    ttl = max(0, int(ttl_seconds))
+    payload: Dict[str, Any] = {
+        "sub": user_id,
+        "session_id": session_id,
+        "child_id": child_id,
+        "purpose": TOKEN_PURPOSE,
+        "jti": uuid4().hex,
+        "iat": now,
+        "exp": now + ttl,
+    }
+    token = jwt.encode(payload, _signing_secret(), algorithm=TOKEN_ALGORITHM)
+    # PyJWT ≥2.0 returns str; ≤1.x returned bytes. Be defensive.
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
+    return token
+
+
+def _sweep_expired_jtis(now: float) -> None:
+    """Drop nonce entries whose token expiration has passed."""
+    expired = [jti for jti, exp in _USED_JTIS.items() if exp < now]
+    for jti in expired:
+        _USED_JTIS.pop(jti, None)
+
+
+def verify_voice_token(token: str) -> Optional[VoiceTokenClaims]:
+    """Validate signature + expiration + purpose + nonce.
+
+    Consumes the ``jti`` on success — a second call with the same token
+    returns ``None`` (replay protection). Returns ``None`` on any failure:
+    bad signature, expired, wrong purpose, replay, malformed payload.
+    """
+    # Sweep BEFORE decode so even malformed inputs (or the broker
+    # spamming us with auth_failed retries) keep the nonce store from
+    # holding on to expired entries forever.
+    _sweep_expired_jtis(time.time())
+
+    try:
+        payload = jwt.decode(
+            token,
+            _signing_secret(),
+            algorithms=[TOKEN_ALGORITHM],
+            options={"require": ["exp", "iat", "sub", "jti"]},
+        )
+    except jwt.ExpiredSignatureError:
+        return None
+    except jwt.InvalidTokenError:
+        return None
+
+    purpose = payload.get("purpose")
+    if purpose != TOKEN_PURPOSE:
+        return None
+
+    jti = payload.get("jti")
+    if not jti or not isinstance(jti, str):
+        return None
+
+    if jti in _USED_JTIS:
+        # Replay — refuse and do not extend the nonce TTL.
+        return None
+
+    # Required fields — surface any missing ones as a failure rather
+    # than letting them flow into the broker as silent defaults.
+    session_id = payload.get("session_id")
+    child_id = payload.get("child_id")
+    if not session_id or not child_id:
+        return None
+
+    # Consume the nonce — even if the broker subsequently rejects the
+    # session for consent/quota reasons, the token itself is spent.
+    _USED_JTIS[jti] = float(payload["exp"])
+
+    return VoiceTokenClaims(
+        session_id=session_id,
+        user_id=payload["sub"],
+        child_id=child_id,
+        purpose=purpose,
+        jti=jti,
+        iat=int(payload["iat"]),
+        exp=int(payload["exp"]),
+    )
+
+
+def _reset_nonce_store_for_tests() -> None:
+    """Test-only helper. Clears the in-memory nonce set between tests."""
+    _USED_JTIS.clear()

--- a/backend/tests/contracts/test_hybrid_realtime_voice_contract.py
+++ b/backend/tests/contracts/test_hybrid_realtime_voice_contract.py
@@ -1,0 +1,415 @@
+"""
+Contract tests for HybridRealtimeVoiceProvider (#614).
+
+The provider talks to live Whisper + ElevenLabs in production, but
+these tests run hermetically — every external call is monkeypatched.
+The point of the suite is to lock the in-memory invariants:
+
+  - Audio bytes are NEVER written to disk
+  - Buffer is reset after every finalize_utterance
+  - Hard byte cap raises the forced_flush signal
+  - Missing OPENAI_API_KEY → provider_unavailable envelope
+  - Missing ELEVENLABS_API_KEY → empty TTS stream (no audio_chunk events)
+  - Whisper raise → stt_failed envelope
+  - Safety MCP raise → fail-closed (safety_passed=False, text="")
+  - Provider satisfies the RealtimeVoiceProvider Protocol
+"""
+
+import builtins
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.src.services import realtime_voice_service as rtvs
+from backend.src.services.realtime_voice_service import (
+    HybridRealtimeVoiceProvider,
+    MAX_UTTERANCE_BYTES,
+    SAFETY_THRESHOLD,
+    SessionHandle,
+    _extension_for,
+    _select_provider,
+)
+
+
+# ---------------------- Protocol shape -------------------------------------
+
+class TestProtocolShape:
+    def test_hybrid_has_required_methods(self):
+        provider = HybridRealtimeVoiceProvider()
+        assert provider.name == "hybrid"
+        for method in (
+            "start_session", "push_audio", "finalize_utterance",
+            "synthesize_speech", "close",
+        ):
+            assert hasattr(provider, method), f"missing {method}"
+
+
+# ---------------------- Mime extension mapping -----------------------------
+
+class TestExtensionFor:
+    def test_webm_with_codec(self):
+        assert _extension_for("audio/webm;codecs=opus") == "audio.webm"
+
+    def test_mp4(self):
+        assert _extension_for("audio/mp4") == "audio.mp4"
+
+    def test_mpeg(self):
+        assert _extension_for("audio/mpeg") == "audio.mp3"
+
+    def test_pcm_and_wav(self):
+        assert _extension_for("audio/wav") == "audio.wav"
+        assert _extension_for("audio/pcm") == "audio.wav"
+
+    def test_unknown_mime_falls_back(self):
+        assert _extension_for("application/octet-stream") == "audio.bin"
+
+
+# ---------------------- start_session shape --------------------------------
+
+class TestStartSession:
+    @pytest.mark.asyncio
+    async def test_start_session_unique_id_and_empty_buffer(self):
+        p = HybridRealtimeVoiceProvider()
+        h1 = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        h2 = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        assert h1.session_id != h2.session_id
+        assert h1.session_id.startswith("voice_hybrid_")
+        assert h1.provider_state["buffer"] == bytearray()
+        assert h1.provider_state["bytes_received"] == 0
+        assert h1.provider_state["utterances"] == 0
+        assert h1.provider_state["forced_flush"] is False
+
+
+# ---------------------- Buffer + forced_flush ------------------------------
+
+class TestBuffering:
+    @pytest.mark.asyncio
+    async def test_push_audio_accumulates(self):
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        await p.push_audio(h, b"\x00" * 100)
+        await p.push_audio(h, b"\x00" * 50)
+        assert h.provider_state["bytes_received"] == 150
+        assert len(h.provider_state["buffer"]) == 150
+        assert h.provider_state["forced_flush"] is False
+
+    @pytest.mark.asyncio
+    async def test_buffer_cap_raises_forced_flush(self):
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        # Push enough to cross the 2 MB threshold in one chunk.
+        await p.push_audio(h, b"\x00" * (MAX_UTTERANCE_BYTES + 1))
+        assert h.provider_state["forced_flush"] is True
+
+    @pytest.mark.asyncio
+    async def test_finalize_resets_buffer(self, monkeypatch):
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        # Skip the network — patch the path that would call Whisper.
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key-for-stt-available-check")
+        from openai import OpenAI as _OpenAI  # noqa: F401  ensure attr exists
+        monkeypatch.setattr(
+            rtvs, "OpenAI", lambda **_kw: MagicMock(),
+        )
+        # Force the inner _sync_transcribe path by injecting a fake
+        # response shape directly. Easier: patch run_in_executor.
+        import asyncio as _aio
+        async def fake_exec(_pool, fn, *args, **kwargs):
+            return {"text": "hello", "language": "en", "duration_ms": 1234}
+        original_get_loop = _aio.get_running_loop
+        class _FakeLoop:
+            def run_in_executor(self, pool, fn):
+                async def _runner():
+                    return fn()
+                return _runner()
+        # Easier path: monkeypatch _safety_check_text + the executor's
+        # inner sync call by replacing client.audio.transcriptions.create.
+        # We do the simplest thing: patch run_in_executor on the running loop.
+        monkeypatch.setattr(
+            _aio, "get_running_loop",
+            lambda: _FakeLoopWithReturn({"text": "hello world", "language": "en", "duration_ms": 1000}),
+        )
+        # Stub the safety helper before finalize runs.
+        from backend.src.services import stt_service as _stt
+        monkeypatch.setattr(
+            _stt, "_safety_check_text",
+            AsyncMock(return_value={"safety_score": 0.95}),
+        )
+
+        await p.push_audio(h, b"\x00" * 200)
+        result = await p.finalize_utterance(h)
+        assert result.success is True
+        assert result.text == "hello world"
+        assert result.safety_passed is True
+        # Buffer must be empty after finalize.
+        assert h.provider_state["buffer"] == bytearray()
+        assert h.provider_state["bytes_received"] == 0
+        assert h.provider_state["utterances"] == 1
+
+
+class _FakeLoopWithReturn:
+    """Helper: a fake event-loop whose run_in_executor returns a canned dict."""
+    def __init__(self, canned_return):
+        self._canned = canned_return
+
+    def run_in_executor(self, pool, fn):
+        async def _runner():
+            # The real impl calls the sync function; for tests we ignore
+            # it and return our canned shape so the test doesn't depend
+            # on the OpenAI SDK being installed/reachable.
+            return self._canned
+        return _runner()
+
+
+# ---------------------- Empty utterance ------------------------------------
+
+class TestEmptyUtterance:
+    @pytest.mark.asyncio
+    async def test_finalize_with_empty_buffer_returns_empty_envelope(self):
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        result = await p.finalize_utterance(h)
+        assert result.success is True
+        assert result.text == ""
+        assert result.safety_passed is False
+        assert result.error == "empty_utterance"
+        assert result.duration_ms == 0
+
+
+# ---------------------- Graceful degradation -------------------------------
+
+class TestGracefulDegradation:
+    @pytest.mark.asyncio
+    async def test_missing_openai_key_returns_provider_unavailable(
+        self, monkeypatch,
+    ):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        await p.push_audio(h, b"\x00" * 200)
+        result = await p.finalize_utterance(h)
+        assert result.success is False
+        assert result.error == "provider_unavailable"
+        assert result.text == ""
+
+    @pytest.mark.asyncio
+    async def test_missing_elevenlabs_key_yields_empty_tts_stream(
+        self, monkeypatch,
+    ):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        gen = await p.synthesize_speech(h, "hello buddy")
+        chunks = [chunk async for chunk in gen]
+        # No audio frames — broker emits assistant_text(is_final=True) and
+        # skips audio_chunk events.
+        assert chunks == []
+
+    @pytest.mark.asyncio
+    async def test_empty_text_yields_empty_stream(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "stub-not-called")
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        gen = await p.synthesize_speech(h, "   ")
+        chunks = [chunk async for chunk in gen]
+        assert chunks == []
+
+
+# ---------------------- Failure envelopes ----------------------------------
+
+class TestFailureEnvelopes:
+    @pytest.mark.asyncio
+    async def test_whisper_exception_returns_stt_failed(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "stub")
+        import asyncio as _aio
+
+        class _RaisingLoop:
+            def run_in_executor(self, pool, fn):
+                async def _runner():
+                    raise RuntimeError("upstream Whisper 500")
+                return _runner()
+
+        monkeypatch.setattr(_aio, "get_running_loop", lambda: _RaisingLoop())
+
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        await p.push_audio(h, b"\x00" * 100)
+        result = await p.finalize_utterance(h)
+        assert result.success is False
+        assert result.error is not None
+        assert result.error.startswith("stt_failed:")
+        assert "Whisper 500" in result.error
+
+    @pytest.mark.asyncio
+    async def test_safety_mcp_raises_fails_closed(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "stub")
+        import asyncio as _aio
+        monkeypatch.setattr(
+            _aio, "get_running_loop",
+            lambda: _FakeLoopWithReturn(
+                {"text": "totally fine", "language": "en", "duration_ms": 500},
+            ),
+        )
+        from backend.src.services import stt_service as _stt
+        monkeypatch.setattr(
+            _stt, "_safety_check_text",
+            AsyncMock(side_effect=RuntimeError("safety MCP down")),
+        )
+
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        await p.push_audio(h, b"\x00" * 100)
+        result = await p.finalize_utterance(h)
+        # Fail-closed: success=True (transport ok) but text empty + flag false.
+        assert result.success is True
+        assert result.text == ""
+        assert result.safety_passed is False
+        assert result.error == "safety_check_failed"
+
+    @pytest.mark.asyncio
+    async def test_safety_score_below_threshold_blocks_text(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "stub")
+        import asyncio as _aio
+        monkeypatch.setattr(
+            _aio, "get_running_loop",
+            lambda: _FakeLoopWithReturn(
+                {"text": "bad stuff", "language": "en", "duration_ms": 500},
+            ),
+        )
+        from backend.src.services import stt_service as _stt
+        monkeypatch.setattr(
+            _stt, "_safety_check_text",
+            AsyncMock(return_value={"safety_score": SAFETY_THRESHOLD - 0.1}),
+        )
+
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        await p.push_audio(h, b"\x00" * 100)
+        result = await p.finalize_utterance(h)
+        assert result.success is True
+        assert result.text == ""
+        assert result.safety_passed is False
+
+
+# ---------------------- The load-bearing invariant -------------------------
+
+class TestNoDiskPersistence:
+    """No audio bytes reach disk during any provider operation."""
+
+    @pytest.mark.asyncio
+    async def test_full_round_trip_never_writes_to_disk(self, monkeypatch):
+        write_bytes_calls: list[str] = []
+        named_temp_calls: list[tuple] = []
+        open_write_calls: list[tuple[str, str]] = []
+
+        original_write_bytes = Path.write_bytes
+        original_named_temp = tempfile.NamedTemporaryFile
+        original_open = builtins.open
+
+        def spy_write_bytes(self, *args, **kwargs):
+            write_bytes_calls.append(str(self))
+            return original_write_bytes(self, *args, **kwargs)
+
+        def spy_named_temp(*args, **kwargs):
+            named_temp_calls.append((args, kwargs))
+            return original_named_temp(*args, **kwargs)
+
+        def spy_open(file, mode="r", *args, **kwargs):
+            if any(c in mode for c in ("w", "a", "x")):
+                open_write_calls.append((str(file), mode))
+            return original_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_bytes", spy_write_bytes)
+        monkeypatch.setattr(tempfile, "NamedTemporaryFile", spy_named_temp)
+        monkeypatch.setattr(builtins, "open", spy_open)
+
+        # Stub the network paths.
+        monkeypatch.setenv("OPENAI_API_KEY", "stub")
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)  # silent TTS
+        import asyncio as _aio
+        monkeypatch.setattr(
+            _aio, "get_running_loop",
+            lambda: _FakeLoopWithReturn(
+                {"text": "hello", "language": "en", "duration_ms": 1000},
+            ),
+        )
+        from backend.src.services import stt_service as _stt
+        monkeypatch.setattr(
+            _stt, "_safety_check_text",
+            AsyncMock(return_value={"safety_score": 0.99}),
+        )
+
+        provider = HybridRealtimeVoiceProvider()
+        h = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        # Realistic mic capture — push a few hundred KB, finalize, attempt
+        # synthesis (silent because no ElevenLabs key), close.
+        for _ in range(4):
+            await provider.push_audio(h, b"\x00" * 65_536)
+        await provider.finalize_utterance(h)
+        gen = await provider.synthesize_speech(h, "buddy reply")
+        async for _ in gen:
+            pass
+        await provider.close(h)
+
+        assert write_bytes_calls == [], (
+            f"hybrid provider wrote to disk: {write_bytes_calls}"
+        )
+        assert named_temp_calls == [], (
+            f"hybrid provider created temp file: {named_temp_calls}"
+        )
+        assert open_write_calls == [], (
+            f"hybrid provider opened a file for writing: {open_write_calls}"
+        )
+
+
+# ---------------------- Provider selection ---------------------------------
+
+class TestProviderSelectionWiresHybrid:
+    def test_hybrid_env_returns_hybrid_provider(self, monkeypatch):
+        monkeypatch.setenv("REALTIME_VOICE_PROVIDER", "hybrid")
+        chosen = _select_provider()
+        assert chosen.name == "hybrid"
+        assert isinstance(chosen, HybridRealtimeVoiceProvider)
+
+
+# ---------------------- Cleanup --------------------------------------------
+
+class TestClose:
+    @pytest.mark.asyncio
+    async def test_close_clears_buffer(self):
+        p = HybridRealtimeVoiceProvider()
+        h = await p.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        await p.push_audio(h, b"\x00" * 100)
+        await p.close(h)
+        assert "buffer" not in h.provider_state
+        assert h.provider_state["closed"] is True

--- a/backend/tests/contracts/test_realtime_voice_service_contract.py
+++ b/backend/tests/contracts/test_realtime_voice_service_contract.py
@@ -130,12 +130,13 @@ class TestProviderSelection:
         chosen = _select_provider()
         assert chosen.name == "mock"
 
-    def test_hybrid_env_falls_back_to_mock_until_implemented(self, monkeypatch):
-        # #614 will replace this with the real provider; until then,
-        # never crash on a half-deployed env.
+    def test_hybrid_env_returns_hybrid_provider_after_614(self, monkeypatch):
+        # #614 wired the real hybrid provider — REALTIME_VOICE_PROVIDER=hybrid
+        # now returns it. The provider itself degrades when API keys are
+        # missing, so half-deployed envs still don't crash.
         monkeypatch.setenv("REALTIME_VOICE_PROVIDER", "hybrid")
         chosen = _select_provider()
-        assert chosen.name == "mock"
+        assert chosen.name == "hybrid"
 
     def test_missing_openai_key_returns_mock(self, monkeypatch):
         monkeypatch.delenv("REALTIME_VOICE_PROVIDER", raising=False)

--- a/backend/tests/contracts/test_voice_ephemeral_token_contract.py
+++ b/backend/tests/contracts/test_voice_ephemeral_token_contract.py
@@ -1,0 +1,179 @@
+"""
+Contract tests for the realtime-voice ephemeral JWT helper (#614).
+
+The token's job is small and the failure modes are well-known. Each
+test pins one invariant: signature, expiry, purpose, single-use, sweep.
+"""
+
+import time
+
+import jwt
+import pytest
+
+from backend.src.services import voice_ephemeral_token as vet
+
+
+@pytest.fixture(autouse=True)
+def _reset_nonce_store():
+    """Each test starts with an empty nonce set."""
+    vet._reset_nonce_store_for_tests()
+    yield
+    vet._reset_nonce_store_for_tests()
+
+
+# ---------------------- Mint contract ---------------------------------------
+
+class TestMint:
+    def test_round_trip_decodes_claims(self):
+        token = vet.mint_voice_token(
+            session_id="voice_sess_abc",
+            user_id="user_xyz",
+            child_id="child_qqq",
+        )
+        claims = vet.verify_voice_token(token)
+        assert claims is not None
+        assert claims.session_id == "voice_sess_abc"
+        assert claims.user_id == "user_xyz"
+        assert claims.child_id == "child_qqq"
+        assert claims.purpose == vet.TOKEN_PURPOSE
+        assert claims.exp - claims.iat == vet.TOKEN_TTL_SECONDS
+
+    def test_token_is_a_string(self):
+        token = vet.mint_voice_token(
+            session_id="s", user_id="u", child_id="c",
+        )
+        assert isinstance(token, str)
+        assert token.count(".") == 2  # JWT three-segment shape
+
+    def test_each_mint_has_unique_jti(self):
+        a = vet.mint_voice_token(session_id="s", user_id="u", child_id="c")
+        b = vet.mint_voice_token(session_id="s", user_id="u", child_id="c")
+        assert a != b
+        claims_a = vet.verify_voice_token(a)
+        # Mint b after verifying a so a's jti is in the consumed set.
+        # b must still verify (different jti).
+        claims_b = vet.verify_voice_token(b)
+        assert claims_a is not None and claims_b is not None
+        assert claims_a.jti != claims_b.jti
+
+
+# ---------------------- Verify failures ------------------------------------
+
+class TestVerifyFailures:
+    def test_replay_returns_none(self):
+        token = vet.mint_voice_token(session_id="s", user_id="u", child_id="c")
+        first = vet.verify_voice_token(token)
+        second = vet.verify_voice_token(token)
+        assert first is not None
+        assert second is None
+
+    def test_expired_token_returns_none(self):
+        # Mint with a zero TTL so it's expired by the time we verify.
+        token = vet.mint_voice_token(
+            session_id="s", user_id="u", child_id="c", ttl_seconds=0,
+        )
+        # PyJWT counts exp <= now as expired; sleep a hair to be safe
+        # across clock granularity.
+        time.sleep(0.01)
+        assert vet.verify_voice_token(token) is None
+
+    def test_tampered_signature_returns_none(self):
+        token = vet.mint_voice_token(session_id="s", user_id="u", child_id="c")
+        # Flip the last character of the signature segment.
+        head, payload, sig = token.split(".")
+        tampered = f"{head}.{payload}.{sig[:-1]}{'A' if sig[-1] != 'A' else 'B'}"
+        assert vet.verify_voice_token(tampered) is None
+
+    def test_wrong_purpose_returns_none(self):
+        # Manually mint with a different purpose — the verifier must reject
+        # it even though signature + expiry are valid.
+        now = int(time.time())
+        bad = jwt.encode(
+            {
+                "sub": "u",
+                "session_id": "s",
+                "child_id": "c",
+                "purpose": "parent_approval",  # wrong scope
+                "jti": "manual-jti-1",
+                "iat": now,
+                "exp": now + 60,
+            },
+            vet._signing_secret(),
+            algorithm=vet.TOKEN_ALGORITHM,
+        )
+        if isinstance(bad, bytes):
+            bad = bad.decode("utf-8")
+        assert vet.verify_voice_token(bad) is None
+
+    def test_missing_session_id_returns_none(self):
+        # Required-field enforcement is on the verifier, not just on mint.
+        now = int(time.time())
+        bad = jwt.encode(
+            {
+                "sub": "u",
+                # session_id missing
+                "child_id": "c",
+                "purpose": vet.TOKEN_PURPOSE,
+                "jti": "manual-jti-2",
+                "iat": now,
+                "exp": now + 60,
+            },
+            vet._signing_secret(),
+            algorithm=vet.TOKEN_ALGORITHM,
+        )
+        if isinstance(bad, bytes):
+            bad = bad.decode("utf-8")
+        assert vet.verify_voice_token(bad) is None
+
+    def test_garbage_returns_none(self):
+        assert vet.verify_voice_token("not-a-token") is None
+        assert vet.verify_voice_token("") is None
+
+
+# ---------------------- Nonce hygiene --------------------------------------
+
+class TestNonceSweep:
+    def test_sweep_removes_expired_entries(self):
+        # Consume a short-lived token's nonce.
+        token = vet.mint_voice_token(
+            session_id="s", user_id="u", child_id="c", ttl_seconds=1,
+        )
+        claims = vet.verify_voice_token(token)
+        assert claims is not None
+        assert claims.jti in vet._USED_JTIS
+
+        # Wait past expiry, then trigger any verify call to run the sweep.
+        time.sleep(1.1)
+        # The sweep runs at the top of verify; we don't care that this
+        # specific call returns None — we care that the side-effect ran.
+        vet.verify_voice_token("does-not-matter")
+        assert claims.jti not in vet._USED_JTIS
+
+    def test_nonce_store_is_bounded_by_ttl(self):
+        # 50 short-TTL tokens consumed, then a sweep — set should be empty.
+        consumed_jtis = []
+        for _ in range(50):
+            token = vet.mint_voice_token(
+                session_id="s", user_id="u", child_id="c", ttl_seconds=1,
+            )
+            claims = vet.verify_voice_token(token)
+            assert claims is not None
+            consumed_jtis.append(claims.jti)
+
+        assert all(j in vet._USED_JTIS for j in consumed_jtis)
+        time.sleep(1.1)
+        vet._sweep_expired_jtis(time.time())
+        assert vet._USED_JTIS == {}
+
+
+# ---------------------- Constants locked -----------------------------------
+
+class TestConstants:
+    def test_ttl_matches_prd(self):
+        assert vet.TOKEN_TTL_SECONDS == 60
+
+    def test_purpose_is_voice_realtime(self):
+        assert vet.TOKEN_PURPOSE == "voice_realtime"
+
+    def test_algorithm_is_hs256(self):
+        assert vet.TOKEN_ALGORITHM == "HS256"


### PR DESCRIPTION
## Summary

Real network provider for Talk to Buddy realtime voice (PRD §3.16) plus the one-time JWT that lets the WS broker (#615) authenticate sessions without exposing the OpenAI key to the browser.

| File | Purpose |
|------|---------|
| [services/voice_ephemeral_token.py](backend/src/services/voice_ephemeral_token.py) | HS256 single-use JWT mint + verify with nonce protection |
| [services/realtime_voice_service.py](backend/src/services/realtime_voice_service.py) | Extended with `HybridRealtimeVoiceProvider` and wired into `_select_provider("hybrid")` |
| [tests/contracts/test_voice_ephemeral_token_contract.py](backend/tests/contracts/test_voice_ephemeral_token_contract.py) | 14 tests — every failure mode |
| [tests/contracts/test_hybrid_realtime_voice_contract.py](backend/tests/contracts/test_hybrid_realtime_voice_contract.py) | 20 tests — every invariant including no-disk-persistence |

## Ephemeral JWT contract

- **HS256**, 60s TTL, single-use
- Signing key resolves `VOICE_REALTIME_TOKEN_SECRET → SECRET_KEY → dev fallback` (logs WARNING once when fallback fires)
- Purpose-scoped (`"voice_realtime"`) so the same secret can't accidentally validate a parent-approval or Supabase token
- Nonce storage: in-memory `_USED_JTIS` dict; lazy sweep at the top of every `verify_voice_token` call keeps the set bounded by `TOKEN_TTL × mint rate`
- `TODO(scale)`: replace with Redis when multi-worker uvicorn is in scope

## Hybrid provider contract

Mirrors `OpenAISTTProvider` from `stt_service.py`:
- Audio bytes live in `handle.provider_state["buffer"]` (`bytearray`) — never reach disk
- `finalize_utterance` calls Whisper via `io.BytesIO` with a `.name` extension hint (`audio.webm`/`audio.mp4`/`audio.mp3`/`audio.wav`)
- Safety check runs immediately after Whisper via the existing `stt_service._safety_check_text`. Fail-closed on MCP exception.
- Per-utterance `MAX_UTTERANCE_BYTES=2MB` cap raises `forced_flush=True` for the broker (never raises)

### Graceful degradation
| Missing env | Result |
|------------|--------|
| `OPENAI_API_KEY` | `finalize_utterance` returns `success=False, error="provider_unavailable"` |
| `ELEVENLABS_API_KEY` | `synthesize_speech` yields empty stream; broker emits `assistant_text(is_final=True)` and skips audio |
| Both | Session starts but produces no transcript and no audio |
| OpenAI/ElevenLabs SDK import failure | Same paths as missing keys |

## Test plan

- [x] `pytest backend/tests/contracts/test_voice_ephemeral_token_contract.py` → 14/14
- [x] `pytest backend/tests/contracts/test_hybrid_realtime_voice_contract.py` → 20/20
- [x] Full voice contract sweep (5 files) → 75/75 pass
- [x] No regressions in stt/child-profile/audio-transcription contracts
- [ ] Manual: REST `POST /voice/session` still returns 501 (broker is #615) — but `REALTIME_VOICE_PROVIDER=hybrid` now wires the real provider in
- [ ] Manual: with both API keys set, the hybrid provider should round-trip a real utterance through Whisper + ElevenLabs (requires #615 broker to actually exercise)

### The load-bearing test
`test_full_round_trip_never_writes_to_disk` monkey-patches `Path.write_bytes`, `tempfile.NamedTemporaryFile`, and `builtins.open(w*)`, then pushes 256 KB of audio through start → push×4 → finalize → synthesize → close. All three spy lists must stay empty.

## What this unblocks

#615 (WS broker + real /session) now has everything it needs:
- `voice_ephemeral_token.mint` + `verify` for handshake auth
- `realtime_voice_service._select_provider()` returns either Mock or Hybrid based on env
- `voice_session_repo.create_session` + `end_session` + `sum_seconds_in_window` from #612

The broker is the next sub-story.

Fixes #614
Parent Story: #606
Parent Epic: #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)