### PR TITLE
feat(my-agent): ParentConsentGate voice_conversation variant + appendVoiceCaption (#619)

### DIFF
--- a/frontend/src/__tests__/components/ParentConsentGate.test.ts
+++ b/frontend/src/__tests__/components/ParentConsentGate.test.ts
@@ -128,3 +128,47 @@ describe('ParentConsentGate: GATE_ERROR_COPY', () => {
     expect(GATE_ERROR_COPY.parent_required.toLowerCase()).toContain('parent')
   })
 })
+
+describe('ParentConsentGate: voice_conversation variant (#619)', () => {
+  it('covers all three age groups for voice_conversation', () => {
+    for (const age of AGE_GROUPS) {
+      const copy = GATE_COPY.voice_conversation[age]
+      expect(copy).toBeDefined()
+      expect(copy.emoji.length).toBeGreaterThan(0)
+      expect(copy.title.length).toBeGreaterThan(0)
+      expect(copy.body.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('uses a distinct conversation emoji', () => {
+    // Distinct from 📸/🎤 so kids and parents can tell the kinds apart at
+    // a glance in screenshots and the consent history audit.
+    for (const age of AGE_GROUPS) {
+      const emoji = GATE_COPY.voice_conversation[age].emoji
+      expect(emoji).not.toBe('📸')
+      expect(emoji).not.toBe('🎤')
+    }
+  })
+
+  it('age 3-5 voice_conversation copy stays short', () => {
+    expect(GATE_COPY.voice_conversation['3-5'].body.length).toBeLessThanOrEqual(140)
+  })
+
+  it('voice_conversation copy promises audio is not stored', () => {
+    // PRD §3.16 hard rule — must be visible to the parent at consent time
+    // for at least the older bands. 3-5 defers to a grown-up so we accept
+    // either pattern.
+    for (const age of AGE_GROUPS) {
+      const body = GATE_COPY.voice_conversation[age].body.toLowerCase()
+      const promisesNoStorage =
+        body.includes("don't save") ||
+        body.includes('not stored') ||
+        body.includes('never stored') ||
+        body.includes("only the words") ||
+        body.includes('only the moderated') ||
+        body.includes('only keep the words') ||
+        body.includes('grown-up')
+      expect(promisesNoStorage).toBe(true)
+    }
+  })
+})

--- a/frontend/src/__tests__/store/useAgentChatStore.test.ts
+++ b/frontend/src/__tests__/store/useAgentChatStore.test.ts
@@ -1,0 +1,83 @@
+/* @vitest-environment node */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/services/agentService", () => ({
+  agentService: {
+    listAgentSessions: vi.fn(),
+    getAgentSession: vi.fn(),
+    createAgentSession: vi.fn(),
+    renameAgentSession: vi.fn(),
+    archiveAgentSession: vi.fn(),
+    deleteAgentSession: vi.fn(),
+  },
+}));
+
+type AgentChatStore = typeof import("../../store/useAgentChatStore").default;
+
+let useAgentChatStore: AgentChatStore;
+
+beforeAll(async () => {
+  useAgentChatStore = (
+    await import("../../store/useAgentChatStore")
+  ).default;
+});
+
+beforeEach(() => {
+  useAgentChatStore.getState().reset();
+});
+
+describe("useAgentChatStore.appendVoiceCaption (#619)", () => {
+  it("pushes user-role voice transcripts onto the message list", () => {
+    useAgentChatStore.getState().appendVoiceCaption({
+      role: "user",
+      text: "tell me a story",
+    });
+
+    const messages = useAgentChatStore.getState().messages;
+    expect(messages.length).toBe(1);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].text).toBe("tell me a story");
+    expect(messages[0].source).toBe("voice");
+  });
+
+  it("pushes assistant-role voice transcripts with the voice tag", () => {
+    useAgentChatStore.getState().appendVoiceCaption({
+      role: "assistant",
+      text: "once upon a time",
+    });
+
+    const messages = useAgentChatStore.getState().messages;
+    expect(messages[0].role).toBe("assistant");
+    expect(messages[0].source).toBe("voice");
+  });
+
+  it("preserves ordering when voice + text turns interleave", () => {
+    const store = useAgentChatStore.getState();
+    store.appendUserMessage("first typed turn");
+    store.appendVoiceCaption({ role: "user", text: "second voice turn" });
+    store.appendVoiceCaption({ role: "assistant", text: "buddy reply" });
+    store.appendUserMessage("fourth typed turn");
+
+    const messages = useAgentChatStore.getState().messages;
+    expect(messages.map((m) => m.text)).toEqual([
+      "first typed turn",
+      "second voice turn",
+      "buddy reply",
+      "fourth typed turn",
+    ]);
+    // Source tags differentiate voice from text in the same list.
+    expect(messages[0].source).toBeUndefined();
+    expect(messages[1].source).toBe("voice");
+    expect(messages[2].source).toBe("voice");
+    expect(messages[3].source).toBeUndefined();
+  });
+
+  it("assigns a unique id to each voice caption", () => {
+    const store = useAgentChatStore.getState();
+    store.appendVoiceCaption({ role: "user", text: "a" });
+    store.appendVoiceCaption({ role: "user", text: "b" });
+    const ids = useAgentChatStore.getState().messages.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/frontend/src/components/common/ParentConsentGate/index.tsx
+++ b/frontend/src/components/common/ParentConsentGate/index.tsx
@@ -25,7 +25,7 @@ import useAuthStore from '@/store/useAuthStore'
 import useChildStore from '@/store/useChildStore'
 import type { AgeGroup } from '@/types/api'
 
-export type ConsentKind = 'camera' | 'microphone'
+export type ConsentKind = 'camera' | 'microphone' | 'voice_conversation'
 
 export interface ParentConsentGateProps {
   kind: ConsentKind
@@ -117,6 +117,23 @@ export const GATE_COPY: Record<ConsentKind, Record<AgeGroup, GateCopy>> = {
       body: 'A parent must approve microphone access. Audio is transcribed and never stored — only the moderated text reaches your input.',
     },
   },
+  voice_conversation: {
+    '3-5': {
+      emoji: '💬',
+      title: 'Talk with your buddy?',
+      body: "Ask a grown-up to say yes. Your buddy can listen AND talk back — like a real friend.",
+    },
+    '6-8': {
+      emoji: '💬',
+      title: 'Talk back-and-forth with your buddy?',
+      body: "We need a grown-up's OK before your buddy speaks out loud. We only keep the words (not the audio) and check every reply for kid-safe content.",
+    },
+    '9-12': {
+      emoji: '💬',
+      title: 'Enable voice conversation',
+      body: 'A parent must approve two-way voice chat. Audio is never stored — only the moderated transcript persists in your chat history, same as text mode. The session has a daily time cap.',
+    },
+  },
 }
 
 export function ParentConsentGate({
@@ -134,7 +151,13 @@ export function ParentConsentGate({
   const [error, setError] = useState<string | null>(null)
 
   const copy = GATE_COPY[kind][ageGroup]
-  const consentField = kind === 'camera' ? 'camera_consent' : 'microphone_consent'
+  // Map each kind to the child_profiles boolean it flips.
+  const consentField =
+    kind === 'camera'
+      ? 'camera_consent'
+      : kind === 'microphone'
+        ? 'microphone_consent'
+        : 'voice_conversation_consent'
 
   async function handleAllow(event: React.FormEvent) {
     event.preventDefault()

--- a/frontend/src/pages/MyAgentPage/chatMessageState.ts
+++ b/frontend/src/pages/MyAgentPage/chatMessageState.ts
@@ -13,6 +13,13 @@ export interface ChatMessage {
   role: "user" | "assistant";
   text: string;
   streaming?: boolean;
+  /** When set, marks the message as originating from a non-text modality.
+   *  Currently the only value is "voice" for transcripts of the realtime
+   *  voice channel (#619, PRD §3.16). The chat panel renders a small mic
+   *  icon next to messages with this tag so parents can see at a glance
+   *  which turns happened via voice vs typing.
+   */
+  source?: "voice";
 }
 
 /**

--- a/frontend/src/store/useAgentChatStore.ts
+++ b/frontend/src/store/useAgentChatStore.ts
@@ -38,6 +38,9 @@ interface AgentChatState {
   appendStreamingDelta: (delta: string) => void;
   settleAssistantMessage: (text: string) => void;
   appendUserMessage: (text: string) => void;
+  // Realtime voice transcripts merge into the same chat history with
+  // a `source: "voice"` tag so the UI can render a mic icon (#619).
+  appendVoiceCaption: (turn: { role: "user" | "assistant"; text: string }) => void;
   // Reconcile the server-issued session id from the first SSE `session`
   // event when the turn started without a selected session.
   adoptServerSession: (sessionId: string) => void;
@@ -184,6 +187,22 @@ const useAgentChatStore = create<AgentChatState>((set, get) => ({
   appendUserMessage: (text) => {
     set((state) => ({
       messages: [...state.messages, { id: nextId("user"), role: "user", text }],
+    }));
+  },
+
+  appendVoiceCaption: (turn) => {
+    // Merge a voice-channel transcript into the same message list the
+    // text panel renders so parents see one unified chat history (#619).
+    set((state) => ({
+      messages: [
+        ...state.messages,
+        {
+          id: nextId(`voice_${turn.role}`),
+          role: turn.role,
+          text: turn.text,
+          source: "voice",
+        },
+      ],
     }));
   },
 


### PR DESCRIPTION
## Summary

Two additive changes for Talk to Buddy frontend (PRD §3.16, epic #605):
1. Third ConsentKind (voice_conversation) on ParentConsentGate with age-adapted copy
2. New useAgentChatStore.appendVoiceCaption({role, text}) action

## What this unblocks

- #618 (TalkToBuddyPanel) can mount the gate when voice_conversation_consent is false
- #617 (useVoiceConversation hook) can call appendVoiceCaption on STT finals + assistant replies

## Test plan
- [x] vitest run → 21/21 across ParentConsentGate.test.ts + new useAgentChatStore.test.ts
- [x] tsc -b clean
- [ ] Manual: gate with kind="voice_conversation" → 💬 emoji + age-adapted copy
- [ ] Manual: appendVoiceCaption → message in AgentChatPanel history

Fixes #619
Parent Story: #607
Parent Epic: #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)