### PR TITLE
fix(scripts): repair ChromaDB->pgvector replay in sqlite migration

### DIFF
--- a/backend/scripts/migrate_sqlite_to_postgres.py
+++ b/backend/scripts/migrate_sqlite_to_postgres.py
@@ -177,10 +177,10 @@ async def _replay_chromadb(chroma_path: Path, pg_db, dry_run: bool) -> Dict[str,
     from backend.src.services.database.vector_repository import VectorRepository
 
     client = chromadb.PersistentClient(path=str(chroma_path))
-    # VectorRepository uses the singleton db_manager — the caller must
-    # have arranged for db_manager to be the Postgres one before invoking
-    # this script (which we do via DATABASE_URL env var).
-    vector_repo = VectorRepository()
+    # Bind the repo to the SAME connected pg_db the migration opened.
+    # (The global db_manager singleton is never connected in this script,
+    # so VectorRepository() with no args would fail "not connected".)
+    vector_repo = VectorRepository(db=pg_db)
 
     counts: Dict[str, int] = {}
 
@@ -225,11 +225,14 @@ async def _replay_chromadb(chroma_path: Path, pg_db, dry_run: bool) -> Dict[str,
                 if not child_id or not text:
                     continue
                 await vector_repo.add_story_embedding(
-                    story_id=story_id,
+                    doc_id=story_id,
                     child_id=child_id,
-                    story_text=text,
-                    themes=themes if isinstance(themes, str) else json.dumps(themes),
-                    age_group=age_group,
+                    document_text=text,
+                    metadata={
+                        "story_id": story_id,
+                        "themes": themes if isinstance(themes, str) else json.dumps(themes),
+                        "age_group": age_group,
+                    },
                 )
         counts["story_embeddings"] = len(ids)
     except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
## What & why
The one-shot dev migration `backend/scripts/migrate_sqlite_to_postgres.py` copied SQL tables fine but **Phase D (ChromaDB → pgvector vector replay) was completely broken** by two bugs:

1. **Stale kwargs** — `add_story_embedding(story_id=, story_text=, themes=, age_group=)` no longer matches the repository signature `(doc_id, child_id, document_text, metadata)` → `TypeError` on every story doc.
2. **Wrong DB binding** — `VectorRepository()` with no args binds to the global `db_manager` singleton, which this script never connects (it opens its own `pg_db`) → `Database not connected` on every drawing doc.

## Fix
- Bind `VectorRepository(db=pg_db)` to the connected migration connection.
- Pass current kwargs and fold `story_id`/`themes`/`age_group` into `metadata`.

## Verification
Ran end-to-end against **Supabase local** (`postgresql://...:54322`):
- All SQL table counts match the SQLite source exactly (2,971 stories, 15,627 artifacts, …).
- ChromaDB drawings re-embed cleanly into `drawing_embeddings`.
- 6/6 pgvector + hybrid-search integration tests pass.

## Scope / notes
- Dev tooling only — this script never runs in production, so **no deploy impact**.
- No schema, runtime, or env changes. `.env`/local data are not part of this PR.

Related to #313 (Supabase + pgvector production stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)