### PR TITLE
feat(my-agent): wire Talk-to-Buddy into AgentChatPanel + fix corrupt panel + types (#620)

### DIFF
--- a/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
+++ b/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   isEndButtonEnabled,
   isPanelVisible,
+  nextPendingGate,
   pickIndicator,
   shouldShowEntryButton,
   TALK_PANEL_STATE_COPY,
@@ -138,5 +139,38 @@ describe("pickIndicator (#618)", () => {
     for (const state of staticStates) {
       expect(pickIndicator(state, false)).toBe("static");
     }
+  });
+});
+
+describe("nextPendingGate (#620)", () => {
+  it("returns 'mic' when both consents are missing", () => {
+    expect(
+      nextPendingGate({ micConsent: false, voiceConsent: false }),
+    ).toBe("mic");
+  });
+
+  it("returns 'voice' when mic is granted but voice is missing", () => {
+    expect(
+      nextPendingGate({ micConsent: true, voiceConsent: false }),
+    ).toBe("voice");
+  });
+
+  it("returns null when both consents are granted", () => {
+    expect(
+      nextPendingGate({ micConsent: true, voiceConsent: true }),
+    ).toBe(null);
+  });
+
+  it("defensively returns 'mic' for a null child (defer to grown-up)", () => {
+    expect(nextPendingGate(null)).toBe("mic");
+    expect(nextPendingGate(undefined)).toBe("mic");
+  });
+
+  it("treats undefined consent fields as not-granted (mic missing case)", () => {
+    expect(nextPendingGate({})).toBe("mic");
+  });
+
+  it("treats undefined voice consent as not-granted when mic is true", () => {
+    expect(nextPendingGate({ micConsent: true })).toBe("voice");
   });
 });

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -38,6 +38,16 @@ import useAgentChatStore from "@/store/useAgentChatStore";
 import useChildStore from "@/store/useChildStore";
 import VoiceInputButton from "@/components/common/VoiceInputButton";
 import ParentConsentGate from "@/components/common/ParentConsentGate";
+import TalkToBuddyPanel from "./TalkToBuddyPanel";
+import {
+  nextPendingGate,
+  shouldShowEntryButton,
+  type PendingGate,
+} from "./talkToBuddyHelpers";
+import {
+  detectVoiceCapabilities,
+} from "@/hooks/voiceConversationHelpers";
+import { useVoiceConversation } from "@/hooks/useVoiceConversation";
 import type { Agent } from "@/types/agent";
 import type { AgeGroup, MemoryCharacter } from "@/types/api";
 import type {
@@ -75,6 +85,15 @@ const STARTER_PROMPTS: string[] = [
   "What's in the news today for kids?",
   "Let's make an interactive choose-your-own adventure",
 ];
+
+/**
+ * Talk-to-Buddy realtime voice mode (PRD §3.16) is feature-flagged
+ * during staging. Production canary will flip the env var once the
+ * provider + safety pipeline are observed under real traffic.
+ */
+const TALK_TO_BUDDY_ENABLED =
+  (import.meta as { env?: { VITE_TALK_TO_BUDDY_ENABLED?: string } }).env
+    ?.VITE_TALK_TO_BUDDY_ENABLED === "true";
 
 function avatarGlyph(agent: Agent): string {
   return agent.agent_avatar_id.startsWith("emoji:")
@@ -213,6 +232,74 @@ export default function AgentChatPanel({
   const currentChild = useChildStore((s) => s.currentChild);
   const [showMicConsentGate, setShowMicConsentGate] = useState(false);
 
+  // -------------------- Talk-to-Buddy realtime voice (#620) ---------------
+  // Detect browser capability once on mount — cheap, pure, no DOM mutation.
+  const voiceCaps = useMemo(
+    () =>
+      detectVoiceCapabilities({
+        getUserMedia: typeof navigator !== "undefined"
+          ? navigator.mediaDevices?.getUserMedia?.bind(navigator.mediaDevices)
+          : undefined,
+        MediaRecorder:
+          typeof MediaRecorder !== "undefined" ? MediaRecorder : undefined,
+        WebSocket:
+          typeof WebSocket !== "undefined" ? WebSocket : undefined,
+        AudioContext:
+          typeof window !== "undefined"
+            ? (window as { AudioContext?: typeof AudioContext })
+                .AudioContext ?? undefined
+            : undefined,
+        userAgent:
+          typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+      }),
+    [],
+  );
+  const [isTalkOpen, setIsTalkOpen] = useState(false);
+  const [pendingTalkGate, setPendingTalkGate] = useState<PendingGate>(null);
+
+  const talkEntryReady = shouldShowEntryButton({
+    supportsVoice: voiceCaps.supported,
+    micConsentGranted: currentChild?.microphone_consent === true,
+    voiceConversationConsentGranted:
+      currentChild?.voice_conversation_consent === true,
+    hasCurrentChild: Boolean(currentChild?.child_id),
+  });
+
+  // Show the Talk affordance even when consents are missing (renders
+  // as "Ask a grown-up" CTA) so the feature is discoverable. Hidden
+  // entirely when the browser lacks capabilities or the flag is off.
+  const showTalkEntry =
+    TALK_TO_BUDDY_ENABLED && voiceCaps.supported && Boolean(currentChild?.child_id);
+
+  const handleOpenTalk = () => {
+    if (talkEntryReady) {
+      setIsTalkOpen(true);
+      return;
+    }
+    // Compute the next pending gate from the child's consent state.
+    const next = nextPendingGate({
+      micConsent: currentChild?.microphone_consent === true,
+      voiceConsent: currentChild?.voice_conversation_consent === true,
+    });
+    setPendingTalkGate(next);
+  };
+
+  const advancePendingGate = () => {
+    // Re-evaluate against the latest currentChild (the consent gate
+    // mutated it via updateConsent). If everything's granted, open the
+    // panel directly; otherwise show the next missing gate.
+    const next = nextPendingGate({
+      micConsent: currentChild?.microphone_consent === true,
+      voiceConsent: currentChild?.voice_conversation_consent === true,
+    });
+    if (next === null) {
+      setPendingTalkGate(null);
+      setIsTalkOpen(true);
+    } else {
+      setPendingTalkGate(next);
+    }
+  };
+
   const clearImage = () => {
     setImage(null);
     if (imageInputRef.current) imageInputRef.current.value = "";
@@ -342,6 +429,31 @@ export default function AgentChatPanel({
               className="shrink-0 animate-spin text-violet-600"
               aria-label="Streaming"
             />
+          )}
+          {showTalkEntry && (
+            <button
+              type="button"
+              onClick={handleOpenTalk}
+              disabled={isStreaming}
+              className={
+                talkEntryReady
+                  ? "inline-flex items-center gap-1 rounded-full bg-violet-600 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-violet-700 disabled:opacity-50"
+                  : "inline-flex items-center gap-1 rounded-full border border-violet-300 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-100 disabled:opacity-50"
+              }
+              title={
+                talkEntryReady
+                  ? `Talk to ${agent.agent_name}`
+                  : "Ask a grown-up to turn on voice chat"
+              }
+              aria-label={
+                talkEntryReady
+                  ? `Talk to ${agent.agent_name}`
+                  : "Ask a grown-up to turn on voice chat"
+              }
+            >
+              <span aria-hidden="true">💬</span>
+              <span>{talkEntryReady ? "Talk" : "Ask"}</span>
+            </button>
           )}
           {onConfigure && (
             <button
@@ -583,6 +695,89 @@ export default function AgentChatPanel({
           onDismiss={() => setShowMicConsentGate(false)}
         />
       )}
+      {pendingTalkGate === "mic" && ageGroup && (
+        <ParentConsentGate
+          kind="microphone"
+          ageGroup={ageGroup}
+          childId={childId}
+          onGranted={advancePendingGate}
+          onDismiss={() => setPendingTalkGate(null)}
+        />
+      )}
+      {pendingTalkGate === "voice" && ageGroup && (
+        <ParentConsentGate
+          kind="voice_conversation"
+          ageGroup={ageGroup}
+          childId={childId}
+          onGranted={advancePendingGate}
+          onDismiss={() => setPendingTalkGate(null)}
+        />
+      )}
+      {isTalkOpen && (
+        <TalkToBuddyContainer
+          childId={childId}
+          persona={agent.agent_name}
+          ageGroup={ageGroup}
+          onClose={() => setIsTalkOpen(false)}
+        />
+      )}
     </section>
+  );
+}
+
+/**
+ * Adapter that instantiates `useVoiceConversation` only while the panel
+ * is mounted. Keeps the WebSocket / MediaStream / AudioContext out of
+ * the always-rendered parent so idle cost stays zero.
+ *
+ * Voice transcripts flow into `useAgentChatStore.appendVoiceCaption`
+ * so they merge into the same chat history the text panel renders.
+ */
+function TalkToBuddyContainer({
+  childId,
+  persona,
+  ageGroup,
+  onClose,
+}: {
+  childId: string;
+  persona: string;
+  ageGroup?: AgeGroup | null;
+  onClose: () => void;
+}) {
+  void ageGroup; // Future: thread per-age TTS preset overrides (Phase C, #608).
+  const appendVoiceCaption = useAgentChatStore((s) => s.appendVoiceCaption);
+
+  const voice = useVoiceConversation({
+    childId,
+    persona,
+    onCaption: (caption) => {
+      // Only persist finalized turns so the chat history doesn't get
+      // spammed with partial-transcript noise. Safety-blocked utterances
+      // also surface in the timeline so the kid can see what happened.
+      if (caption.kind === "final") {
+        appendVoiceCaption({ role: "user", text: caption.text });
+      } else if (caption.kind === "assistant" && caption.isFinal) {
+        appendVoiceCaption({ role: "assistant", text: caption.text });
+      }
+    },
+  });
+
+  const prefersReducedMotion =
+    typeof window !== "undefined" && typeof window.matchMedia === "function"
+      ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      : false;
+
+  return (
+    <TalkToBuddyPanel
+      state={voice.state}
+      partialTranscript={voice.partialTranscript}
+      assistantText={voice.assistantText}
+      inputLevel={voice.inputLevel}
+      prefersReducedMotion={prefersReducedMotion}
+      onStart={() => voice.start(true)}
+      onEnd={voice.end}
+      onRetry={voice.retry}
+      onClose={onClose}
+    />
   );
 }

--- a/frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx
@@ -1,142 +1,185 @@
-import { describe, expect, it } from "vitest";
+/**
+ * TalkToBuddyPanel (#618) — full-screen UI for the Talk-to-Buddy
+ * realtime voice surface (PRD §3.16).
+ *
+ * Mobile sheet on (pointer: coarse) and (max-width: 1024px); desktop
+ * side panel otherwise. Pure helpers (state copy map, indicator picker,
+ * entry-button truth table) live in `talkToBuddyHelpers.ts` so the
+ * test load stays off this presentational component.
+ *
+ * The panel does NOT own the WebSocket or MediaRecorder — those live
+ * in `useVoiceConversation` (#617). This component only renders the
+ * current state and forwards user-pressed events (Start, End, Retry).
+ * The hook is instantiated in a TalkToBuddyContainer up in
+ * AgentChatPanel (#620), which forwards state + handlers down here.
+ *
+ * NOTE: PR #629 accidentally shipped a duplicate of the test file as
+ * this component. PR #620 reconstructs the real component content.
+ */
+
+import { motion } from "framer-motion";
 import {
   isEndButtonEnabled,
   isPanelVisible,
   pickIndicator,
-  shouldShowEntryButton,
   TALK_PANEL_STATE_COPY,
-} from "@/pages/MyAgentPage/talkToBuddyHelpers";
+} from "./talkToBuddyHelpers";
 import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
 
-const ALL_STATES: VoiceConversationState[] = [
-  "idle",
-  "connecting",
-  "listening",
-  "thinking",
-  "speaking",
-  "interrupted",
-  "ending",
-  "error",
-  "unsupported",
-];
+export interface TalkToBuddyPanelProps {
+  state: VoiceConversationState;
+  /** Latest STT partial transcript ("what I'm hearing you say so far"). */
+  partialTranscript?: string;
+  /** Latest assistant text delta accumulator. */
+  assistantText?: string;
+  /** RMS-derived mic input level 0..1 for the waveform animation. */
+  inputLevel?: number;
+  prefersReducedMotion?: boolean;
+  onStart: () => void;
+  onEnd: () => void;
+  onRetry?: () => void;
+  /** Optional close button for the panel itself (separate from End). */
+  onClose?: () => void;
+}
 
-describe("TALK_PANEL_STATE_COPY (#618)", () => {
-  it("covers every state in the reducer", () => {
-    for (const state of ALL_STATES) {
-      expect(TALK_PANEL_STATE_COPY[state]).toBeDefined();
-      expect(TALK_PANEL_STATE_COPY[state].length).toBeGreaterThan(10);
-    }
-  });
+function Indicator({
+  variant,
+  level,
+}: {
+  variant: "static" | "pulse-listening" | "pulse-speaking";
+  level: number;
+}) {
+  if (variant === "static") {
+    return (
+      <div
+        className="h-2 w-2 rounded-full bg-primary"
+        aria-hidden="true"
+      />
+    );
+  }
+  const colorClass =
+    variant === "pulse-listening" ? "bg-emerald-500" : "bg-violet-500";
+  const scale = 1 + Math.min(0.4, (level ?? 0) * 0.4);
+  return (
+    <motion.div
+      className={`h-3 w-3 rounded-full ${colorClass}`}
+      animate={{ scale: [1, scale, 1] }}
+      transition={{ duration: 0.8, repeat: Infinity, ease: "easeInOut" }}
+      aria-hidden="true"
+    />
+  );
+}
 
-  it("unsupported copy points the user to typed chat", () => {
-    expect(TALK_PANEL_STATE_COPY.unsupported.toLowerCase()).toContain("typ");
-  });
+export function TalkToBuddyPanel({
+  state,
+  partialTranscript = "",
+  assistantText = "",
+  inputLevel = 0,
+  prefersReducedMotion = false,
+  onStart,
+  onEnd,
+  onRetry,
+  onClose,
+}: TalkToBuddyPanelProps) {
+  if (!isPanelVisible(state)) return null;
 
-  it("error copy offers a recovery path", () => {
-    const copy = TALK_PANEL_STATE_COPY.error.toLowerCase();
-    expect(copy).toMatch(/try again|typing|switch/);
-  });
-});
+  const status = TALK_PANEL_STATE_COPY[state];
+  const indicator = pickIndicator(state, prefersReducedMotion);
+  const endEnabled = isEndButtonEnabled(state);
+  const canStart = state === "idle" || state === "error";
 
-describe("shouldShowEntryButton (#618)", () => {
-  const baseline = {
-    supportsVoice: true,
-    micConsentGranted: true,
-    voiceConversationConsentGranted: true,
-    hasCurrentChild: true,
-  };
+  return (
+    <section
+      role="dialog"
+      aria-modal="true"
+      aria-label="Talk to your buddy"
+      className="fixed inset-0 z-40 flex flex-col bg-gradient-to-b from-violet-50 to-white lg:inset-auto lg:bottom-4 lg:right-4 lg:h-[640px] lg:w-[420px] lg:rounded-2xl lg:border lg:border-gray-200 lg:shadow-2xl"
+    >
+      <header className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Indicator variant={indicator} level={inputLevel} />
+          <h2 className="text-lg font-semibold text-gray-800">
+            Talk to Buddy
+          </h2>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onEnd}
+            disabled={!endEnabled}
+            className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            End
+          </button>
+          {onClose && (
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close Talk to Buddy"
+              className="rounded-lg p-1.5 text-gray-600 hover:bg-gray-100"
+            >
+              ×
+            </button>
+          )}
+        </div>
+      </header>
 
-  it("shows the button only when every precondition is met", () => {
-    expect(shouldShowEntryButton(baseline)).toBe(true);
-  });
+      <div
+        className="flex-1 overflow-y-auto px-4 py-4"
+        aria-live="polite"
+        aria-atomic="false"
+      >
+        <p className="mb-3 text-center text-sm font-medium text-gray-600">
+          {status}
+        </p>
 
-  it("hides when voice support is missing", () => {
-    expect(
-      shouldShowEntryButton({ ...baseline, supportsVoice: false }),
-    ).toBe(false);
-  });
+        {partialTranscript && (
+          <div className="mb-3 rounded-lg bg-emerald-50 p-3 text-sm text-emerald-900">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-emerald-700">
+              You
+            </p>
+            <p>{partialTranscript}</p>
+          </div>
+        )}
 
-  it("hides when microphone consent is missing", () => {
-    expect(
-      shouldShowEntryButton({ ...baseline, micConsentGranted: false }),
-    ).toBe(false);
-  });
+        {assistantText && (
+          <div className="mb-3 rounded-lg bg-violet-50 p-3 text-sm text-violet-900">
+            <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-violet-700">
+              Buddy
+            </p>
+            <p>{assistantText}</p>
+          </div>
+        )}
+      </div>
 
-  it("hides when voice_conversation_consent is missing", () => {
-    expect(
-      shouldShowEntryButton({
-        ...baseline,
-        voiceConversationConsentGranted: false,
-      }),
-    ).toBe(false);
-  });
+      <footer className="border-t border-gray-200 px-4 py-3">
+        {canStart && (
+          <motion.button
+            type="button"
+            onClick={onStart}
+            whileTap={{ scale: 0.97 }}
+            className="w-full rounded-xl bg-primary px-6 py-4 text-base font-bold text-white shadow-md hover:bg-primary/90"
+          >
+            {state === "error" ? "Try Again" : "Start Talking"}
+          </motion.button>
+        )}
+        {state === "error" && onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-2 w-full text-sm font-medium text-violet-600 underline"
+          >
+            Reset and start over
+          </button>
+        )}
+        {!canStart && (
+          <p className="text-center text-xs text-gray-500">
+            Tap End to stop the conversation when you're done.
+          </p>
+        )}
+      </footer>
+    </section>
+  );
+}
 
-  it("hides when no child profile is selected", () => {
-    expect(
-      shouldShowEntryButton({ ...baseline, hasCurrentChild: false }),
-    ).toBe(false);
-  });
-});
-
-describe("isPanelVisible (#618)", () => {
-  it("hides only on the terminal unsupported state", () => {
-    for (const state of ALL_STATES) {
-      const visible = isPanelVisible(state);
-      expect(visible).toBe(state !== "unsupported");
-    }
-  });
-});
-
-describe("isEndButtonEnabled (#618)", () => {
-  it("enables the End button during any active session state", () => {
-    const active: VoiceConversationState[] = [
-      "connecting",
-      "listening",
-      "thinking",
-      "speaking",
-      "interrupted",
-      "ending",
-    ];
-    for (const state of active) {
-      expect(isEndButtonEnabled(state)).toBe(true);
-    }
-  });
-
-  it("disables the End button when there is no active session", () => {
-    const inactive: VoiceConversationState[] = ["idle", "error", "unsupported"];
-    for (const state of inactive) {
-      expect(isEndButtonEnabled(state)).toBe(false);
-    }
-  });
-});
-
-describe("pickIndicator (#618)", () => {
-  it("reduced-motion users always get the static pill", () => {
-    for (const state of ALL_STATES) {
-      expect(pickIndicator(state, true)).toBe("static");
-    }
-  });
-
-  it("listening + interrupted → pulse-listening (kid speaking)", () => {
-    expect(pickIndicator("listening", false)).toBe("pulse-listening");
-    expect(pickIndicator("interrupted", false)).toBe("pulse-listening");
-  });
-
-  it("thinking + speaking → pulse-speaking (buddy active)", () => {
-    expect(pickIndicator("thinking", false)).toBe("pulse-speaking");
-    expect(pickIndicator("speaking", false)).toBe("pulse-speaking");
-  });
-
-  it("everything else gets a static indicator even without reduced motion", () => {
-    const staticStates: VoiceConversationState[] = [
-      "idle",
-      "connecting",
-      "ending",
-      "error",
-      "unsupported",
-    ];
-    for (const state of staticStates) {
-      expect(pickIndicator(state, false)).toBe("static");
-    }
-  });
-});
+export default TalkToBuddyPanel;

--- a/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
@@ -102,3 +102,30 @@ export function pickIndicator(
   if (state === "speaking" || state === "thinking") return "pulse-speaking";
   return "static";
 }
+
+/**
+ * Pick the next ParentConsentGate kind to render in the consent chain,
+ * or null when both consents are granted (#620).
+ *
+ * PRD §3.16.3 specifies stacked consent: microphone first, then
+ * voice_conversation. This pure helper locks the ordering so the
+ * AgentChatPanel integration can't drift.
+ *
+ * Defensive: a null/undefined child returns "mic" so the panel
+ * surfaces the first gate rather than crashing on an undefined read.
+ */
+export type PendingGate = "mic" | "voice" | null;
+
+export interface ChildConsentState {
+  micConsent?: boolean;
+  voiceConsent?: boolean;
+}
+
+export function nextPendingGate(
+  child: ChildConsentState | null | undefined,
+): PendingGate {
+  if (!child) return "mic";
+  if (!child.micConsent) return "mic";
+  if (!child.voiceConsent) return "voice";
+  return null;
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -519,6 +519,16 @@ export interface ChildProfile {
   archived_at?: string | null;
   camera_consent?: boolean;
   microphone_consent?: boolean;
+  /** Two-way realtime voice with the buddy (PRD §3.16, epic #605).
+   *  Separate from microphone_consent: that gates one-shot speech-to-text
+   *  on input fields (#586), this one gates the full Talk-to-Buddy
+   *  duplex channel. Both are parent-PIN-gated.
+   */
+  voice_conversation_consent?: boolean;
+  /** Buddy TTS voice preset for realtime voice mode (#612). */
+  voice_persona?: string;
+  /** Daily voice quota in seconds (#612). 0 = no cap configured. */
+  voice_session_quota_seconds?: number;
   created_at?: string;
   updated_at?: string;
 }
@@ -541,12 +551,14 @@ export interface ChildProfileUpdateRequest {
   avatar?: string | null;
 }
 
-// PATCH /child-profiles/{child_id}/consent (#587).
-// At least one of camera_consent or microphone_consent must be supplied; the
-// backend rejects an empty body with 422.
+// PATCH /child-profiles/{child_id}/consent (#587, extended in #612).
+// At least one field must be supplied; backend rejects an empty body with 422.
 export interface ChildProfileConsentUpdateRequest {
   camera_consent?: boolean;
   microphone_consent?: boolean;
+  voice_conversation_consent?: boolean;
+  voice_persona?: string;
+  voice_session_quota_seconds?: number;
 }
 
 // Upload status


### PR DESCRIPTION
## Summary

Final integration story for Talk-to-Buddy realtime voice (epic #605, PRD §3.16). Wires the four just-shipped pieces into `AgentChatPanel` and fixes three regressions from upstream PRs that blocked the integration.

## Pre-work fixes (caught by the `/plan` agent)

These three must land here so #620 ships standalone:

### 1. `TalkToBuddyPanel.tsx` was corrupt on main
PR #629 shipped a duplicate of the test file as the component (both 142 lines, both `import { describe, expect, it } from "vitest"`). The integration needs the real component. Reconstructed.

### 2. `voice_conversation_consent` missing from `ChildProfile` TS type
Backend (#612 migration) treats it as real but the read-side type didn't expose it — `shouldShowEntryButton` always returned false. Added `voice_conversation_consent` + `voice_persona` + `voice_session_quota_seconds` to both [ChildProfile](frontend/src/types/api.ts#L511) and `ChildProfileConsentUpdateRequest`.

### 3. New pure helper: `nextPendingGate`
Picks the next gate kind in the PRD §3.16.3 stacked-consent chain (mic first, voice second). 6 new tests cover the truth table + defensive cases.

## Integration

| Change | Why |
|--------|-----|
| `detectVoiceCapabilities` memoized on mount | `shouldShowEntryButton` needs `supportsVoice` BEFORE the hook attaches |
| New Talk button in header (next to gear) | Discoverable mode-switch per PRD §3.16.2 ("co-equal in v1") |
| Two variants: primary "Talk" pill / outlined "Ask" CTA | Surfaces discovery path when consent missing |
| `pendingTalkGate: 'mic' \| 'voice' \| null` state | Sequential consent chain via `nextPendingGate` + `advancePendingGate` |
| `TalkToBuddyContainer` (new inline adapter) | Hook only attaches while panel is mounted → zero idle cost |
| `onCaption` → `appendVoiceCaption` | Voice transcripts merge into existing chat history |
| `VITE_TALK_TO_BUDDY_ENABLED` feature flag | Default-off in prod; staging exercises with `REALTIME_VOICE_PROVIDER=mock` |
| Talk button disabled while streaming | Avoids dual-modality confusion |

The existing #586 inline mic-INPUT button stays unchanged.

## Test plan

- [x] `vitest run` → **355/355 pass** (6 new `nextPendingGate` cases, no regressions)
- [x] `tsc -b` clean
- [ ] Manual: set `VITE_TALK_TO_BUDDY_ENABLED=true` + `REALTIME_VOICE_PROVIDER=mock` → Talk button visible in header, opens panel, mock provider returns canned transcript + audio
- [ ] Manual: consent missing → "Ask" button → mic gate → voice gate → panel opens
- [ ] Manual: reduced-motion → indicator stays static
- [ ] Manual: text stream in flight → Talk button disabled

## Epic #605 status after this lands

**Phase B (frontend) complete.** Combined with Phase A backend (merged through #627), the full Talk-to-Buddy surface ships end-to-end behind the feature flag.

Three follow-ups from #615 PR body still apply (consent-revoke registry, `stream_my_agent_chat` integration replacing the deterministic stand-in reply, `VoiceWSLaunchFlowEvent` for launch_flow parity).

Fixes #620
Closes the Phase B track for Epic #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)