### PR TITLE
refactor(my-agent): replace Ask/Talk header pill with floating FAB + onboarding banner

### DIFF
--- a/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
+++ b/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
@@ -5,7 +5,9 @@ import {
   nextPendingGate,
   pickIndicator,
   shouldShowEntryButton,
+  shouldShowOnboardingBanner,
   TALK_PANEL_STATE_COPY,
+  voiceBannerStorageKey,
 } from "@/pages/MyAgentPage/talkToBuddyHelpers";
 import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
 
@@ -172,5 +174,75 @@ describe("nextPendingGate (#620)", () => {
 
   it("treats undefined voice consent as not-granted when mic is true", () => {
     expect(nextPendingGate({ micConsent: true })).toBe("voice");
+  });
+});
+
+describe("shouldShowOnboardingBanner (UX rework)", () => {
+  const baseline = {
+    flagEnabled: true,
+    supportsVoice: true,
+    hasCurrentChild: true,
+    micConsentGranted: false,
+    voiceConversationConsentGranted: false,
+    dismissed: false,
+  };
+
+  it("shows when feature flag on + capable + child loaded + setup left + not dismissed", () => {
+    expect(shouldShowOnboardingBanner(baseline)).toBe(true);
+  });
+
+  it("hides when the feature flag is off (prod default)", () => {
+    expect(
+      shouldShowOnboardingBanner({ ...baseline, flagEnabled: false }),
+    ).toBe(false);
+  });
+
+  it("hides when the device cannot support voice", () => {
+    expect(
+      shouldShowOnboardingBanner({ ...baseline, supportsVoice: false }),
+    ).toBe(false);
+  });
+
+  it("hides when no child profile is loaded", () => {
+    expect(
+      shouldShowOnboardingBanner({ ...baseline, hasCurrentChild: false }),
+    ).toBe(false);
+  });
+
+  it("hides when the parent has dismissed it", () => {
+    expect(
+      shouldShowOnboardingBanner({ ...baseline, dismissed: true }),
+    ).toBe(false);
+  });
+
+  it("hides when both consents are already granted (nothing to do)", () => {
+    expect(
+      shouldShowOnboardingBanner({
+        ...baseline,
+        micConsentGranted: true,
+        voiceConversationConsentGranted: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("still shows when only one consent is missing (setup left)", () => {
+    expect(
+      shouldShowOnboardingBanner({
+        ...baseline,
+        micConsentGranted: true,
+        voiceConversationConsentGranted: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("voiceBannerStorageKey (UX rework)", () => {
+  it("namespaces per child profile so different children get fresh banners", () => {
+    expect(voiceBannerStorageKey("child_abc")).toBe(
+      "talk_to_buddy_banner_dismissed:child_abc",
+    );
+    expect(voiceBannerStorageKey("child_xyz")).not.toBe(
+      voiceBannerStorageKey("child_abc"),
+    );
   });
 });

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -21,10 +21,12 @@ import {
   useRef,
   useState,
 } from "react";
+import { motion } from "framer-motion";
 import {
   ExternalLink,
   ImagePlus,
   Loader2,
+  Mic,
   Send,
   Settings,
   Sparkles,
@@ -42,6 +44,8 @@ import TalkToBuddyPanel from "./TalkToBuddyPanel";
 import {
   nextPendingGate,
   shouldShowEntryButton,
+  shouldShowOnboardingBanner,
+  voiceBannerStorageKey,
   type PendingGate,
 } from "./talkToBuddyHelpers";
 import {
@@ -265,23 +269,59 @@ export default function AgentChatPanel({
     hasCurrentChild: Boolean(currentChild?.child_id),
   });
 
-  // Show the Talk affordance even when consents are missing (renders
-  // as "Ask a grown-up" CTA) so the feature is discoverable. Hidden
-  // entirely when the browser lacks capabilities or the flag is off.
-  const showTalkEntry =
-    TALK_TO_BUDDY_ENABLED && voiceCaps.supported && Boolean(currentChild?.child_id);
+  // Per-child onboarding-banner dismissal flag (persisted via localStorage).
+  // We hydrate from storage on mount whenever the active child changes —
+  // a parent who set up voice for kid A shouldn't see the banner for kid A
+  // again, but kid B should still get their own first-run nudge.
+  const [bannerDismissed, setBannerDismissed] = useState<boolean>(false);
+  useEffect(() => {
+    if (!currentChild?.child_id || typeof window === "undefined") {
+      setBannerDismissed(false);
+      return;
+    }
+    const stored = window.localStorage.getItem(
+      voiceBannerStorageKey(currentChild.child_id),
+    );
+    setBannerDismissed(stored === "1");
+  }, [currentChild?.child_id]);
+
+  const showOnboardingBanner = shouldShowOnboardingBanner({
+    flagEnabled: TALK_TO_BUDDY_ENABLED,
+    supportsVoice: voiceCaps.supported,
+    hasCurrentChild: Boolean(currentChild?.child_id),
+    micConsentGranted: currentChild?.microphone_consent === true,
+    voiceConversationConsentGranted:
+      currentChild?.voice_conversation_consent === true,
+    dismissed: bannerDismissed,
+  });
+
+  // Feature-flag + capability gate for the floating Talk pill. Hidden
+  // entirely when capabilities are missing or the flag is off; "ready"
+  // (consents granted) decides whether the FAB renders.
+  const fabVisible = TALK_TO_BUDDY_ENABLED && talkEntryReady && !isStreaming;
 
   const handleOpenTalk = () => {
     if (talkEntryReady) {
       setIsTalkOpen(true);
       return;
     }
-    // Compute the next pending gate from the child's consent state.
+    // Setup path — compute next pending gate. Used by the onboarding
+    // banner's primary CTA, not the (now-removed) header pill.
     const next = nextPendingGate({
       micConsent: currentChild?.microphone_consent === true,
       voiceConsent: currentChild?.voice_conversation_consent === true,
     });
     setPendingTalkGate(next);
+  };
+
+  const dismissOnboardingBanner = () => {
+    setBannerDismissed(true);
+    if (currentChild?.child_id && typeof window !== "undefined") {
+      window.localStorage.setItem(
+        voiceBannerStorageKey(currentChild.child_id),
+        "1",
+      );
+    }
   };
 
   const advancePendingGate = () => {
@@ -430,31 +470,6 @@ export default function AgentChatPanel({
               aria-label="Streaming"
             />
           )}
-          {showTalkEntry && (
-            <button
-              type="button"
-              onClick={handleOpenTalk}
-              disabled={isStreaming}
-              className={
-                talkEntryReady
-                  ? "inline-flex items-center gap-1 rounded-full bg-violet-600 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-violet-700 disabled:opacity-50"
-                  : "inline-flex items-center gap-1 rounded-full border border-violet-300 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-100 disabled:opacity-50"
-              }
-              title={
-                talkEntryReady
-                  ? `Talk to ${agent.agent_name}`
-                  : "Ask a grown-up to turn on voice chat"
-              }
-              aria-label={
-                talkEntryReady
-                  ? `Talk to ${agent.agent_name}`
-                  : "Ask a grown-up to turn on voice chat"
-              }
-            >
-              <span aria-hidden="true">💬</span>
-              <span>{talkEntryReady ? "Talk" : "Ask"}</span>
-            </button>
-          )}
           {onConfigure && (
             <button
               type="button"
@@ -475,6 +490,43 @@ export default function AgentChatPanel({
       >
         {messages.length === 0 ? (
           <div className="mx-auto flex h-full max-w-md flex-col items-center justify-center gap-5 text-center">
+            {showOnboardingBanner && (
+              <div
+                role="status"
+                className="w-full rounded-2xl border border-violet-200 bg-violet-50 p-4 text-left shadow-sm"
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-2xl" aria-hidden="true">
+                    🎤
+                  </span>
+                  <div className="flex-1">
+                    <p className="text-sm font-semibold text-violet-900">
+                      Did you know {agent.agent_name} can talk?
+                    </p>
+                    <p className="mt-1 text-xs leading-relaxed text-violet-800">
+                      A grown-up can turn on voice chat so you can have a real
+                      back-and-forth conversation with your buddy.
+                    </p>
+                    <div className="mt-3 flex items-center gap-3">
+                      <button
+                        type="button"
+                        onClick={handleOpenTalk}
+                        className="rounded-full bg-violet-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-violet-700"
+                      >
+                        Ask a grown-up to turn it on
+                      </button>
+                      <button
+                        type="button"
+                        onClick={dismissOnboardingBanner}
+                        className="text-xs font-medium text-violet-700 underline-offset-2 hover:underline"
+                      >
+                        Not now
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white text-3xl shadow-md ring-2 ring-violet-100">
               {buddyGlyph}
             </div>
@@ -720,6 +772,28 @@ export default function AgentChatPanel({
           ageGroup={ageGroup}
           onClose={() => setIsTalkOpen(false)}
         />
+      )}
+      {fabVisible && !isTalkOpen && (
+        <motion.button
+          type="button"
+          onClick={() => setIsTalkOpen(true)}
+          whileTap={{ scale: 0.95 }}
+          whileHover={{ scale: 1.04 }}
+          animate={{
+            boxShadow: [
+              "0 10px 24px -8px rgba(124, 58, 237, 0.45)",
+              "0 14px 30px -6px rgba(124, 58, 237, 0.65)",
+              "0 10px 24px -8px rgba(124, 58, 237, 0.45)",
+            ],
+          }}
+          transition={{ duration: 2.2, repeat: Infinity, ease: "easeInOut" }}
+          aria-label={`Talk to ${agent.agent_name}`}
+          title={`Talk to ${agent.agent_name}`}
+          className="fixed bottom-24 right-6 z-30 inline-flex items-center gap-2 rounded-full bg-violet-600 px-5 py-3 text-sm font-bold text-white hover:bg-violet-700 sm:bottom-28 lg:bottom-8 lg:right-8"
+        >
+          <Mic size={18} />
+          <span>Talk to {agent.agent_name}</span>
+        </motion.button>
       )}
     </section>
   );

--- a/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
@@ -129,3 +129,46 @@ export function nextPendingGate(
   if (!child.voiceConsent) return "voice";
   return null;
 }
+
+/**
+ * Inline onboarding banner truth table. Renders only when:
+ *   - The feature flag is on (no banner in prod canary)
+ *   - The device supports voice (don't tease an unavailable feature)
+ *   - A child profile is loaded (banner is per-child)
+ *   - At least one consent is still missing (nothing to surface otherwise)
+ *   - The parent hasn't dismissed it for THIS child profile
+ *
+ * The new UX (post "Ask"-button removal): instead of a button in the
+ * header that mixes "set up" with "use", we surface a one-time inline
+ * banner in the chat empty state. The CTA opens the same consent gate
+ * chain (mic → voice) but the surface only appears when there's actually
+ * something for the parent to do.
+ */
+export interface OnboardingBannerArgs {
+  flagEnabled: boolean;
+  supportsVoice: boolean;
+  hasCurrentChild: boolean;
+  micConsentGranted: boolean;
+  voiceConversationConsentGranted: boolean;
+  dismissed: boolean;
+}
+
+export function shouldShowOnboardingBanner(
+  args: OnboardingBannerArgs,
+): boolean {
+  if (!args.flagEnabled) return false;
+  if (!args.supportsVoice) return false;
+  if (!args.hasCurrentChild) return false;
+  if (args.dismissed) return false;
+  // Banner only appears when there IS setup work left.
+  return !args.micConsentGranted || !args.voiceConversationConsentGranted;
+}
+
+/**
+ * localStorage key for the per-child banner-dismissal flag. Per-child
+ * so a parent who's set up voice for kid A still sees the banner the
+ * first time kid B's profile loads.
+ */
+export function voiceBannerStorageKey(childId: string): string {
+  return `talk_to_buddy_banner_dismissed:${childId}`;
+}


### PR DESCRIPTION
## Summary

Replaces the "Ask"/"Talk" header pill with the canonical voice-mode entry pattern (ChatGPT/Discord/Google Assistant): a floating action button at bottom-right when voice is actually usable, plus a one-time onboarding banner in the chat empty state for the setup path.

## Why the old design was wrong

The header pill mixed two unrelated jobs into one visual affordance:
1. **"Ask"** = request parental approval (a parent setup task)
2. **"Talk"** = start a voice session (the actual feature for the child)

Both lived in the same slot, shared the same icon (`💬` — actually means *text chat* universally), and had similar visual weight. Result: kids saw an empty-promise button on first visit, and the action-unclear "Ask" verb gave no hint what tapping it would do.

## New design (Option A from the investigation)

| Surface | When it appears | What it does |
|---------|----------------|--------------|
| **Floating "🎤 Talk to {buddy_name}" pill** (bottom-right) | Capability + both consents OK + flag on + not streaming | Opens the TalkToBuddyPanel |
| **Inline onboarding banner** (empty state) | Capability + child loaded + at least one consent missing + not dismissed + flag on | "Ask a grown-up to turn it on" CTA opens the consent gate chain |
| **Header** | — | Just the gear icon. Clean. |

Both surfaces are per-child:
- The banner's "Not now" dismissal persists in `localStorage` keyed per `child_id`
- A parent who sets up voice for kid A still sees the banner the first time kid B's profile loads

## Files changed

| File | Change |
|------|--------|
| [talkToBuddyHelpers.ts](frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts) | New: `shouldShowOnboardingBanner()` + `voiceBannerStorageKey()` |
| [AgentChatPanel.tsx](frontend/src/pages/MyAgentPage/AgentChatPanel.tsx) | Removed header pill, added FAB + banner + localStorage rehydration |
| [talkToBuddyHelpers.test.ts](frontend/src/__tests__/components/talkToBuddyHelpers.test.ts) | 8 new tests for the truth table + storage key |

## Test plan

- [x] `vitest run` → 363/363 pass (29 helpers, 8 new)
- [x] `tsc -b` clean
- [ ] Manual: first visit with no consents → banner appears with "Ask a grown-up" CTA
- [ ] Manual: tap "Not now" → banner stays gone (refresh page; still gone for this child)
- [ ] Manual: switch to a different child profile → banner reappears (per-child dismissal)
- [ ] Manual: complete consent chain → banner disappears, FAB appears bottom-right
- [ ] Manual: tap FAB → TalkToBuddyPanel opens
- [ ] Manual: text stream in flight → FAB hidden (no dual-modality confusion)
- [ ] Manual: feature flag off → neither surface appears

## Industry precedent

- **ChatGPT voice mode**: mic icon → fullscreen overlay (mode switch)
- **Discord voice channel**: persistent FAB-like indicator separate from text
- **Google Assistant**: bottom-right FAB is the canonical mobile placement
- **WhatsApp hold-to-talk**: composer-integrated — rejected because that pattern is for one-shot messages, not duplex mode

The FAB won because it matches PRD §3.16.2's "voice is co-equal in v1" framing while keeping the setup path off the primary surface.

## What's NOT in this PR (intentional)

- Settings sheet voice toggle (gear icon → new "Voice conversation" section). Filed as a follow-up — the banner is sufficient for v1 discoverability.
- Voice-message rendering polish (the `source: "voice"` tag in chat messages still has no mic icon next to it). Separate cosmetic story.

Related: closes the UX-debt feedback raised after #620 landed (the "Ask" button felt non-standard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)