### PR TITLE
docs(my-agent): PRD §3.16.5 v2 — Start Talking header CTA + inline voice bubble

### DIFF
--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -2001,17 +2001,20 @@ Both are parent-PIN-gated via `ParentApprovalPage`. The consent screen explicitl
 - New table: `voice_sessions(user_id, child_id, agent_id, started_at, ended_at, duration_seconds, ended_reason)`.
 - Quota: voice minutes count against the existing daily quota (§3.9.1) at age-adapted rates (see 3.16.6).
 
-### 3.16.5 Frontend
-- `frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx` — full-screen voice surface (mobile sheet, desktop side panel) launched from a new Talk button on `AgentChatPanel`.
-- `frontend/src/hooks/useVoiceConversation.ts` + pure `voiceConversationStateMachine.ts` — `getUserMedia` capture, WS client, state machine (`idle → connecting → listening → thinking → speaking → ending → error`). Mirrors the `useVoiceInput` reducer-extracted pattern from #584.
-- Live captions write into `useAgentChatStore` so text history and voice history merge.
-- `ParentConsentGate` gains a `kind="voice_conversation"` variant.
+### 3.16.5 Frontend Entry & Layout
+- **Entry surface (v2 — supersedes the FAB pattern from PR #633):** a prominent "Start Talking" pill in the **`AgentChatPanel` header**, gated by `shouldShowEntryButton` (capability + both consents + active child + not currently text-streaming + not already in voice mode).
+- **In-place layout (replaces the full-screen overlay):** tapping the header pill swaps the composer textarea/send region for an **inline voice bubble** — the `TalkToBuddyPanel` mounted with `variant="inline"`. The message list above stays scrollable and visible; voice transcripts merge into the same list via `useAgentChatStore.appendVoiceCaption`. Tapping **End** unmounts the bubble and re-mounts the composer with focus restored to the textarea.
+- **Why this beats the overlay+FAB pattern**: a single conversation surface, no modality jump, kid never sees two input affordances at once, scroll history stays anchored.
+- **Why the entry stays inside `AgentChatPanel` (not global `PageContainer` chrome)**: only meaningful on `/my-agent` with a buddy + consents; cross-page header would re-litigate the "Ask"/"Talk" header-pill decision from commit `e31c2aa0`. The same rule applies — the entry surface lives where the action lives.
+- **Setup path unchanged**: when `talkEntryReady === false`, the header pill is hidden. The empty-state onboarding banner from PR #633 (when consents are missing) remains the parent-setup affordance.
+- **Components**: `frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx` gains a `variant?: "overlay" | "inline"` prop (overlay = current full-screen behavior, inline = composer-slot layout). `frontend/src/hooks/useVoiceConversation.ts` is unchanged — the voice pipeline (state machine, WS, MediaRecorder, AudioContext) is reused as-is.
+- `ParentConsentGate` `kind="voice_conversation"` variant from #619 stays the consent surface; the header pill simply hides until both consents land.
 
 ### 3.16.6 Age Adaptation
 
 | Concern | 3-5 | 6-8 | 9-12 |
 |---|---|---|---|
-| Entry surface | Giant emoji + "Talk!" | "Talk to {buddy_name}" pill | Mic icon + "Voice" |
+| Entry surface (header pill) | Giant emoji + "Talk!" | "Talk to {buddy_name}" | Mic icon + "Voice" |
 | Default mode | Continuous VAD | Continuous VAD + PTT toggle | Push-to-talk default |
 | Greeting | One short line | Two-sentence with prompt | One line + suggestion list |
 | TTS voice picker | Parent-locked | 3 curated voices | 8 curated voices |


### PR DESCRIPTION
## Summary

Updates PRD §3.16.5 to specify the new Talk-to-Buddy entry pattern: a prominent **"Start Talking" pill in the AgentChatPanel header** that swaps the composer for an **inline voice bubble** when tapped. Supersedes the FAB + full-screen overlay pattern from PR #633 (still open).

## Why this matters

User feedback after PR #633's FAB + overlay flow: the modality switch felt jarring. The new pattern keeps a single conversation surface — message history stays visible above, the input region toggles between typing and talking, voice transcripts merge into the same chat list.

## §3.16.5 changes

- Header pill entry surface (replaces FAB)
- Composer-slot inline bubble (replaces full-screen overlay)
- New `variant?: "overlay" | "inline"` prop on `TalkToBuddyPanel`
- Setup path (consent missing) unchanged — banner from PR #633 remains the parent-setup affordance
- Cites commit `e31c2aa0` so a future contributor doesn't re-litigate the "no header pill" decision out of context

## §3.16.6 age table

Entry-surface row clarified — per-age header pill labels stay as drafted.

## Sub-stories filed under epic #605

| # | Title | Priority | Depends on |
|---|-------|----------|-----------|
| [#635](https://github.com/xenophobed/Demi_Creative/issues/635) | Add inline variant to TalkToBuddyPanel | P1 | — |
| [#636](https://github.com/xenophobed/Demi_Creative/issues/636) | Add Start Talking header pill + composer swap | P1 | #635 |
| [#637](https://github.com/xenophobed/Demi_Creative/issues/637) | Remove or feature-flag the floating Talk FAB | P2 | #636 |
| [#638](https://github.com/xenophobed/Demi_Creative/issues/638) | Age-adapted header CTA copy helper | P3 | #636 |

## Ordering note

PR #633 (FAB + banner UX) intentionally remains open. Two viable orderings:

- **Stack on top**: land #633 first → banner is in place as the setup affordance → #635-#638 evolve the entry pattern. The FAB lives briefly until #637 removes it.
- **Replace**: close #633 → start fresh from #635. Avoids ever shipping the FAB.

Either ordering works; #635 doesn't depend on #633's helpers. Recommend the stack approach so the onboarding banner ships sooner.

Related to #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)