### PR TITLE
feat(my-agent): Start Talking header pill + composer swap on AgentChatPanel (#636)

### DIFF
--- a/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
+++ b/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   nextPendingGate,
   pickIndicator,
   shouldShowEntryButton,
+  shouldShowHeaderTalkPill,
   TALK_PANEL_STATE_COPY,
 } from "@/pages/MyAgentPage/talkToBuddyHelpers";
 import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
@@ -172,5 +173,47 @@ describe("nextPendingGate (#620)", () => {
 
   it("treats undefined voice consent as not-granted when mic is true", () => {
     expect(nextPendingGate({ micConsent: true })).toBe("voice");
+  });
+});
+
+describe("shouldShowHeaderTalkPill (#636)", () => {
+  const allGranted = {
+    supportsVoice: true,
+    micConsentGranted: true,
+    voiceConversationConsentGranted: true,
+    hasCurrentChild: true,
+  };
+
+  it("shows the pill when consents + capability are ready and no stream/bubble is active", () => {
+    expect(shouldShowHeaderTalkPill(allGranted, false, false)).toBe(true);
+  });
+
+  it("hides while the chat is streaming a text response", () => {
+    // Pressing Start mid-stream would race the AbortController flow.
+    expect(shouldShowHeaderTalkPill(allGranted, true, false)).toBe(false);
+  });
+
+  it("hides while the inline voice bubble is already open", () => {
+    // The bubble has replaced the composer; a second entry point in
+    // the header would be redundant + confusing.
+    expect(shouldShowHeaderTalkPill(allGranted, false, true)).toBe(false);
+  });
+
+  it("hides when both streaming and talk-open are true (sanity)", () => {
+    expect(shouldShowHeaderTalkPill(allGranted, true, true)).toBe(false);
+  });
+
+  it("delegates capability/consent gating to shouldShowEntryButton", () => {
+    // Any single precondition failure must hide the pill, no matter
+    // what the streaming/talk-open state is.
+    const cases = [
+      { ...allGranted, supportsVoice: false },
+      { ...allGranted, micConsentGranted: false },
+      { ...allGranted, voiceConversationConsentGranted: false },
+      { ...allGranted, hasCurrentChild: false },
+    ];
+    for (const broken of cases) {
+      expect(shouldShowHeaderTalkPill(broken, false, false)).toBe(false);
+    }
   });
 });

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -38,10 +38,13 @@ import useAgentChatStore from "@/store/useAgentChatStore";
 import useChildStore from "@/store/useChildStore";
 import VoiceInputButton from "@/components/common/VoiceInputButton";
 import ParentConsentGate from "@/components/common/ParentConsentGate";
-import TalkToBuddyPanel from "./TalkToBuddyPanel";
+import TalkToBuddyPanel, {
+  type TalkToBuddyPanelVariant,
+} from "./TalkToBuddyPanel";
 import {
   nextPendingGate,
   shouldShowEntryButton,
+  shouldShowHeaderTalkPill,
   type PendingGate,
 } from "./talkToBuddyHelpers";
 import {
@@ -255,7 +258,21 @@ export default function AgentChatPanel({
     [],
   );
   const [isTalkOpen, setIsTalkOpen] = useState(false);
+  const wasTalkOpenRef = useRef(false);
   const [pendingTalkGate, setPendingTalkGate] = useState<PendingGate>(null);
+
+  // #636: when the inline voice bubble unmounts (user tapped End), put
+  // focus back on the textarea so the kid can immediately keep typing
+  // without a second tap. Only fires on the true → false transition so
+  // typing in the textarea between sessions doesn't get stolen.
+  useEffect(() => {
+    if (wasTalkOpenRef.current && !isTalkOpen) {
+      // Defer one tick so the composer form has remounted.
+      const id = setTimeout(() => textareaRef.current?.focus(), 0);
+      return () => clearTimeout(id);
+    }
+    wasTalkOpenRef.current = isTalkOpen;
+  }, [isTalkOpen]);
 
   const talkEntryReady = shouldShowEntryButton({
     supportsVoice: voiceCaps.supported,
@@ -270,6 +287,25 @@ export default function AgentChatPanel({
   // entirely when the browser lacks capabilities or the flag is off.
   const showTalkEntry =
     TALK_TO_BUDDY_ENABLED && voiceCaps.supported && Boolean(currentChild?.child_id);
+
+  // #636: the new "Start Talking" header pill — only when the
+  // capability + consent preconditions are met AND nothing else is
+  // contending for the composer area (no in-flight text stream, no
+  // already-open inline bubble). Truth table locked by
+  // shouldShowHeaderTalkPill's contract tests.
+  const showHeaderStartTalking =
+    TALK_TO_BUDDY_ENABLED &&
+    shouldShowHeaderTalkPill(
+      {
+        supportsVoice: voiceCaps.supported,
+        micConsentGranted: currentChild?.microphone_consent === true,
+        voiceConversationConsentGranted:
+          currentChild?.voice_conversation_consent === true,
+        hasCurrentChild: Boolean(currentChild?.child_id),
+      },
+      isStreaming,
+      isTalkOpen,
+    );
 
   const handleOpenTalk = () => {
     if (talkEntryReady) {
@@ -430,29 +466,33 @@ export default function AgentChatPanel({
               aria-label="Streaming"
             />
           )}
-          {showTalkEntry && (
+          {showHeaderStartTalking && (
             <button
               type="button"
               onClick={handleOpenTalk}
-              disabled={isStreaming}
-              className={
-                talkEntryReady
-                  ? "inline-flex items-center gap-1 rounded-full bg-violet-600 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-violet-700 disabled:opacity-50"
-                  : "inline-flex items-center gap-1 rounded-full border border-violet-300 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-100 disabled:opacity-50"
-              }
-              title={
-                talkEntryReady
-                  ? `Talk to ${agent.agent_name}`
-                  : "Ask a grown-up to turn on voice chat"
-              }
-              aria-label={
-                talkEntryReady
-                  ? `Talk to ${agent.agent_name}`
-                  : "Ask a grown-up to turn on voice chat"
-              }
+              className="inline-flex items-center gap-1 rounded-full bg-violet-600 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-violet-700"
+              title={`Start talking with ${agent.agent_name}`}
+              aria-label={`Start talking with ${agent.agent_name}`}
             >
               <span aria-hidden="true">💬</span>
-              <span>{talkEntryReady ? "Talk" : "Ask"}</span>
+              <span>Start Talking</span>
+            </button>
+          )}
+          {/* Consents-missing fallback: surface the entry as "Ask"
+              while the per-#633 onboarding banner is unshipped, so the
+              feature stays discoverable for first-run kids. Hidden
+              once consents are granted (the Start Talking pill takes
+              over) and hidden while streaming or the bubble is open. */}
+          {showTalkEntry && !talkEntryReady && !isStreaming && !isTalkOpen && (
+            <button
+              type="button"
+              onClick={handleOpenTalk}
+              className="inline-flex items-center gap-1 rounded-full border border-violet-300 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-100"
+              title="Ask a grown-up to turn on voice chat"
+              aria-label="Ask a grown-up to turn on voice chat"
+            >
+              <span aria-hidden="true">💬</span>
+              <span>Ask</span>
             </button>
           )}
           {onConfigure && (
@@ -577,6 +617,17 @@ export default function AgentChatPanel({
         </div>
       )}
 
+      {isTalkOpen ? (
+        <div className="border-t border-gray-100 bg-white px-4 py-3">
+          <TalkToBuddyContainer
+            childId={childId}
+            persona={agent.agent_name}
+            ageGroup={ageGroup}
+            variant="inline"
+            onClose={() => setIsTalkOpen(false)}
+          />
+        </div>
+      ) : (
       <form
         className="border-t border-gray-100 bg-white px-4 py-3"
         onSubmit={onSubmit}
@@ -686,6 +737,7 @@ export default function AgentChatPanel({
           )}
         </div>
       </form>
+      )}
       {showMicConsentGate && ageGroup && (
         <ParentConsentGate
           kind="microphone"
@@ -713,14 +765,6 @@ export default function AgentChatPanel({
           onDismiss={() => setPendingTalkGate(null)}
         />
       )}
-      {isTalkOpen && (
-        <TalkToBuddyContainer
-          childId={childId}
-          persona={agent.agent_name}
-          ageGroup={ageGroup}
-          onClose={() => setIsTalkOpen(false)}
-        />
-      )}
     </section>
   );
 }
@@ -738,11 +782,15 @@ function TalkToBuddyContainer({
   persona,
   ageGroup,
   onClose,
+  variant = "overlay",
 }: {
   childId: string;
   persona: string;
   ageGroup?: AgeGroup | null;
   onClose: () => void;
+  /** When `inline`, the End button also unmounts the bubble (no
+   *  separate X close affordance — see PRD §3.16.5 v2 + #635). */
+  variant?: TalkToBuddyPanelVariant;
 }) {
   void ageGroup; // Future: thread per-age TTS preset overrides (Phase C, #608).
   const appendVoiceCaption = useAgentChatStore((s) => s.appendVoiceCaption);
@@ -767,6 +815,18 @@ function TalkToBuddyContainer({
       ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
       : false;
 
+  // Inline mode collapses End + Close into a single affordance: the
+  // user expects "End" to dismiss the bubble and return the textarea,
+  // not just transition to idle. Audio cleanup still runs via the
+  // hook's useEffect on unmount (#617), so eager close is safe.
+  const handleEnd =
+    variant === "inline"
+      ? () => {
+          voice.end();
+          onClose();
+        }
+      : voice.end;
+
   return (
     <TalkToBuddyPanel
       state={voice.state}
@@ -775,9 +835,10 @@ function TalkToBuddyContainer({
       inputLevel={voice.inputLevel}
       prefersReducedMotion={prefersReducedMotion}
       onStart={() => voice.start(true)}
-      onEnd={voice.end}
+      onEnd={handleEnd}
       onRetry={voice.retry}
       onClose={onClose}
+      variant={variant}
     />
   );
 }

--- a/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
@@ -129,3 +129,31 @@ export function nextPendingGate(
   if (!child.voiceConsent) return "voice";
   return null;
 }
+
+/**
+ * Whether the new "Start Talking" header pill in AgentChatPanel should
+ * render (#636). Three conditions, all of them gating:
+ *
+ * 1. Capability + consent + child preconditions are met (delegates to
+ *    `shouldShowEntryButton`).
+ * 2. The chat is not currently streaming a text response — pressing
+ *    Start Talking mid-stream would race the existing AbortController
+ *    flow and create a confusing "buddy is typing AND listening?" state.
+ * 3. The inline voice bubble is not already open — when `isTalkOpen` is
+ *    true, the bubble has replaced the composer and there's no second
+ *    entry point to surface in the header.
+ *
+ * Pure helper so the composer-swap story (#636) can lock the truth
+ * table without mounting AgentChatPanel — same pattern as the entry
+ * button (#618) and the variant CSS (#635).
+ */
+export function shouldShowHeaderTalkPill(
+  preconditions: TalkButtonPreconditions,
+  isStreaming: boolean,
+  isTalkOpen: boolean,
+): boolean {
+  if (!shouldShowEntryButton(preconditions)) return false;
+  if (isStreaming) return false;
+  if (isTalkOpen) return false;
+  return true;
+}


### PR DESCRIPTION
## Summary

The headline UX change from PRD §3.16.5 v2. The old "Talk"/"Ask" pill (which routed everything through the floating overlay) is replaced with two distinct entry points; tapping "Start Talking" now swaps the composer `<form>` for the new inline `TalkToBuddyPanel` from #635, so the kid sees their chat history above and just toggles between typing and talking in the same slot.

## Stacking

**Depends on #641 (TalkToBuddyPanel inline variant).** This PR's base is `feat/635-talk-to-buddy-inline-variant`, not `main`. Once #641 merges, this branch can be rebased onto main and the base updated. The diff shown against `feat/635-...` is the *only* code added by this PR.

## Changes

### `talkToBuddyHelpers.ts`
- New pure helper `shouldShowHeaderTalkPill(preconds, isStreaming, isTalkOpen)` that delegates capability/consent to `shouldShowEntryButton` and adds the two contextual gates: don't render mid-stream (would race the AbortController), don't render while the bubble is already in the composer.

### `AgentChatPanel.tsx`

**Header pill:**
- New **"Start Talking"** pill (granted-consent path), gated on `shouldShowHeaderTalkPill(...)`.
- Existing **"Ask"** pill (consents-missing) is **kept** as a discovery fallback. The issue AC says the consents-missing entry should be hidden in favor of #633's onboarding banner — but #633 closed unmerged. Without this fallback, first-run kids without consent would have zero entry point. Marked with a comment to remove once #633's replacement ships. _Reviewer: flag if you'd rather strictly hide and accept the discoverability gap._

**Composer slot:**
- When `isTalkOpen === true`, the `<form>` unmounts and `<TalkToBuddyContainer variant="inline" .../>` renders in its place (same `border-t`/`px-4`/`py-3` wrapper so the surface chrome stays consistent).
- Removed the old bottom-of-section overlay mount — there's now a single canonical mount point.

**End behavior:**
- `TalkToBuddyContainer` accepts `variant?: "overlay" | "inline"` (default `overlay` keeps prior callers working).
- Inline mode collapses End + Close into one tap: `voice.end()` → `onClose()`. Audio cleanup runs on unmount via `useVoiceConversation`'s effect cleanup (#617), so the eager close is safe.
- New `useEffect` on `isTalkOpen` restores focus to the textarea on the true → false transition (defer one tick so the form has remounted; guarded by a ref so typing between sessions can't be stolen).

### `talkToBuddyHelpers.test.ts` — 5 new contract tests
- Pill shows when all preconditions pass + not streaming + bubble closed
- Pill hides while streaming (AbortController race protection)
- Pill hides while the bubble is open (no duplicate entry point)
- Pill hides when both flags are true (sanity)
- Pill delegates capability/consent gating — any single precondition failure hides it

## Acceptance Criteria

- [x] Header pill renders only when `talkEntryReady && !isStreaming && !isTalkOpen` (via `shouldShowHeaderTalkPill`).
- [x] Tapping the pill sets `isTalkOpen = true` and unmounts the composer `<form>`; inline bubble mounts in its place.
- [x] Ending the bubble unmounts the bubble and re-mounts the composer; textarea regains focus.
- [x] Voice transcripts continue to merge into `useAgentChatStore.appendVoiceCaption` via the existing wiring (no new history surface).
- [x] Pressing Start Talking is impossible while `isStreaming === true` (button hidden, not just disabled).
- [⚠] When consents are missing, the header pill is hidden — implemented, but with an "Ask" fallback retained until #633's replacement banner ships (see Stacking section).
- [x] No regression: existing text-chat flow still works on `/my-agent` with voice mode never engaged.

## Out of Scope (separate sub-stories)
- **#637** — remove floating FAB (won't apply — FAB code never landed since #633 closed)
- **#638** — age-adapted header CTA copy

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — 365 / 365 pass (5 new contract tests in `talkToBuddyHelpers.test.ts`)
- [ ] Manual on `/my-agent`:
  - With consents granted: header shows "Start Talking" → tap → composer becomes the bubble → tap End → composer returns with cursor in textarea
  - Mid-stream: pill is hidden until the assistant finishes
  - Without consents: header shows "Ask" → tap → consent gate flow
  - Resize to mobile width — bubble stays in the composer slot (no `fixed inset-0`)

Fixes #636
Related to #605 (Epic: Talk to Buddy — Realtime Voice)
Related to PRD §3.16.5 v2 (landed in #639)

🤖 Generated with [Claude Code](https://claude.com/claude-code)