### PR TITLE
chore(infra): enable WebSocket proxy on /api for realtime voice dev

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
       '/api': {
         target: 'http://127.0.0.1:8000',
         changeOrigin: true,
+        ws: true,
       },
       '/audio': {
         target: 'http://127.0.0.1:8000',


### PR DESCRIPTION
## Summary

One-line fix: add \`ws: true\` to the \`/api\` proxy rule in [frontend/vite.config.ts](frontend/vite.config.ts) so the realtime-voice WebSocket upgrade tunnels through Vite to the FastAPI backend during local dev.

## Why

While testing Talk to Buddy locally (epic #605), every voice session failed at the WS handshake:
\`\`\`
useVoiceConversation.ts:228 WebSocket connection to 'ws://localhost:5173/api/v1/me/agent/voice/stream?token=...'
failed: WebSocket is closed before the connection is established.
\`\`\`

Root cause: the hook builds the WS URL from \`window.location.origin\` (correct — that way it works in both dev and prod), but Vite's HTTP and WebSocket proxying are configured separately. \`changeOrigin: true\` only sets the HTTP \`Host\` header; it does NOT opt the proxy into tunneling the \`Upgrade: websocket\` handshake. That requires \`ws: true\`, which Vite defaults to OFF for safety.

Without this flag, Vite refuses the upgrade and closes the socket before the handshake finishes — exactly the "closed before the connection is established" message.

## What this changes

Just one line:
\`\`\`diff
       '/api': {
         target: 'http://127.0.0.1:8000',
         changeOrigin: true,
+        ws: true,
       },
\`\`\`

## What this does NOT change

- **\`/audio\` and \`/data\`** stay HTTP-only. They serve static files; flipping \`ws: true\` there would be cargo-culting.
- **Production reverse proxies** (Railway, Vercel edge) have their own WebSocket-upgrade configuration. This change affects local dev only.
- **Frontend hook code** (\`useVoiceConversation.ts\`) is already correct — the bug was 100% on the dev proxy side.

## Test plan

- [x] With this change, local Vite dev proxy successfully tunnels \`/api/v1/me/agent/voice/stream\` WS upgrade to backend on \`127.0.0.1:8000\`
- [x] Existing HTTP routes through \`/api\` continue to work
- [ ] Production deploy unaffected (no prod config changed)

Related to #605 (Epic: Talk to Buddy — Realtime Voice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)