### PR TITLE
feat(my-agent): OpenAIRealtimeProvider scaffold (#644)

### DIFF
--- a/backend/src/services/realtime_voice_service.py
+++ b/backend/src/services/realtime_voice_service.py
@@ -41,6 +41,18 @@ except Exception:  # pragma: no cover - import fallback for test env
     _elevenlabs_AsyncClient = None
     _elevenlabs_VoiceSettings = None
 
+# httpx is a hard dep (see requirements.txt). Aliasing the class through
+# the module gives tests a stable monkeypatch target — they can swap
+# ``rtvs._httpx_AsyncClient`` for a fake without touching the global
+# ``httpx`` namespace. Import is intentionally module-level (no network
+# I/O), and the class is only *constructed* inside ``start_session``.
+try:
+    import httpx as _httpx
+    _httpx_AsyncClient = _httpx.AsyncClient
+except Exception:  # pragma: no cover - import fallback for test env
+    _httpx = None
+    _httpx_AsyncClient = None  # type: ignore[assignment]
+
 
 # ---------------------------------------------------------------------------
 # Public constants
@@ -54,6 +66,17 @@ SAFETY_THRESHOLD: float = 0.85
 # deterministic in-memory provider; "hybrid" routes to the Whisper +
 # ElevenLabs Flash impl in #614 (not implemented yet).
 DEFAULT_PROVIDER_ENV: str = "REALTIME_VOICE_PROVIDER"
+
+# OpenAI Realtime API constants (#644 scaffold; broker integration → #645).
+# We mint ephemeral client secrets server-side via the documented endpoint
+# so the browser never sees the long-lived OPENAI_API_KEY.
+OPENAI_REALTIME_CLIENT_SECRETS_URL: str = (
+    "https://api.openai.com/v1/realtime/client_secrets"
+)
+# Default model — the "mini" tier is the cost guardrail. Escalation to the
+# full ``gpt-realtime-2`` tier is owned by #648 (E5 cost telemetry).
+OPENAI_REALTIME_MODEL_DEFAULT: str = "gpt-realtime-mini"
+OPENAI_REALTIME_MODEL_ESCALATED: str = "gpt-realtime-2"
 
 
 # ---------------------------------------------------------------------------
@@ -486,6 +509,185 @@ class HybridRealtimeVoiceProvider:
 
 
 # ---------------------------------------------------------------------------
+# OpenAI Realtime provider — scaffold (#644)
+# ---------------------------------------------------------------------------
+
+# Reused message string so the #645 (E2) reviewer can grep for every
+# call-site the broker integration must replace.
+_E2_NOT_IMPLEMENTED: str = "E2 — broker integration"
+
+
+class OpenAIRealtimeProvider:
+    """OpenAI Realtime API provider — scaffold only.
+
+    This story (#644) gives the provider class a Protocol-conformant
+    shape and a working ``start_session`` that mints an ephemeral client
+    secret via ``POST /v1/realtime/client_secrets``. Audio forwarding,
+    tool-call translation, and synthesis stream from the upstream WS
+    land in **E2 (#645)** — those methods explicitly raise
+    ``NotImplementedError(_E2_NOT_IMPLEMENTED)`` here so a reviewer can
+    grep the codebase and verify every site got wired.
+
+    Graceful degradation:
+      - Missing ``OPENAI_API_KEY`` → ``start_session`` returns a degraded
+        handle with ``provider_state["provider_unavailable"] = True``.
+        Mirrors the Hybrid provider's pattern: the broker translates
+        this into ``VoiceWSErrorEvent(code="provider_unavailable")``
+        instead of every caller wrapping ``start_session`` in try/except.
+      - Missing ``httpx`` (test env without dep) → same degraded handle.
+
+    Audio-on-disk invariant:
+      - The provider never touches disk. The client secret + model
+        metadata live in ``handle.provider_state`` (memory-only).
+    """
+
+    name: str = "openai_realtime"
+
+    def __init__(
+        self,
+        *,
+        model: str = OPENAI_REALTIME_MODEL_DEFAULT,
+        timeout_seconds: float = 10.0,
+    ) -> None:
+        self.model = model
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def _is_available(self) -> bool:
+        return bool(os.getenv("OPENAI_API_KEY")) and _httpx_AsyncClient is not None
+
+    async def start_session(
+        self,
+        *,
+        user_id: str,
+        child_id: str,
+        target_age: int,
+        persona: str = "buddy_default",
+    ) -> SessionHandle:
+        # Degraded path: no key (or httpx missing in test env). Return a
+        # handle the broker can recognise without raising.
+        if not self._is_available:
+            logger.warning(
+                "OpenAIRealtimeProvider unavailable — OPENAI_API_KEY missing "
+                "or httpx not installed; returning degraded handle"
+            )
+            return SessionHandle(
+                session_id=f"voice_openai_{uuid4().hex[:12]}",
+                user_id=user_id,
+                child_id=child_id,
+                target_age=target_age,
+                persona=persona,
+                provider_state={
+                    "openai_client_secret": "",
+                    "provider_unavailable": True,
+                    "model": self.model,
+                },
+            )
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        # Body shape per OpenAI Realtime docs: a "session" object with
+        # type + model. Voice config is owned by the broker (E2) so we
+        # keep the body minimal here — just enough to mint the secret.
+        body: Dict[str, Any] = {
+            "session": {
+                "type": "realtime",
+                "model": self.model,
+            }
+        }
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+
+        client_secret: str = ""
+        expires_at: Optional[int] = None
+        try:
+            # Lazy: construct httpx client only when we actually mint.
+            async with _httpx_AsyncClient(timeout=self.timeout_seconds) as client:  # type: ignore[misc]
+                response = await client.post(
+                    OPENAI_REALTIME_CLIENT_SECRETS_URL,
+                    headers=headers,
+                    json=body,
+                )
+                response.raise_for_status()
+                payload = response.json() or {}
+                # OpenAI returns ``{"value": "ek_...", "expires_at": <epoch>}``
+                # at the top level. Be defensive: also accept a nested
+                # ``client_secret`` shape if the API ever shifts.
+                client_secret = (
+                    payload.get("value")
+                    or payload.get("client_secret", {}).get("value", "")
+                    or ""
+                )
+                expires_at = payload.get("expires_at")
+        except Exception as exc:
+            logger.warning(
+                "OpenAI client_secrets mint failed: %s — returning degraded handle",
+                exc,
+            )
+            return SessionHandle(
+                session_id=f"voice_openai_{uuid4().hex[:12]}",
+                user_id=user_id,
+                child_id=child_id,
+                target_age=target_age,
+                persona=persona,
+                provider_state={
+                    "openai_client_secret": "",
+                    "provider_unavailable": True,
+                    "model": self.model,
+                    "mint_error": str(exc),
+                },
+            )
+
+        return SessionHandle(
+            session_id=f"voice_openai_{uuid4().hex[:12]}",
+            user_id=user_id,
+            child_id=child_id,
+            target_age=target_age,
+            persona=persona,
+            provider_state={
+                "openai_client_secret": client_secret,
+                "model": self.model,
+                "expires_at": expires_at,
+            },
+        )
+
+    async def push_audio(
+        self,
+        handle: SessionHandle,
+        audio_bytes: bytes,
+    ) -> None:
+        # Audio forwarding to the upstream OpenAI Realtime WS lands in
+        # #645. Reviewer: grep for ``_E2_NOT_IMPLEMENTED`` and wire each
+        # call-site to the real WS forward.
+        raise NotImplementedError(_E2_NOT_IMPLEMENTED)
+
+    async def finalize_utterance(
+        self,
+        handle: SessionHandle,
+    ) -> FinalTranscript:
+        raise NotImplementedError(_E2_NOT_IMPLEMENTED)
+
+    async def synthesize_speech(
+        self,
+        handle: SessionHandle,
+        text: str,
+    ) -> AsyncIterator[bytes]:
+        # Matches the Protocol shape — the existing Mock/Hybrid impls
+        # also ``async def`` this method and return an async iterator.
+        # In E2 this will yield audio frames forwarded from the OpenAI
+        # Realtime WS ``response.output_audio.delta`` events.
+        raise NotImplementedError(_E2_NOT_IMPLEMENTED)
+
+    async def close(self, handle: SessionHandle) -> None:
+        # No persistent upstream connection in the scaffold — the broker
+        # holds nothing for us to release. Closing the upstream WS is
+        # E2 territory; keep this a benign no-op so the broker's
+        # session-cleanup path doesn't fail under the scaffold.
+        handle.provider_state["closed"] = True
+
+
+# ---------------------------------------------------------------------------
 # Provider selection
 # ---------------------------------------------------------------------------
 
@@ -499,8 +701,13 @@ def _select_provider(
       2. ``REALTIME_VOICE_PROVIDER=mock`` → MockRealtimeVoiceProvider.
       3. ``REALTIME_VOICE_PROVIDER=hybrid`` → HybridRealtimeVoiceProvider
          (degrades internally when keys are missing).
-      4. Missing ``OPENAI_API_KEY`` → Mock (dev/test env without keys).
-      5. Default → Mock until an operator opts into hybrid.
+      4. ``REALTIME_VOICE_PROVIDER=openai`` →
+         a) OPENAI_API_KEY set → OpenAIRealtimeProvider
+         b) OPENAI_API_KEY missing → Hybrid (next tier in the
+            graceful-degradation chain; Hybrid further degrades to a
+            ``provider_unavailable`` envelope if its own key is missing).
+      5. Missing ``OPENAI_API_KEY`` → Mock (dev/test env without keys).
+      6. Default → Mock until an operator opts into a real provider.
     """
     if override is not None:
         return override
@@ -510,6 +717,18 @@ def _select_provider(
         return MockRealtimeVoiceProvider()
 
     if requested == "hybrid":
+        return HybridRealtimeVoiceProvider()
+
+    if requested == "openai":
+        if os.getenv("OPENAI_API_KEY"):
+            return OpenAIRealtimeProvider()
+        # Fallback chain: openai -> hybrid -> mock. Hybrid itself
+        # degrades internally if ELEVENLABS / OPENAI keys go missing,
+        # so half-deployed envs still don't crash.
+        logger.warning(
+            "REALTIME_VOICE_PROVIDER=openai but OPENAI_API_KEY missing "
+            "— falling back to HybridRealtimeVoiceProvider"
+        )
         return HybridRealtimeVoiceProvider()
 
     if not os.getenv("OPENAI_API_KEY"):

--- a/backend/tests/contracts/test_openai_realtime_provider_contract.py
+++ b/backend/tests/contracts/test_openai_realtime_provider_contract.py
@@ -1,0 +1,407 @@
+"""
+Contract tests for OpenAIRealtimeProvider (#644).
+
+This is the **scaffold story** for the OpenAI Realtime API provider. The
+provider class exists, conforms to the ``RealtimeVoiceProvider`` Protocol,
+and mints an ephemeral client secret via
+``POST https://api.openai.com/v1/realtime/client_secrets``. The audio
+forwarding + tool-call plumbing lands in E2 (#645).
+
+What we lock here:
+
+  - Protocol conformance: all five Protocol methods exist with the right
+    async/non-async shape.
+  - ``start_session`` happy path: with ``OPENAI_API_KEY`` set, returns a
+    ``SessionHandle`` whose ``provider_state["openai_client_secret"]`` is
+    populated. The httpx POST is mocked — no network in CI.
+  - ``start_session`` degraded path: without ``OPENAI_API_KEY``, returns
+    a degraded handle (mirrors the Hybrid provider's graceful-degradation
+    pattern — the broker turns this into a clean error envelope).
+  - Scaffold methods (``push_audio``, ``finalize_utterance``,
+    ``synthesize_speech``) raise ``NotImplementedError("E2 — broker
+    integration")``. The exact message is a contract for the #645 reviewer.
+  - ``_select_provider`` routing for ``REALTIME_VOICE_PROVIDER=openai``,
+    including the fallback chain when ``OPENAI_API_KEY`` is missing.
+  - Audio bytes never reach disk (the existing project-wide invariant,
+    repeated for the new provider).
+  - Importing the module does NOT construct an OpenAI client at import
+    time (lazy httpx use inside ``start_session``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import builtins
+import inspect
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.src.services import realtime_voice_service as rtvs
+from backend.src.services.realtime_voice_service import (
+    HybridRealtimeVoiceProvider,
+    MockRealtimeVoiceProvider,
+    OPENAI_REALTIME_CLIENT_SECRETS_URL,
+    OPENAI_REALTIME_MODEL_DEFAULT,
+    OPENAI_REALTIME_MODEL_ESCALATED,
+    OpenAIRealtimeProvider,
+    SessionHandle,
+    _select_provider,
+)
+
+
+# ---------------------- Protocol shape -------------------------------------
+
+class TestProtocolShape:
+    """OpenAIRealtimeProvider satisfies the RealtimeVoiceProvider Protocol."""
+
+    def test_provider_has_required_attributes(self):
+        provider = OpenAIRealtimeProvider()
+        assert provider.name == "openai_realtime"
+        for method in (
+            "start_session", "push_audio", "finalize_utterance",
+            "synthesize_speech", "close",
+        ):
+            assert hasattr(provider, method), f"missing {method}"
+
+    def test_async_methods_are_coroutine_functions(self):
+        provider = OpenAIRealtimeProvider()
+        # Mirror the Protocol exactly: start_session/push_audio/
+        # finalize_utterance/close are async; synthesize_speech returns
+        # an AsyncIterator (the Mock/Hybrid both `async def` it).
+        assert inspect.iscoroutinefunction(provider.start_session)
+        assert inspect.iscoroutinefunction(provider.push_audio)
+        assert inspect.iscoroutinefunction(provider.finalize_utterance)
+        assert inspect.iscoroutinefunction(provider.close)
+        # synthesize_speech: the existing providers declare it `async def`
+        # returning an AsyncIterator, so we conform to that shape.
+        assert inspect.iscoroutinefunction(provider.synthesize_speech)
+
+    def test_module_exposes_constants(self):
+        assert OPENAI_REALTIME_MODEL_DEFAULT == "gpt-realtime-mini"
+        assert OPENAI_REALTIME_MODEL_ESCALATED == "gpt-realtime-2"
+        assert OPENAI_REALTIME_CLIENT_SECRETS_URL == (
+            "https://api.openai.com/v1/realtime/client_secrets"
+        )
+
+
+# ---------------------- start_session happy path ---------------------------
+
+class _FakeHttpxResponse:
+    """Mimic enough of httpx.Response for the provider's path."""
+
+    def __init__(self, *, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"http {self.status_code}")
+
+
+class _FakeAsyncClient:
+    """Drop-in for httpx.AsyncClient used as an async context manager."""
+
+    last_post_args = None  # captured for assertions
+
+    def __init__(self, *args, **kwargs):
+        # Record construction kwargs so tests can assert on timeout etc.
+        type(self).last_init_kwargs = kwargs
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, **kwargs):
+        type(self).last_post_args = {"url": url, **kwargs}
+        return _FakeHttpxResponse(
+            status_code=200,
+            json_data={
+                "value": "ek_test_abc123",
+                "expires_at": 1_900_000_000,
+            },
+        )
+
+
+class TestStartSessionHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_handle_with_client_secret(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        # Patch httpx.AsyncClient where the provider imports it.
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u1", child_id="c1", target_age=7,
+        )
+
+        assert isinstance(handle, SessionHandle)
+        assert handle.session_id.startswith("voice_openai_")
+        assert handle.user_id == "u1"
+        assert handle.child_id == "c1"
+        assert handle.target_age == 7
+        assert handle.persona == "buddy_default"
+        # Load-bearing: the ephemeral client secret is populated.
+        assert handle.provider_state["openai_client_secret"] == "ek_test_abc123"
+        assert handle.provider_state["model"] == OPENAI_REALTIME_MODEL_DEFAULT
+        assert handle.provider_state["expires_at"] == 1_900_000_000
+
+    @pytest.mark.asyncio
+    async def test_post_targets_client_secrets_endpoint(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+
+        provider = OpenAIRealtimeProvider()
+        await provider.start_session(
+            user_id="u1", child_id="c1", target_age=7,
+        )
+
+        post_args = _FakeAsyncClient.last_post_args
+        assert post_args is not None
+        assert post_args["url"] == OPENAI_REALTIME_CLIENT_SECRETS_URL
+        # Authorization header carries the bearer token.
+        headers = post_args.get("headers", {})
+        assert headers.get("Authorization") == "Bearer sk-test-key"
+        # Body includes the model — cost-guardrail default.
+        body = post_args.get("json", {})
+        # Body shape per OpenAI docs: { "session": { "type": "realtime", ... } }
+        session_body = body.get("session", body)
+        assert session_body.get("model") == OPENAI_REALTIME_MODEL_DEFAULT
+
+    @pytest.mark.asyncio
+    async def test_unique_session_ids(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+
+        provider = OpenAIRealtimeProvider()
+        h1 = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        h2 = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        assert h1.session_id != h2.session_id
+
+
+# ---------------------- start_session degraded -----------------------------
+
+class TestStartSessionDegraded:
+    """Without OPENAI_API_KEY, the provider returns a degraded handle.
+
+    Design choice (documented here): we mirror the Hybrid provider's
+    graceful-degradation pattern — never raise from start_session. The
+    handle has an empty/missing client secret and a flag the broker can
+    inspect to translate into VoiceWSErrorEvent(code="provider_unavailable").
+    Raising would force the broker to wrap every start_session call in a
+    try/except; the envelope pattern is uniform across providers.
+    """
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_returns_degraded_handle(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        assert isinstance(handle, SessionHandle)
+        # Degraded shape: no client secret, explicit unavailable flag.
+        assert handle.provider_state.get("openai_client_secret") in (None, "")
+        assert handle.provider_state.get("provider_unavailable") is True
+
+    @pytest.mark.asyncio
+    async def test_degraded_start_does_not_hit_network(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # Booby-trap the httpx client — if the provider tries to construct
+        # it, the test fails loudly.
+        class _ExplodingClient:
+            def __init__(self, *_a, **_k):
+                raise AssertionError("provider hit network in degraded mode")
+
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _ExplodingClient)
+
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        assert handle.provider_state.get("provider_unavailable") is True
+
+
+# ---------------------- Scaffold NotImplementedError -----------------------
+
+_E2_MESSAGE = "E2 — broker integration"
+
+
+class TestScaffoldNotImplemented:
+    """The scaffold methods raise NotImplementedError with an exact string.
+
+    The string is a contract for the #645 (E2) reviewer — they'll grep
+    for this message and replace each call site with the real upstream
+    WebSocket forwarding.
+    """
+
+    @pytest.mark.asyncio
+    async def test_push_audio_raises(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        with pytest.raises(NotImplementedError) as ei:
+            await provider.push_audio(handle, b"\x00" * 64)
+        assert str(ei.value) == _E2_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_finalize_utterance_raises(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        with pytest.raises(NotImplementedError) as ei:
+            await provider.finalize_utterance(handle)
+        assert str(ei.value) == _E2_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_synthesize_speech_raises(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        with pytest.raises(NotImplementedError) as ei:
+            await provider.synthesize_speech(handle, "hello buddy")
+        assert str(ei.value) == _E2_MESSAGE
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        # close logic lands in E2 with the upstream WS lifecycle; here
+        # it must be a benign no-op (does not raise).
+        await provider.close(handle)
+
+
+# ---------------------- _select_provider routing ---------------------------
+
+class TestSelectProviderRouting:
+    def test_openai_env_with_api_key_returns_openai_provider(self, monkeypatch):
+        monkeypatch.setenv("REALTIME_VOICE_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        chosen = _select_provider()
+        assert isinstance(chosen, OpenAIRealtimeProvider)
+        assert chosen.name == "openai_realtime"
+
+    def test_openai_env_without_api_key_falls_back_to_hybrid(self, monkeypatch):
+        # Fallback chain: openai -> hybrid -> mock. Without OPENAI_API_KEY
+        # the OpenAI provider can't mint a secret, so we fall back to
+        # Hybrid (which itself degrades internally if its keys are missing).
+        monkeypatch.setenv("REALTIME_VOICE_PROVIDER", "openai")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        chosen = _select_provider()
+        assert isinstance(chosen, HybridRealtimeVoiceProvider)
+        assert chosen.name == "hybrid"
+
+    def test_hybrid_env_still_returns_hybrid_no_regression(self, monkeypatch):
+        monkeypatch.setenv("REALTIME_VOICE_PROVIDER", "hybrid")
+        chosen = _select_provider()
+        assert isinstance(chosen, HybridRealtimeVoiceProvider)
+
+    def test_mock_env_still_returns_mock_no_regression(self, monkeypatch):
+        monkeypatch.setenv("REALTIME_VOICE_PROVIDER", "mock")
+        chosen = _select_provider()
+        assert isinstance(chosen, MockRealtimeVoiceProvider)
+
+    def test_unset_env_respects_existing_default(self, monkeypatch):
+        # Existing default: no env + no OPENAI_API_KEY = Mock.
+        monkeypatch.delenv("REALTIME_VOICE_PROVIDER", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        chosen = _select_provider()
+        assert chosen.name == "mock"
+
+
+# ---------------------- No disk persistence --------------------------------
+
+class TestNoDiskPersistence:
+    """Audio bytes (and provider state) never reach disk."""
+
+    @pytest.mark.asyncio
+    async def test_start_session_never_writes_to_disk(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setattr(rtvs, "_httpx_AsyncClient", _FakeAsyncClient)
+
+        write_bytes_calls: list[str] = []
+        named_temp_calls: list[tuple] = []
+        open_write_calls: list[tuple[str, str]] = []
+
+        original_write_bytes = Path.write_bytes
+        original_named_temp = tempfile.NamedTemporaryFile
+        original_open = builtins.open
+
+        def spy_write_bytes(self, *args, **kwargs):
+            write_bytes_calls.append(str(self))
+            return original_write_bytes(self, *args, **kwargs)
+
+        def spy_named_temp(*args, **kwargs):
+            named_temp_calls.append((args, kwargs))
+            return original_named_temp(*args, **kwargs)
+
+        def spy_open(file, mode="r", *args, **kwargs):
+            if any(c in mode for c in ("w", "a", "x")):
+                open_write_calls.append((str(file), mode))
+            return original_open(file, mode, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "write_bytes", spy_write_bytes)
+        monkeypatch.setattr(tempfile, "NamedTemporaryFile", spy_named_temp)
+        monkeypatch.setattr(builtins, "open", spy_open)
+
+        provider = OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+        )
+        await provider.close(handle)
+
+        assert write_bytes_calls == [], (
+            f"openai provider wrote to disk: {write_bytes_calls}"
+        )
+        assert named_temp_calls == [], (
+            f"openai provider created temp file: {named_temp_calls}"
+        )
+        assert open_write_calls == [], (
+            f"openai provider opened a file for writing: {open_write_calls}"
+        )
+
+
+# ---------------------- Import-time side-effects ---------------------------
+
+class TestNoImportSideEffects:
+    def test_import_does_not_construct_openai_client(self):
+        """The provider class must not instantiate any network client at
+        import time. Constructors are lazy — they run inside ``start_session``
+        only. We re-import the module fresh and confirm the class is
+        present without having touched httpx or the openai SDK."""
+        import importlib
+        import sys
+        # Drop the cached module so the test forces a true re-import.
+        sys.modules.pop("backend.src.services.realtime_voice_service", None)
+        mod = importlib.import_module(
+            "backend.src.services.realtime_voice_service"
+        )
+        assert hasattr(mod, "OpenAIRealtimeProvider")
+        # The class itself is importable and constructible without any
+        # network call. Constructing it must not require OPENAI_API_KEY.
+        provider = mod.OpenAIRealtimeProvider()
+        assert provider.name == "openai_realtime"


### PR DESCRIPTION
## Summary

Adds the third `RealtimeVoiceProvider` — `OpenAIRealtimeProvider` — alongside the existing Mock and Hybrid (Whisper + ElevenLabs Flash) providers. This is the **scaffold story** under epic #605: the class exists, conforms to the `RealtimeVoiceProvider` Protocol, and mints an ephemeral OpenAI Realtime client secret via `POST /v1/realtime/client_secrets`. Audio forwarding, tool-call translation, and synthesis stream from the upstream WS land in **E2 (#645)**.

## What landed

- `OpenAIRealtimeProvider` class with `name = "openai_realtime"` implementing all 5 Protocol methods
- `start_session` uses **httpx** (already a project dep) to mint a client secret with the default model `gpt-realtime-mini`
- `push_audio`, `finalize_utterance`, `synthesize_speech` raise `NotImplementedError("E2 — broker integration")` — exact string as a contract for the #645 reviewer to grep
- `close` is a benign no-op (upstream WS lifecycle lands in #645)
- `_select_provider` extended: `REALTIME_VOICE_PROVIDER=openai` -> `OpenAIRealtimeProvider` with fallback chain `openai -> hybrid -> mock` when `OPENAI_API_KEY` is missing
- New constants: `OPENAI_REALTIME_CLIENT_SECRETS_URL`, `OPENAI_REALTIME_MODEL_DEFAULT = "gpt-realtime-mini"`, `OPENAI_REALTIME_MODEL_ESCALATED = "gpt-realtime-2"`
- 19 contract tests in `backend/tests/contracts/test_openai_realtime_provider_contract.py` covering Protocol conformance, mint happy path (mocked httpx), degraded mode, `NotImplementedError` boundaries, `_select_provider` routing, no-disk invariant, and no-import-side-effects

## Design choices

- **Degraded mode = handle, not raise** — mirrors `HybridRealtimeVoiceProvider`. Missing `OPENAI_API_KEY` returns a `SessionHandle` with `provider_state["provider_unavailable"] = True`. The broker (#645) can translate uniformly to a `VoiceWSErrorEvent(code="provider_unavailable")` without wrapping every `start_session` call in try/except.
- **No new deps** — used the httpx client we already have. The full `openai` Python SDK can land in #645 only if the WS plumbing needs it.
- **Default model `gpt-realtime-mini`** — cost guardrail. Escalation to `gpt-realtime-2` is owned by #648 (E5 cost telemetry).
- **Module-level `_httpx_AsyncClient` alias** — gives tests a clean monkeypatch target without polluting the global `httpx` namespace. The class is *imported* at module load but never *constructed* until `start_session` runs.

## Test plan

- [x] `pytest backend/tests/contracts/test_openai_realtime_provider_contract.py -v` — 19/19 green
- [x] `pytest backend/tests/contracts/test_realtime_voice_service_contract.py backend/tests/contracts/test_hybrid_realtime_voice_contract.py backend/tests/contracts/test_voice_broker_contract.py backend/tests/contracts/test_voice_realtime_contract.py backend/tests/contracts/test_voice_ephemeral_token_contract.py backend/tests/contracts/test_voice_session_repository_contract.py` — 86/86 green (no regressions on Mock / Hybrid / broker / REST)
- [x] `python -c "from backend.src.services.realtime_voice_service import OpenAIRealtimeProvider"` — no side effects at import time
- [x] Pre-existing failing contracts (default_child_id, onboarding, safety_prompt, agent_endpoint) confirmed unrelated by re-running against origin/main baseline

## Out of scope (E2 #645 and later)

- Actual upstream OpenAI Realtime WebSocket forwarding
- Tool-definition translation (`launch_flow` -> OpenAI tools schema) → E3
- WebRTC direct mode → E4
- Cost telemetry + tier escalation → E5 (#648)

Fixes #644
Related to #605 (Epic: Talk to Buddy — Realtime Voice)
Unblocks #645 (E2 — broker integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)