### PR TITLE
feat(my-agent): BuddyOrb — audio-reactive voice UI (#651)

### DIFF
--- a/frontend/src/__tests__/components/BuddyOrb.test.ts
+++ b/frontend/src/__tests__/components/BuddyOrb.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Component-level contract tests for BuddyOrb (#651).
+ *
+ * We follow the no-render contract from #635: only exported
+ * class-string maps and computed-style helpers are tested here, never
+ * the React tree. Keeping component tests DOM-less avoids pulling in
+ * @testing-library/react as a dependency and keeps CI fast.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  ORB_FACE_AGE_CEILING,
+  shouldRenderFace,
+  computeOrbInlineStyle,
+} from "@/pages/MyAgentPage/BuddyOrb";
+
+describe("BuddyOrb age-gating contract (#651)", () => {
+  it("renders the face overlay for pre-readers under the age ceiling", () => {
+    expect(shouldRenderFace(3)).toBe(true);
+    expect(shouldRenderFace(5)).toBe(true);
+    expect(shouldRenderFace(ORB_FACE_AGE_CEILING - 1)).toBe(true);
+  });
+
+  it("hides the face for readers at or above the age ceiling", () => {
+    expect(shouldRenderFace(ORB_FACE_AGE_CEILING)).toBe(false);
+    expect(shouldRenderFace(7)).toBe(false);
+    expect(shouldRenderFace(12)).toBe(false);
+  });
+
+  it("hides the face when age is missing (defensive default)", () => {
+    expect(shouldRenderFace(null)).toBe(false);
+    expect(shouldRenderFace(undefined)).toBe(false);
+  });
+
+  it("documents 6 as the cutoff (pre-reader vs reader boundary)", () => {
+    // Lock the magic number so a future refactor surfaces in code review.
+    expect(ORB_FACE_AGE_CEILING).toBe(6);
+  });
+});
+
+describe("BuddyOrb inline style contract (#651)", () => {
+  it("sets width and height to the exact diameter (locks the box for layout)", () => {
+    const style = computeOrbInlineStyle(180);
+    expect(style.width).toBe(180);
+    expect(style.height).toBe(180);
+  });
+
+  it("scales proportionally for the pre-reader hero size", () => {
+    const style = computeOrbInlineStyle(220);
+    expect(style.width).toBe(style.height);
+  });
+});

--- a/frontend/src/__tests__/components/buddyOrbHelpers.test.ts
+++ b/frontend/src/__tests__/components/buddyOrbHelpers.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Contract tests for buddyOrbHelpers (#651).
+ *
+ * Pure helpers backing the BuddyOrb component. Same separation-for-
+ * testability pattern as talkToBuddyHelpers (#618): exhaustively cover
+ * every reducer state, reduced-motion case, and age band so the panel
+ * layer can't drift.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  breathFactor,
+  orbColorForMode,
+  orbDiameterForAge,
+  pickOrbMode,
+  type OrbMode,
+} from "@/pages/MyAgentPage/buddyOrbHelpers";
+import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
+
+const ALL_STATES: VoiceConversationState[] = [
+  "idle",
+  "connecting",
+  "listening",
+  "thinking",
+  "speaking",
+  "interrupted",
+  "ending",
+  "error",
+  "unsupported",
+];
+
+describe("pickOrbMode (#651)", () => {
+  it("returns the matching mode for every reducer state when motion is allowed", () => {
+    for (const state of ALL_STATES) {
+      const mode = pickOrbMode(state, false);
+      // mode must be a string and must be one of the documented orb modes
+      expect(typeof mode).toBe("string");
+      expect(mode.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("preserves state identity for every active reducer state", () => {
+    // Active states map 1:1 to a distinct visual mode — the whole point
+    // of #651 vs the 3-variant Indicator.
+    const stateToMode: Record<VoiceConversationState, OrbMode | "static"> = {
+      idle: "idle",
+      connecting: "connecting",
+      listening: "listening",
+      thinking: "thinking",
+      speaking: "speaking",
+      interrupted: "interrupted",
+      ending: "ending",
+      error: "error",
+      unsupported: "static",
+    };
+    for (const state of ALL_STATES) {
+      expect(pickOrbMode(state, false)).toBe(stateToMode[state]);
+    }
+  });
+
+  it("collapses to a static/idle mode when prefers-reduced-motion is true, regardless of state", () => {
+    for (const state of ALL_STATES) {
+      const mode = pickOrbMode(state, true);
+      // Reduced-motion contract from #618 — always render the same calm
+      // mode so screen-reader users + vestibular-sensitive users get a
+      // stable orb. We accept either "idle" or "static" as the calm mode.
+      expect(["idle", "static"]).toContain(mode);
+    }
+  });
+});
+
+describe("orbDiameterForAge (#651)", () => {
+  it("3-5 (pre-readers) get the hero-sized 220px orb", () => {
+    expect(orbDiameterForAge(3)).toBe(220);
+    expect(orbDiameterForAge(4)).toBe(220);
+    expect(orbDiameterForAge(5)).toBe(220);
+  });
+
+  it("6-8 get the mid-sized 180px orb", () => {
+    expect(orbDiameterForAge(6)).toBe(180);
+    expect(orbDiameterForAge(7)).toBe(180);
+    expect(orbDiameterForAge(8)).toBe(180);
+  });
+
+  it("9-12 get the compact 140px orb (transcript is hero)", () => {
+    expect(orbDiameterForAge(9)).toBe(140);
+    expect(orbDiameterForAge(12)).toBe(140);
+  });
+
+  it("falls back to a sensible default (180) when age is null/undefined", () => {
+    expect(orbDiameterForAge(null)).toBe(180);
+    expect(orbDiameterForAge(undefined)).toBe(180);
+  });
+});
+
+describe("orbColorForMode (#651)", () => {
+  it("error mode uses AMBER classes, never red (research flag: red scares kids)", () => {
+    const palette = orbColorForMode("error");
+    const combined = `${palette.core} ${palette.halo}`;
+    expect(combined).toMatch(/amber/);
+    expect(combined).not.toMatch(/\bred\b/);
+    expect(combined).not.toMatch(/\bbg-red-/);
+  });
+
+  it("listening mode uses a warm green/emerald palette (mic-active)", () => {
+    const palette = orbColorForMode("listening");
+    const combined = `${palette.core} ${palette.halo}`;
+    expect(combined).toMatch(/emerald|green/);
+  });
+
+  it("speaking mode uses a violet/purple palette (buddy-active)", () => {
+    const palette = orbColorForMode("speaking");
+    const combined = `${palette.core} ${palette.halo}`;
+    expect(combined).toMatch(/violet|purple/);
+  });
+
+  it("returns non-empty core and halo class strings for every reducer mode", () => {
+    const modes: OrbMode[] = [
+      "idle",
+      "connecting",
+      "listening",
+      "thinking",
+      "speaking",
+      "interrupted",
+      "ending",
+      "error",
+      "static",
+    ];
+    for (const mode of modes) {
+      const palette = orbColorForMode(mode);
+      expect(palette.core.length).toBeGreaterThan(0);
+      expect(palette.halo.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("breathFactor (#651)", () => {
+  it("is deterministic given (t, mode, level)", () => {
+    expect(breathFactor(1000, "listening", 0.5)).toBe(
+      breathFactor(1000, "listening", 0.5),
+    );
+    expect(breathFactor(0, "idle", 0)).toBe(breathFactor(0, "idle", 0));
+  });
+
+  it("is bounded in [0.9, 1.5] across a sweep of inputs", () => {
+    const modes: OrbMode[] = [
+      "idle",
+      "connecting",
+      "listening",
+      "thinking",
+      "speaking",
+      "interrupted",
+      "ending",
+      "error",
+      "static",
+    ];
+    for (const mode of modes) {
+      for (let t = 0; t < 10000; t += 137) {
+        for (const level of [0, 0.25, 0.5, 0.75, 1, 1.5 /* over-1 safety */]) {
+          const f = breathFactor(t, mode, level);
+          expect(f).toBeGreaterThanOrEqual(0.9);
+          expect(f).toBeLessThanOrEqual(1.5);
+        }
+      }
+    }
+  });
+
+  it("idle/connecting still pulse a small heartbeat even when level=0 (orb never looks frozen)", () => {
+    // Sample over a full cycle and check that the value moves — i.e. is
+    // not pinned at exactly 1.0 the whole time.
+    const sampleSet = new Set<number>();
+    for (let t = 0; t < 8000; t += 200) {
+      sampleSet.add(breathFactor(t, "idle", 0));
+    }
+    expect(sampleSet.size).toBeGreaterThan(1);
+    // And the spread is meaningful, not float-noise: max - min >= 0.01
+    const values = Array.from(sampleSet);
+    const spread = Math.max(...values) - Math.min(...values);
+    expect(spread).toBeGreaterThan(0.005);
+  });
+
+  it("speaking with high level pushes the factor above the idle baseline", () => {
+    // At the same t, a louder speaking signal should never be quieter
+    // than idle-with-no-level — the orb must visibly react to volume.
+    const idleVal = breathFactor(500, "idle", 0);
+    const loudVal = breathFactor(500, "speaking", 1);
+    expect(loudVal).toBeGreaterThanOrEqual(idleVal);
+  });
+
+  it("static mode (reduced-motion fallback) is pinned at exactly 1.0", () => {
+    for (let t = 0; t < 5000; t += 250) {
+      expect(breathFactor(t, "static", 0.5)).toBe(1.0);
+    }
+  });
+});

--- a/frontend/src/hooks/useVoiceConversation.ts
+++ b/frontend/src/hooks/useVoiceConversation.ts
@@ -78,6 +78,14 @@ export interface UseVoiceConversationResult {
   partialTranscript: string;
   assistantText: string;
   inputLevel: number;
+  /**
+   * RMS-derived TTS output level 0..1 (#651). Mirrors `inputLevel` but
+   * is sourced from the AnalyserNode wired between the assistant audio
+   * element and the AudioContext destination. Used by BuddyOrb to drive
+   * the speaking animation. Stays at 0 in environments without the Web
+   * Audio API (test/SSR) or when no TTS is currently playing.
+   */
+  outputLevel: number;
   sessionId: string | null;
 }
 
@@ -120,6 +128,7 @@ export function useVoiceConversation(
   const [partialTranscript, setPartialTranscript] = useState("");
   const [assistantText, setAssistantText] = useState("");
   const [inputLevel, setInputLevel] = useState(0);
+  const [outputLevel, setOutputLevel] = useState(0);
   const [sessionId, setSessionId] = useState<string | null>(null);
 
   const stateRef = useRef<VoiceConversationState>("idle");
@@ -132,6 +141,13 @@ export function useVoiceConversation(
   const analyserRef = useRef<AnalyserNode | null>(null);
   const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const rafRef = useRef<number | null>(null);
+  // Output-side analyser (#651): the assistant's TTS audio element fed
+  // through createMediaElementSource → AnalyserNode → destination. RMS
+  // from this analyser becomes `outputLevel` so the BuddyOrb can react
+  // to the buddy talking, not just the kid talking.
+  const outputAnalyserRef = useRef<AnalyserNode | null>(null);
+  const outputSourceRef = useRef<MediaElementAudioSourceNode | null>(null);
+  const outputRafRef = useRef<number | null>(null);
   const audioElementRef = useRef<HTMLAudioElement | null>(null);
   const blobUrlRef = useRef<string | null>(null);
   const ttsChunksRef = useRef<Uint8Array[]>([]);
@@ -169,6 +185,14 @@ export function useVoiceConversation(
       try { cancelAnimationFrame(rafRef.current); } catch { /* ignore */ }
       rafRef.current = null;
     }
+  }, []);
+
+  const stopOutputAnalyserLoop = useCallback(() => {
+    if (outputRafRef.current != null) {
+      try { cancelAnimationFrame(outputRafRef.current); } catch { /* ignore */ }
+      outputRafRef.current = null;
+    }
+    setOutputLevel(0);
   }, []);
 
   const stopRecorder = useCallback(() => {
@@ -215,11 +239,15 @@ export function useVoiceConversation(
     if (ctx) {
       try { analyserRef.current?.disconnect(); } catch { /* ignore */ }
       try { sourceRef.current?.disconnect(); } catch { /* ignore */ }
+      try { outputAnalyserRef.current?.disconnect(); } catch { /* ignore */ }
+      try { outputSourceRef.current?.disconnect(); } catch { /* ignore */ }
       ctx.close().catch(() => { /* ignore */ });
     }
     audioCtxRef.current = null;
     analyserRef.current = null;
     sourceRef.current = null;
+    outputAnalyserRef.current = null;
+    outputSourceRef.current = null;
   }, []);
 
   const closeWebSocket = useCallback((code: number = 1000, reason = "") => {
@@ -232,6 +260,7 @@ export function useVoiceConversation(
 
   const teardown = useCallback(() => {
     stopAnalyserLoop();
+    stopOutputAnalyserLoop();
     stopRecorder();
     stopStream();
     stopPlayback();
@@ -241,7 +270,7 @@ export function useVoiceConversation(
     lastSpeechAtRef.current = null;
     firstAboveAtRef.current = null;
     sentVadEndRef.current = false;
-  }, [stopAnalyserLoop, stopRecorder, stopStream, stopPlayback, closeAudioContext, closeWebSocket]);
+  }, [stopAnalyserLoop, stopOutputAnalyserLoop, stopRecorder, stopStream, stopPlayback, closeAudioContext, closeWebSocket]);
 
   useEffect(() => () => teardown(), [teardown]);
 
@@ -252,6 +281,43 @@ export function useVoiceConversation(
       const last = lastTtsChunkAtRef.current ?? now;
       if (now - last >= TTS_END_QUIET_WINDOW_MS) send({ type: "ttsEnd" });
     }, TTS_END_QUIET_WINDOW_MS + 50);
+  }
+
+  function startOutputAnalyserLoop() {
+    const analyser = outputAnalyserRef.current;
+    if (!analyser) return;
+    const buf = new Uint8Array(analyser.fftSize);
+    const tick = () => {
+      const a = outputAnalyserRef.current;
+      if (!a) return;
+      a.getByteTimeDomainData(buf);
+      const rms = computeRms(buf);
+      setOutputLevel(rms);
+      outputRafRef.current = requestAnimationFrame(tick);
+    };
+    outputRafRef.current = requestAnimationFrame(tick);
+  }
+
+  function ensureOutputAnalyserWired(audio: HTMLAudioElement) {
+    // Lazy-wire on the first TTS playback so we don't pay the cost on
+    // sessions that never reach speaking. Skip cleanly if Web Audio
+    // isn't available (test env, older browsers).
+    const ctx = audioCtxRef.current;
+    if (!ctx) return;
+    if (outputAnalyserRef.current && outputSourceRef.current) return;
+    try {
+      const source = ctx.createMediaElementSource(audio);
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 512;
+      source.connect(analyser);
+      // Keep audible: also connect through to the destination.
+      analyser.connect(ctx.destination);
+      outputSourceRef.current = source;
+      outputAnalyserRef.current = analyser;
+    } catch {
+      // createMediaElementSource throws if called twice on the same
+      // element — that's fine, we already wired it earlier.
+    }
   }
 
   function playAssembledAudio() {
@@ -266,7 +332,12 @@ export function useVoiceConversation(
     if (!audioElementRef.current) audioElementRef.current = new Audio();
     const audio = audioElementRef.current;
     audio.src = url;
-    audio.onended = () => send({ type: "ttsEnd" });
+    audio.onended = () => {
+      stopOutputAnalyserLoop();
+      send({ type: "ttsEnd" });
+    };
+    ensureOutputAnalyserWired(audio);
+    startOutputAnalyserLoop();
     void audio.play().catch(() => {
       onError?.("network", "Audio playback was blocked by the browser");
     });
@@ -387,6 +458,7 @@ export function useVoiceConversation(
       setPartialTranscript("");
       setAssistantText("");
       setInputLevel(0);
+      setOutputLevel(0);
       send({ type: "start", consentGranted: true });
 
       let response: VoiceSessionStartResponse;
@@ -498,6 +570,7 @@ export function useVoiceConversation(
     setPartialTranscript("");
     setAssistantText("");
     setInputLevel(0);
+    setOutputLevel(0);
     setSessionId(null);
     send({ type: "reset" });
   }, [send, teardown]);
@@ -515,6 +588,7 @@ export function useVoiceConversation(
     partialTranscript,
     assistantText,
     inputLevel,
+    outputLevel,
     sessionId,
   };
 }

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -718,6 +718,7 @@ export default function AgentChatPanel({
           childId={childId}
           persona={agent.agent_name}
           ageGroup={ageGroup}
+          childAge={ageGroupToRepresentativeAge(ageGroup)}
           onClose={() => setIsTalkOpen(false)}
         />
       )}
@@ -733,15 +734,33 @@ export default function AgentChatPanel({
  * Voice transcripts flow into `useAgentChatStore.appendVoiceCaption`
  * so they merge into the same chat history the text panel renders.
  */
+/**
+ * Map an AgeGroup band to a representative numeric age so BuddyOrb
+ * (#651) can pick a diameter + decide whether to render the face
+ * overlay. Our profile model stores the band, not raw age, so this is
+ * a stable midpoint pick: 3-5 → 4 (pre-reader), 6-8 → 7, 9-12 → 10.
+ */
+function ageGroupToRepresentativeAge(
+  ageGroup?: AgeGroup | null,
+): number | null {
+  if (!ageGroup) return null;
+  if (ageGroup === "3-5") return 4;
+  if (ageGroup === "6-8") return 7;
+  if (ageGroup === "9-12") return 10;
+  return null;
+}
+
 function TalkToBuddyContainer({
   childId,
   persona,
   ageGroup,
+  childAge,
   onClose,
 }: {
   childId: string;
   persona: string;
   ageGroup?: AgeGroup | null;
+  childAge?: number | null;
   onClose: () => void;
 }) {
   void ageGroup; // Future: thread per-age TTS preset overrides (Phase C, #608).
@@ -773,6 +792,8 @@ function TalkToBuddyContainer({
       partialTranscript={voice.partialTranscript}
       assistantText={voice.assistantText}
       inputLevel={voice.inputLevel}
+      outputLevel={voice.outputLevel}
+      childAge={childAge}
       prefersReducedMotion={prefersReducedMotion}
       onStart={() => voice.start(true)}
       onEnd={voice.end}

--- a/frontend/src/pages/MyAgentPage/BuddyFace.tsx
+++ b/frontend/src/pages/MyAgentPage/BuddyFace.tsx
@@ -1,0 +1,142 @@
+/**
+ * BuddyFace (#651) — small SVG face overlay for pre-readers (age < 6).
+ *
+ * Five visual states matching the orb mode. Renders inside the orb so
+ * a kid who can't read the status copy still understands what the buddy
+ * is doing. Pure SVG + Tailwind — zero new dependencies.
+ *
+ * Error face is friendly-concerned (slight frown + soft eyes), NOT a
+ * red X. Research flag from the 2026-06 synthesis: red and scary error
+ * iconography distresses children and erodes trust in the buddy.
+ *
+ * The speaking mouth is driven by `outputLevel` so kids see the buddy
+ * "open its mouth" with louder syllables — the headline alive feel.
+ */
+import { motion } from "framer-motion";
+import type { OrbMode } from "./buddyOrbHelpers";
+
+interface BuddyFaceProps {
+  mode: OrbMode;
+  /** 0..1 audio level from the assistant's TTS analyser. */
+  outputLevel: number;
+}
+
+/**
+ * Width of the open-mouth shape in SVG units, derived from outputLevel.
+ * Pure helper exported for testability. Capped so loud peaks don't draw
+ * a mouth wider than the face.
+ */
+export function mouthOpennessFor(outputLevel: number): number {
+  const safe = Math.max(0, Math.min(1, outputLevel));
+  // Min mouth height 2, max 14 — the face viewBox is 60x60.
+  return 2 + 12 * safe;
+}
+
+export function BuddyFace({ mode, outputLevel }: BuddyFaceProps) {
+  const eyesClosed = mode === "thinking";
+  const wideEyes = mode === "listening";
+  const eyeR = wideEyes ? 4.5 : eyesClosed ? 0.6 : 3;
+  // Mouth depends on mode.
+  let mouthEl: JSX.Element;
+  if (mode === "speaking") {
+    const h = mouthOpennessFor(outputLevel);
+    mouthEl = (
+      <motion.ellipse
+        cx={30}
+        cy={42}
+        rx={6}
+        ry={h / 2}
+        fill="#4c1d95"
+        opacity={0.85}
+      />
+    );
+  } else if (mode === "listening") {
+    // Slightly open mouth — "I'm listening".
+    mouthEl = (
+      <ellipse cx={30} cy={42} rx={5} ry={2} fill="#4c1d95" opacity={0.75} />
+    );
+  } else if (mode === "error") {
+    // Friendly concerned — gentle frown, NOT a red X.
+    mouthEl = (
+      <path
+        d="M22 44 Q30 38 38 44"
+        stroke="#92400e"
+        strokeWidth={2.2}
+        strokeLinecap="round"
+        fill="none"
+      />
+    );
+  } else if (mode === "thinking") {
+    // Tiny pursed line — eyes-closed thinking pose.
+    mouthEl = (
+      <line
+        x1={26}
+        y1={42}
+        x2={34}
+        y2={42}
+        stroke="#4c1d95"
+        strokeWidth={2}
+        strokeLinecap="round"
+      />
+    );
+  } else {
+    // idle / connecting / interrupted / ending — gentle smile.
+    mouthEl = (
+      <path
+        d="M22 41 Q30 47 38 41"
+        stroke="#4c1d95"
+        strokeWidth={2.2}
+        strokeLinecap="round"
+        fill="none"
+      />
+    );
+  }
+
+  // Slow blink for idle — runs as a CSS-driven keyframe via framer to
+  // avoid React re-renders per frame.
+  const blink =
+    mode === "idle"
+      ? { ry: [eyeR, 0.5, eyeR] }
+      : { ry: eyeR };
+
+  return (
+    <svg
+      viewBox="0 0 60 60"
+      className="pointer-events-none absolute inset-0 h-full w-full"
+      role="img"
+      aria-label={`Buddy is ${mode}`}
+    >
+      {/* Eyes */}
+      <motion.ellipse
+        cx={22}
+        cy={28}
+        rx={eyeR}
+        ry={eyeR}
+        fill="#312e81"
+        animate={blink}
+        transition={{
+          duration: 0.3,
+          repeat: mode === "idle" ? Infinity : 0,
+          repeatDelay: 3.5,
+        }}
+      />
+      <motion.ellipse
+        cx={38}
+        cy={28}
+        rx={eyeR}
+        ry={eyeR}
+        fill="#312e81"
+        animate={blink}
+        transition={{
+          duration: 0.3,
+          repeat: mode === "idle" ? Infinity : 0,
+          repeatDelay: 3.5,
+        }}
+      />
+      {/* Mouth */}
+      {mouthEl}
+    </svg>
+  );
+}
+
+export default BuddyFace;

--- a/frontend/src/pages/MyAgentPage/BuddyOrb.tsx
+++ b/frontend/src/pages/MyAgentPage/BuddyOrb.tsx
@@ -1,0 +1,202 @@
+/**
+ * BuddyOrb (#651) — audio-reactive voice UI replacing the flat dot
+ * indicator from #618.
+ *
+ * Every reducer state gets a visually distinct motion pattern. Driven
+ * by BOTH `inputLevel` (mic RMS) and `outputLevel` (assistant TTS RMS)
+ * so the orb feels alive whether the kid or the buddy is talking.
+ *
+ * Performance contract:
+ *   - Scale is a `useMotionValue` written from `useAnimationFrame`. NO
+ *     React `setState` per frame — that's the 60Hz perf trap.
+ *   - All overlays (rings, orbiting dots) use Framer's declarative
+ *     animation so they animate via the compositor, not React renders.
+ *
+ * Accessibility:
+ *   - `prefers-reduced-motion` collapses to a static gradient (the
+ *     #618 contract still holds via `pickOrbMode` returning "idle").
+ *   - The face overlay (BuddyFace) only renders for pre-readers (< 6)
+ *     so older kids who can read status copy aren't distracted.
+ */
+import { motion, useAnimationFrame, useMotionValue } from "framer-motion";
+import type { CSSProperties } from "react";
+import {
+  breathFactor,
+  orbColorForMode,
+  orbDiameterForAge,
+  type OrbMode,
+} from "./buddyOrbHelpers";
+import { BuddyFace } from "./BuddyFace";
+
+/**
+ * Age below which we render the BuddyFace overlay. Exported so the
+ * BuddyOrb contract test can lock the magic number — research-anchored
+ * "pre-reader" cutoff matches our 3-5 / 6-8 / 9-12 age band split.
+ */
+export const ORB_FACE_AGE_CEILING = 6;
+
+/**
+ * Pure predicate: should we draw the face? Defensive on null/undefined
+ * so the parent can pass `currentChild?.age` without a guard.
+ */
+export function shouldRenderFace(age?: number | null): boolean {
+  if (age == null) return false;
+  return age < ORB_FACE_AGE_CEILING;
+}
+
+/**
+ * Pure helper for the orb's outer-box inline style — width/height in
+ * px. Exported so the contract test can lock the layout box without
+ * mounting React.
+ */
+export function computeOrbInlineStyle(diameter: number): CSSProperties {
+  return { width: diameter, height: diameter };
+}
+
+export interface BuddyOrbProps {
+  mode: OrbMode;
+  /** Mic RMS, 0..1. Drives the listening animation. */
+  inputLevel: number;
+  /** Assistant TTS RMS, 0..1. Drives the speaking animation. */
+  outputLevel: number;
+  /** Raw child age in years (3..12). Null/undefined → no face overlay. */
+  childAge?: number | null;
+  /** When true, all motion collapses to a static gradient. */
+  prefersReducedMotion?: boolean;
+}
+
+/**
+ * Small overlay: 3 expanding concentric rings that grow + fade. Tied
+ * declaratively to mic level via the `key` so a louder peak restarts
+ * the ring animation faster — kid sees "I heard you".
+ */
+function ExpandingRings({ level }: { level: number }) {
+  // Higher level → faster rings. Bound the duration so quiet input
+  // doesn't render a frozen ring.
+  const duration = 1.6 - Math.min(0.8, level * 0.8);
+  return (
+    <>
+      {[0, 1, 2].map((i) => (
+        <motion.div
+          key={i}
+          className="pointer-events-none absolute inset-0 rounded-full border-2 border-emerald-300/60"
+          initial={{ scale: 1, opacity: 0.7 }}
+          animate={{ scale: 1.6, opacity: 0 }}
+          transition={{
+            duration,
+            repeat: Infinity,
+            ease: "easeOut",
+            delay: i * (duration / 3),
+          }}
+          aria-hidden="true"
+        />
+      ))}
+    </>
+  );
+}
+
+/**
+ * Small overlay: 4 orbiting dots — visually distinct from a spinner.
+ * Research flag: spinners read as "loading", orbiting dots read as
+ * "alive and thinking".
+ */
+function OrbitingDots() {
+  return (
+    <motion.div
+      className="pointer-events-none absolute inset-0"
+      animate={{ rotate: 360 }}
+      transition={{ duration: 3, repeat: Infinity, ease: "linear" }}
+      aria-hidden="true"
+    >
+      {[0, 90, 180, 270].map((deg) => (
+        <div
+          key={deg}
+          className="absolute left-1/2 top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-sky-400 shadow-md"
+          style={{ transform: `rotate(${deg}deg) translate(0,0)` }}
+        />
+      ))}
+    </motion.div>
+  );
+}
+
+export function BuddyOrb({
+  mode,
+  inputLevel,
+  outputLevel,
+  childAge,
+  prefersReducedMotion = false,
+}: BuddyOrbProps) {
+  const diameter = orbDiameterForAge(childAge);
+  const colors = orbColorForMode(mode);
+  const scale = useMotionValue(1);
+
+  // 60Hz audio-reactive loop. We write directly into the motion value;
+  // NEVER call setState here (perf contract from the #651 plan).
+  useAnimationFrame((t) => {
+    if (prefersReducedMotion) {
+      scale.set(1);
+      return;
+    }
+    const level =
+      mode === "speaking"
+        ? outputLevel
+        : mode === "listening"
+          ? inputLevel
+          : 0;
+    scale.set(breathFactor(t, mode, level));
+  });
+
+  const showFace = shouldRenderFace(childAge);
+  const boxStyle = computeOrbInlineStyle(diameter);
+
+  return (
+    <div
+      className="relative flex items-center justify-center"
+      style={boxStyle}
+      aria-hidden={!showFace || undefined}
+    >
+      {/* Outer halo — blurred soft glow that breathes with the orb. */}
+      <motion.div
+        className={`absolute inset-0 rounded-full opacity-60 blur-2xl ${colors.halo}`}
+        style={{ scale }}
+        aria-hidden="true"
+      />
+      {/* Inner core gradient. */}
+      <motion.div
+        className={`absolute inset-2 rounded-full ${colors.core} shadow-lg`}
+        style={{ scale }}
+        aria-hidden="true"
+      />
+      {/* State-distinct overlays. */}
+      {!prefersReducedMotion && mode === "listening" && (
+        <ExpandingRings level={inputLevel} />
+      )}
+      {!prefersReducedMotion && mode === "thinking" && <OrbitingDots />}
+      {/* Interrupted: quick spring pop overlay so the orb visibly
+          "catches" the interruption. */}
+      {!prefersReducedMotion && mode === "interrupted" && (
+        <motion.div
+          key="interrupt"
+          className="pointer-events-none absolute inset-0 rounded-full ring-4 ring-amber-300"
+          initial={{ scale: 1.15, opacity: 0.9 }}
+          animate={{ scale: 0.95, opacity: 0 }}
+          transition={{ duration: 0.12, ease: "easeOut" }}
+          aria-hidden="true"
+        />
+      )}
+      {/* Error: gentle tilt-wobble, AMBER not red, NOT a shake. */}
+      {!prefersReducedMotion && mode === "error" && (
+        <motion.div
+          className="pointer-events-none absolute inset-0"
+          animate={{ rotate: [-3, 3, -3] }}
+          transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
+          aria-hidden="true"
+        />
+      )}
+      {/* Pre-reader face overlay. */}
+      {showFace && <BuddyFace mode={mode} outputLevel={outputLevel} />}
+    </div>
+  );
+}
+
+export default BuddyOrb;

--- a/frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx
@@ -28,9 +28,10 @@ import { motion } from "framer-motion";
 import {
   isEndButtonEnabled,
   isPanelVisible,
-  pickIndicator,
   TALK_PANEL_STATE_COPY,
 } from "./talkToBuddyHelpers";
+import { pickOrbMode } from "./buddyOrbHelpers";
+import { BuddyOrb } from "./BuddyOrb";
 import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
 
 /**
@@ -49,6 +50,10 @@ export interface TalkToBuddyPanelProps {
   assistantText?: string;
   /** RMS-derived mic input level 0..1 for the waveform animation. */
   inputLevel?: number;
+  /** RMS-derived TTS output level 0..1 for the speaking animation (#651). */
+  outputLevel?: number;
+  /** Raw child age in years. When < 6, the BuddyOrb renders the face overlay. */
+  childAge?: number | null;
   prefersReducedMotion?: boolean;
   onStart: () => void;
   onEnd: () => void;
@@ -72,39 +77,13 @@ export const PANEL_WRAPPER_CLASS: Record<TalkToBuddyPanelVariant, string> = {
     "flex flex-col gap-3 rounded-2xl border border-violet-200 bg-violet-50/40 p-3",
 };
 
-function Indicator({
-  variant,
-  level,
-}: {
-  variant: "static" | "pulse-listening" | "pulse-speaking";
-  level: number;
-}) {
-  if (variant === "static") {
-    return (
-      <div
-        className="h-2 w-2 rounded-full bg-primary"
-        aria-hidden="true"
-      />
-    );
-  }
-  const colorClass =
-    variant === "pulse-listening" ? "bg-emerald-500" : "bg-violet-500";
-  const scale = 1 + Math.min(0.4, (level ?? 0) * 0.4);
-  return (
-    <motion.div
-      className={`h-3 w-3 rounded-full ${colorClass}`}
-      animate={{ scale: [1, scale, 1] }}
-      transition={{ duration: 0.8, repeat: Infinity, ease: "easeInOut" }}
-      aria-hidden="true"
-    />
-  );
-}
-
 export function TalkToBuddyPanel({
   state,
   partialTranscript = "",
   assistantText = "",
   inputLevel = 0,
+  outputLevel = 0,
+  childAge = null,
   prefersReducedMotion = false,
   onStart,
   onEnd,
@@ -115,7 +94,7 @@ export function TalkToBuddyPanel({
   if (!isPanelVisible(state)) return null;
 
   const status = TALK_PANEL_STATE_COPY[state];
-  const indicator = pickIndicator(state, prefersReducedMotion);
+  const orbMode = pickOrbMode(state, prefersReducedMotion);
   const endEnabled = isEndButtonEnabled(state);
   const canStart = state === "idle" || state === "error";
 
@@ -159,7 +138,6 @@ export function TalkToBuddyPanel({
     >
       <header className={headerClass}>
         <div className="flex items-center gap-2">
-          <Indicator variant={indicator} level={inputLevel} />
           <h2
             className={
               isInline
@@ -197,6 +175,15 @@ export function TalkToBuddyPanel({
         aria-live="polite"
         aria-atomic="false"
       >
+        <div className={isInline ? "mb-2 flex justify-center" : "mb-4 flex justify-center"}>
+          <BuddyOrb
+            mode={orbMode}
+            inputLevel={inputLevel}
+            outputLevel={outputLevel}
+            childAge={childAge}
+            prefersReducedMotion={prefersReducedMotion}
+          />
+        </div>
         <p
           className={
             isInline

--- a/frontend/src/pages/MyAgentPage/buddyOrbHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/buddyOrbHelpers.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure helpers for BuddyOrb (#651).
+ *
+ * Extracted so reducer-state-to-mode mapping, age-adapted sizing,
+ * color palette, and the audio-reactive scale formula can all be unit-
+ * tested without rendering React. Same separation pattern as
+ * talkToBuddyHelpers (#618) and CameraCapture helpers (#581).
+ *
+ * Design rationale:
+ *   - Mode is the full 8-state reducer enum (plus "static") so each
+ *     reducer state has a distinct visual pattern. The previous
+ *     `pickIndicator` (#618) only had 3 variants, which is why kids
+ *     couldn't tell "thinking" from "listening". This is the #651 win.
+ *   - Error palette is AMBER, not red — research flag from the 2026-06
+ *     synthesis: red faces/colors scare children and read as "punishment".
+ *   - `breathFactor` is a pure sin-based formula so the audio-frame
+ *     callback in BuddyOrb can call it 60Hz without recomputing state.
+ */
+import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
+
+/**
+ * Distinct visual modes for the orb. Mirrors the reducer enum but
+ * adds `"static"` as the reduced-motion fallback so the BuddyOrb's
+ * animation loop has a single sentinel to check.
+ */
+export type OrbMode =
+  | "idle"
+  | "connecting"
+  | "listening"
+  | "thinking"
+  | "speaking"
+  | "interrupted"
+  | "ending"
+  | "error"
+  | "static";
+
+/**
+ * Map the reducer state to the orb's visual mode.
+ *
+ * Reduced-motion users always get `"idle"` (a calm static gradient).
+ * The terminal `"unsupported"` state also collapses to `"static"` — the
+ * panel never mounts in that state but we still want a defined return.
+ */
+export function pickOrbMode(
+  state: VoiceConversationState,
+  prefersReducedMotion: boolean,
+): OrbMode {
+  if (prefersReducedMotion) return "idle";
+  if (state === "unsupported") return "static";
+  // Every other reducer state maps 1:1 to the orb mode of the same name.
+  return state;
+}
+
+/**
+ * Age-adapted orb diameter in pixels.
+ *
+ * 3-5 → 220 (orb is the hero; transcript is secondary)
+ * 6-8 → 180 (balanced)
+ * 9-12 → 140 (transcript is the hero; orb is a comfort indicator)
+ *
+ * Defaults to 180 when age is unknown — safe middle ground that won't
+ * dominate the layout for an unknown reader yet stays readable.
+ */
+export function orbDiameterForAge(age?: number | null): number {
+  if (age == null) return 180;
+  if (age < 6) return 220;
+  if (age < 9) return 180;
+  return 140;
+}
+
+/**
+ * Tailwind class strings for the orb's core gradient and outer halo.
+ *
+ * Error uses AMBER (warm warning) instead of red (research flag: red
+ * scares kids and reads as punishment). Idle/connecting share a calm
+ * indigo so the transition into listening (green) feels like waking up.
+ */
+export function orbColorForMode(mode: OrbMode): {
+  core: string;
+  halo: string;
+} {
+  switch (mode) {
+    case "listening":
+      // Mic-active: warm green. Same hue as the existing pulse-listening
+      // pill so returning users recognize the signal.
+      return {
+        core: "bg-gradient-to-br from-emerald-300 via-emerald-400 to-emerald-500",
+        halo: "bg-emerald-400",
+      };
+    case "thinking":
+      // Buddy-thinking: cool sky-blue. Visually distinct from speaking
+      // (violet) and listening (green) — the "I'm processing" beat.
+      return {
+        core: "bg-gradient-to-br from-sky-300 via-sky-400 to-indigo-500",
+        halo: "bg-sky-400",
+      };
+    case "speaking":
+      // Buddy-talking: violet (matches existing pulse-speaking).
+      return {
+        core: "bg-gradient-to-br from-violet-300 via-violet-400 to-violet-600",
+        halo: "bg-violet-400",
+      };
+    case "interrupted":
+      // Brief flash back toward listening — same green but with a
+      // shorter motion so the panel doesn't feel like it skipped a state.
+      return {
+        core: "bg-gradient-to-br from-emerald-200 via-emerald-400 to-violet-400",
+        halo: "bg-emerald-300",
+      };
+    case "ending":
+      // Fading farewell: dusk pink/orange. Distinct from idle so the
+      // user sees the exhale.
+      return {
+        core: "bg-gradient-to-br from-rose-200 via-rose-300 to-amber-200",
+        halo: "bg-rose-300",
+      };
+    case "error":
+      // AMBER — friendly warning, NOT red.
+      return {
+        core: "bg-gradient-to-br from-amber-200 via-amber-300 to-amber-500",
+        halo: "bg-amber-400",
+      };
+    case "connecting":
+      // Same indigo as idle but slightly brighter to signal "warming up".
+      return {
+        core: "bg-gradient-to-br from-indigo-300 via-indigo-400 to-violet-400",
+        halo: "bg-indigo-400",
+      };
+    case "static":
+    case "idle":
+    default:
+      // Calm resting indigo — the orb at rest.
+      return {
+        core: "bg-gradient-to-br from-indigo-200 via-indigo-300 to-violet-300",
+        halo: "bg-indigo-300",
+      };
+  }
+}
+
+/**
+ * Audio-reactive scale factor for the orb.
+ *
+ * Returns a multiplier in [0.9, 1.5] so the orb breathes around 1.0x.
+ * Pure: same (t, mode, level) → same factor. Safe to call inside
+ * `useAnimationFrame` at 60Hz with no allocations.
+ *
+ * - `static` mode pins at 1.0 (reduced-motion contract).
+ * - `idle`/`connecting` get a slow 0.2 Hz heartbeat even when level=0
+ *   so the orb never looks frozen (acceptance criterion).
+ * - `listening`/`speaking` blend the heartbeat with a level-driven
+ *   boost capped at +0.4 so loud peaks don't shake the layout.
+ * - `interrupted` is a quick pop centered ~120ms (covered by the spring
+ *   animation in BuddyOrb; the scale formula stays gentle).
+ */
+export function breathFactor(t: number, mode: OrbMode, level: number): number {
+  if (mode === "static") return 1.0;
+
+  // Base heartbeat: 0.2 Hz when calm, slightly faster when active.
+  const calmFreq = 0.2; // hz
+  const activeFreq = 0.5; // hz
+  const isActive =
+    mode === "listening" ||
+    mode === "speaking" ||
+    mode === "thinking" ||
+    mode === "interrupted";
+  const freq = isActive ? activeFreq : calmFreq;
+
+  // 2π * f * t/1000 — t is ms from useAnimationFrame.
+  const phase = (2 * Math.PI * freq * t) / 1000;
+  const baseAmp = 0.05; // ±5% breathing baseline
+  const base = 1.0 + baseAmp * Math.sin(phase);
+
+  // Level-reactive boost only for the audio-active modes.
+  let boost = 0;
+  const safeLevel = Math.max(0, Math.min(1, level));
+  if (mode === "listening" || mode === "speaking") {
+    // Cap at +0.4 so the orb scales in [~0.95, 1.45].
+    boost = 0.4 * safeLevel;
+  } else if (mode === "interrupted") {
+    // Slight extra emphasis when interrupted but no audio yet.
+    boost = 0.1;
+  }
+
+  // Clamp the final factor into the documented [0.9, 1.5] range so
+  // callers — and tests — can rely on the bound regardless of inputs.
+  const raw = base + boost;
+  return Math.max(0.9, Math.min(1.5, raw));
+}


### PR DESCRIPTION
## Summary

Replaces the flat 3-variant dot `Indicator` in `TalkToBuddyPanel` with a breathing, audio-reactive **BuddyOrb** that gives every voice-conversation reducer state a visually distinct motion pattern, and is driven by BOTH input (mic RMS) and output (assistant TTS RMS) audio levels. Closes the production UX gap from 2026-06-05 user feedback: kids — especially pre-readers — can now see whether Buddy is listening, thinking, talking, or stuck.

### What changed
- **New** `frontend/src/pages/MyAgentPage/BuddyOrb.tsx` — Framer Motion + Tailwind orb. Uses `useMotionValue` + `useAnimationFrame` (never `setState` in the loop) for the breathing scale. State-distinct overlays: expanding rings (listening), orbiting dots (thinking — NOT a spinner), spring pop (interrupted), gentle tilt-wobble (error).
- **New** `frontend/src/pages/MyAgentPage/BuddyFace.tsx` — SVG face overlay for pre-readers (age < 6). Five visible states; speaking mouth opens with `outputLevel`. Error face is friendly-concerned, NOT a red X.
- **New** `frontend/src/pages/MyAgentPage/buddyOrbHelpers.ts` — pure helpers: `pickOrbMode`, `orbDiameterForAge` (220/180/140), `orbColorForMode` (error → AMBER not red), `breathFactor` (bounded [0.9, 1.5]).
- **Edit** `frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx` — swap `<Indicator>` for `<BuddyOrb>`. New props: `outputLevel`, `childAge`. Existing variant/visibility contracts preserved.
- **Edit** `frontend/src/hooks/useVoiceConversation.ts` — expose `outputLevel`. Wires a second `AnalyserNode` (mirrors the input RMS analyser) between the assistant audio element and `AudioContext.destination`. Lazily attached on first TTS playback; torn down on `end()` / `retry()` / unmount.
- **Edit** `frontend/src/pages/MyAgentPage/AgentChatPanel.tsx` — `TalkToBuddyContainer` threads `outputLevel` and a derived numeric age (mapped from `AgeGroup` mid-band) through to the panel.

### Tests
- 22 new contract tests in `buddyOrbHelpers.test.ts` and `BuddyOrb.test.ts` (RED-first → GREEN). Cover all 8 reducer states, reduced-motion collapse, age-band diameter math, the amber-not-red palette, `breathFactor` determinism + [0.9, 1.5] bound, idle heartbeat still moves at `level=0`, static mode pinned at 1.0, face-overlay age gating.
- All 377 frontend tests pass (was 355). `tsc -b` clean. No new deps.

### Trade-off
The hook still uses `setState` to publish `inputLevel`/`outputLevel` to React consumers — same pattern shipped in #617 — so the values cross the React boundary once per animation frame. The 60Hz perf trap is avoided where it matters most: inside `BuddyOrb`'s own animation loop, which writes a Framer `useMotionValue` directly and never triggers a React render. If profiling later shows the hook-side updates are too chatty, a follow-up can throttle to ~30Hz or switch the hook to emit a `useMotionValue` directly.

### Notes for E2 (#645 — broker integration)
- The output AnalyserNode is wired via `createMediaElementSource(audio)` on the assembled-blob `<audio>` element. When E2 swaps the WS server-relay path for a WebRTC remote track, the output analyser needs to switch to `ctx.createMediaStreamSource(remoteStream)` instead. The hook's `ensureOutputAnalyserWired` is the only call site to touch.
- The `ageGroupToRepresentativeAge` helper in `AgentChatPanel.tsx` is a stopgap — if E2 introduces a richer per-child voice context, please thread raw age through instead of the midpoint pick.

## Test plan
- [x] `npx vitest run` — 377/377 pass
- [x] `npx tsc -b` — clean
- [ ] Manual: start a Talk-to-Buddy session, watch the orb breathe in `idle`, then expand-ring in `listening` (speak), orbit-dot in `thinking`, scale-with-volume in `speaking`. Confirm AMBER (not red) on a forced error. Confirm pre-reader face overlay shows only for age 3-5.
- [ ] Manual: enable OS-level `prefers-reduced-motion` and confirm the orb collapses to a calm static gradient.

Fixes #651
Related to #605 (Epic: Talk to Buddy — Realtime Voice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)