### PR TITLE
feat(my-agent): wire #655 tool calls into #657 broker (end-to-end voice loop)

### DIFF
--- a/backend/src/api/routes/voice_realtime.py
+++ b/backend/src/api/routes/voice_realtime.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import json
 import logging
 import time
 from datetime import datetime, timedelta
@@ -60,6 +61,10 @@ from ...services.realtime_voice_service import (
     SessionHandle,
     _select_provider,
     safety_threshold_for_age,
+)
+from ...services.realtime_voice_tools import (
+    ToolContext,
+    handle_tool_call,
 )
 from ...services.user_service import UserData
 from ...services.voice_ephemeral_token import (
@@ -394,6 +399,87 @@ async def _run_safety_gate(
     return score >= safety_threshold_for_age(target_age)
 
 
+def _age_group_for_target(target_age: int) -> str:
+    """Map the broker's integer ``target_age`` to the age-group enum
+    that tools and prompts expect. Mirrors the band split used in
+    ``realtime_voice_service`` for safety thresholds."""
+    if target_age <= 5:
+        return "3-5"
+    if target_age <= 8:
+        return "6-8"
+    return "9-12"
+
+
+async def _dispatch_function_call(
+    *,
+    websocket: WebSocket,
+    provider: RealtimeVoiceProvider,
+    handle: SessionHandle,
+    target_age: int,
+    ev: Any,  # ReplyEvent — typed via duck-typing to keep the import diamond shallow
+    state: Dict[str, Any],
+) -> None:
+    """Route one model-issued tool call.
+
+    Always pairs the dispatch with a ``function_call_output`` upstream
+    so the model isn't stranded. Envelope ``type`` is the router:
+
+    - ``launch_flow``  → forward as a WS event to the client (existing
+      ``useLaunchFlowNavigation`` consumer); also echo a minimal ack
+      back to the model so its turn settles cleanly.
+    - ``tool_result``  → feed the full payload back to the model as
+      JSON so it can continue the conversation with the lookup result.
+    - ``end_call``     → flag the outer broker loop to close the WS
+      with ``ended_reason="voice_tool_end_call"`` after this turn.
+
+    Tool handlers never raise (per ``realtime_voice_tools`` contract),
+    so any exception caught here is a wiring bug — log loudly and emit
+    an error envelope to the model so the turn doesn't hang.
+    """
+    ctx = ToolContext(
+        user_id=handle.user_id,
+        child_id=handle.child_id,
+        age_group=_age_group_for_target(target_age),
+        session_id=handle.session_id,
+    )
+    try:
+        envelope = await handle_tool_call(ev.name, ev.args, ctx)
+    except Exception as exc:  # defensive — handler contract says never raise
+        logger.exception("[session=%s] tool dispatch crashed: %s", handle.session_id, exc)
+        envelope = {"type": "tool_result", "payload": {"error": f"dispatch_crash:{exc}"}}
+
+    envelope_type = envelope.get("type", "")
+    payload = envelope.get("payload") or {}
+
+    if envelope_type == "launch_flow":
+        # Surface the navigation event to the browser BEFORE acking the
+        # model so the client transition feels in sync with the buddy's
+        # spoken handoff sentence.
+        await _send_event(websocket, {"type": "launch_flow", **payload})
+        ack_output = json.dumps({"status": "launched", "flow_type": payload.get("flow_type")})
+    elif envelope_type == "end_call":
+        # Don't ack the model — we're closing. Just remember to break.
+        state["end_call_requested"] = True
+        state["end_call_reason"] = payload.get("ended_reason") or "voice_tool_end_call"
+        return
+    else:
+        # tool_result (including unknown / error envelopes from the
+        # handler) — feed the whole payload back so the model can
+        # incorporate it into its next turn.
+        ack_output = json.dumps(payload)
+
+    if callable(getattr(provider, "send_function_call_output", None)):
+        try:
+            await provider.send_function_call_output(  # type: ignore[attr-defined]
+                handle, call_id=ev.call_id, output=ack_output,
+            )
+        except Exception as exc:  # pragma: no cover - upstream WS noise
+            logger.warning(
+                "[session=%s] failed to send function_call_output: %s",
+                handle.session_id, exc,
+            )
+
+
 async def _stream_openai_reply(
     *,
     websocket: WebSocket,
@@ -412,6 +498,7 @@ async def _stream_openai_reply(
     text_acc = ""
     audio_buffer: List[bytes] = []
     text_done_seen = False
+    end_call_requested = False
 
     stream = await provider.stream_assistant_reply(handle)  # type: ignore[attr-defined]
     async for ev in stream:
@@ -422,8 +509,30 @@ async def _stream_openai_reply(
             text_done_seen = True
         elif ev.kind == "audio_chunk":
             audio_buffer.append(ev.audio)
+        elif ev.kind == "function_call":
+            # Dispatch the model's tool call. The handler returns a typed
+            # envelope: ``launch_flow`` notifies the client to navigate,
+            # ``tool_result`` feeds extra context back to the model,
+            # ``end_call`` closes the session at the next turn boundary.
+            # Every call MUST be paired with a ``function_call_output``
+            # upstream so the model doesn't hang waiting on it.
+            await _dispatch_function_call(
+                websocket=websocket,
+                provider=provider,
+                handle=handle,
+                target_age=target_age,
+                ev=ev,
+                state=state,
+            )
+            if state.get("end_call_requested"):
+                end_call_requested = True
         elif ev.kind == "response_done":
             break
+
+    # An end_call tool fired during this turn — let the broker's outer
+    # loop close cleanly with the documented ended_reason.
+    if end_call_requested:
+        return
 
     # Run the pre-TTS safety gate on the assembled text. The gate is the
     # load-bearing safeguard — even if the model emitted the full audio
@@ -712,6 +821,13 @@ async def stream_voice_session(websocket: WebSocket) -> None:
                     target_age=target_age,
                     state=state,
                 )
+                # A tool dispatched an end_call envelope this turn —
+                # close cleanly with the dedicated reason so Parent
+                # Dashboard can distinguish kid-initiated voice goodbyes
+                # from network drops.
+                if state.get("end_call_requested"):
+                    termination_reason = "voice_tool_end_call"
+                    return
 
             elif event_type == "client_done":
                 termination_reason = "user_ended"

--- a/backend/src/services/realtime_voice_service.py
+++ b/backend/src/services/realtime_voice_service.py
@@ -582,11 +582,20 @@ class ReplyEvent:
       - ``"text_delta"``     — a partial chunk of the model's text reply
       - ``"text_done"``      — final accumulated reply text (full string)
       - ``"audio_chunk"``    — a chunk of synthesized audio bytes
+      - ``"function_call"``  — the model invoked a tool; the broker should
+        dispatch via ``realtime_voice_tools.handle_tool_call`` and feed the
+        result back via ``send_function_call_output``
       - ``"response_done"``  — the model finished the current response
     """
     kind: str
     text: str = ""
     audio: bytes = b""
+    # Populated when ``kind == "function_call"``. ``call_id`` is the
+    # opaque OpenAI-side identifier the broker echoes back in the
+    # ``function_call_output`` event so the model can correlate.
+    call_id: str = ""
+    name: str = ""
+    args: Dict[str, Any] = field(default_factory=dict)
 
 
 def _build_openai_system_prompt(*, target_age: int, persona: str) -> str:
@@ -625,9 +634,16 @@ def _build_openai_system_prompt(*, target_age: int, persona: str) -> str:
         f"Aim for around {cap} tokens or less. Stop at natural sentence "
         "boundaries — never trail off mid-thought.\n\n"
         "# Tools\n"
-        "Tool calls (launch_flow / delegate_to_specialist) are owned by "
-        "a separate orchestration layer. Do not invoke tools in this "
-        "session — focus on conversation only.\n\n"
+        "You have a small set of tools available. Use them when the "
+        "child asks for something a tool can do — do not announce that "
+        "you are using a tool, just call it:\n"
+        "- launch_image_story / launch_interactive_story / launch_kids_daily — "
+        "open the matching activity. Say one short, age-friendly handoff "
+        "sentence BEFORE calling the tool (e.g. 'Cool, let's do that!').\n"
+        "- recall_memory — look up something the child told you before.\n"
+        "- safety_review_reply — request explicit safety review of "
+        "content you're unsure about; better safe than sorry.\n"
+        "- end_call — politely end the chat when the child says goodbye.\n\n"
         "# Fallback\n"
         "If you are unsure how to respond safely, say: "
         "'Let's pick something different to talk about. What's something "
@@ -824,6 +840,12 @@ class OpenAIRealtimeProvider:
                     # Older websockets API — fall back to __aenter__.
                     upstream_ws = await cm_or_awaitable.__aenter__()
                 # Send the session.update event configuring voice + prompt.
+                # Tools are registered here so the model can call into our
+                # specialist surface (launch_flow / recall_memory / end_call)
+                # without a separate WS round-trip. The model-facing schema
+                # lives in `realtime_voice_tools.get_tool_definitions()`; the
+                # broker dispatches each call back through `handle_tool_call`.
+                from .realtime_voice_tools import get_tool_definitions
                 await upstream_ws.send(json.dumps({
                     "type": "session.update",
                     "session": {
@@ -833,6 +855,7 @@ class OpenAIRealtimeProvider:
                         "input_audio_format": "pcm16",
                         "output_audio_format": "pcm16",
                         "input_audio_transcription": {"model": "whisper-1"},
+                        "tools": get_tool_definitions(),
                     },
                 }))
             except Exception as exc:
@@ -1087,6 +1110,32 @@ class OpenAIRealtimeProvider:
 
         return _gen()
 
+    async def send_function_call_output(
+        self,
+        handle: SessionHandle,
+        *,
+        call_id: str,
+        output: str,
+    ) -> None:
+        """Feed a tool result back to the upstream model.
+
+        OpenAI Realtime requires every function call to be paired with a
+        ``conversation.item.create`` of type ``function_call_output`` and
+        then a ``response.create`` to trigger the model's continuation.
+        Skipping either step leaves the model waiting indefinitely. The
+        broker calls this after dispatching the tool via
+        ``realtime_voice_tools.handle_tool_call``.
+        """
+        await self._send_event(handle, {
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": output,
+            },
+        })
+        await self._send_event(handle, {"type": "response.create"})
+
     async def close(self, handle: SessionHandle) -> None:
         """Tear down the upstream WS cleanly."""
         handle.provider_state["closed"] = True
@@ -1146,6 +1195,25 @@ async def _ev_to_reply_events(ev: Dict[str, Any]) -> AsyncIterator[ReplyEvent]:
         chunk = _extract_audio_delta(ev)
         if chunk:
             yield ReplyEvent(kind="audio_chunk", audio=chunk)
+    elif ev_type == "response.function_call_arguments.done":
+        # The model decided to call one of our tools. Surface it as a
+        # ReplyEvent so the broker can dispatch via the tools module and
+        # echo back via send_function_call_output. Malformed args are
+        # coerced to an empty dict so the dispatcher's error path can
+        # respond rather than crashing the stream.
+        raw_args = ev.get("arguments", "") or "{}"
+        try:
+            parsed_args = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+        except Exception:
+            parsed_args = {}
+        if not isinstance(parsed_args, dict):
+            parsed_args = {}
+        yield ReplyEvent(
+            kind="function_call",
+            call_id=ev.get("call_id", "") or "",
+            name=ev.get("name", "") or "",
+            args=parsed_args,
+        )
     elif ev_type == "response.done":
         yield ReplyEvent(kind="response_done")
 

--- a/backend/tests/contracts/test_voice_tool_calls_glue_contract.py
+++ b/backend/tests/contracts/test_voice_tool_calls_glue_contract.py
@@ -1,0 +1,423 @@
+"""Contract tests for the #655/#657 glue PR — realtime tool calls wired
+end-to-end through the broker.
+
+What this PR locks in:
+
+1. The OpenAI Realtime system prompt no longer tells the model "do not
+   invoke tools" — it lists the available tools instead.
+2. ``session.update`` registers tool definitions on session open.
+3. ``_ev_to_reply_events`` translates ``response.function_call_arguments.done``
+   into a ``ReplyEvent(kind="function_call")``.
+4. ``OpenAIRealtimeProvider.send_function_call_output`` sends the
+   correct two-event sequence (``conversation.item.create`` of type
+   ``function_call_output`` + ``response.create``) to the upstream.
+5. The broker's ``_dispatch_function_call`` routes envelopes by type:
+   - ``launch_flow`` → WS event to client + ack to model
+   - ``tool_result`` → ack to model with full payload
+   - ``end_call`` → flag the outer loop to close with the documented reason
+
+Tests intentionally avoid hitting OpenAI — they exercise the in-process
+seams with mocked WS / provider objects.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.src.services.realtime_voice_service import (
+    OpenAIRealtimeProvider,
+    ReplyEvent,
+    SessionHandle,
+    _ev_to_reply_events,
+)
+
+
+# ---------------------------------------------------------------------------
+# (1) System prompt no longer suppresses tools
+# ---------------------------------------------------------------------------
+
+def test_system_prompt_invites_tool_use():
+    """The model used to be told 'do not invoke tools'. Now we list the
+    available tools so it can actually call them."""
+    from backend.src.services.realtime_voice_service import (
+        _build_openai_system_prompt,
+    )
+    prompt = _build_openai_system_prompt(persona="buddy_default", target_age=7)
+    # Negative: must NOT carry the old suppression line
+    assert "Do not invoke tools" not in prompt
+    assert "do not invoke tools" not in prompt
+    # Positive: must list the load-bearing tools by name
+    for tool_name in (
+        "launch_image_story",
+        "launch_interactive_story",
+        "launch_kids_daily",
+        "recall_memory",
+        "end_call",
+    ):
+        assert tool_name in prompt, f"system prompt is missing {tool_name!r}"
+
+
+# ---------------------------------------------------------------------------
+# (2) session.update registers tool definitions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_session_update_includes_tool_definitions(monkeypatch):
+    """When the upstream WS opens, session.update must carry the full
+    tool definitions list so the model knows what it can call."""
+    from backend.src.services import realtime_voice_service as svc
+
+    # Pretend we have keys + the opt-in flag for the upstream WS path.
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_REALTIME_OPEN_UPSTREAM", "1")
+
+    # Stub the httpx client_secrets POST.
+    fake_resp = SimpleNamespace(
+        json=lambda: {"client_secret": {"value": "ek-test", "expires_at": 9999999999}},
+        raise_for_status=lambda: None,
+    )
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+        async def post(self, *args, **kwargs):
+            return fake_resp
+
+    monkeypatch.setattr(svc, "_httpx_AsyncClient", _FakeAsyncClient)
+
+    # Stub the websockets.connect call so we capture the session.update payload.
+    sent_payloads: List[str] = []
+
+    class _FakeWS:
+        async def send(self, payload: str) -> None:
+            sent_payloads.append(payload)
+
+        async def close(self) -> None:
+            return None
+
+        async def recv(self) -> str:
+            return "{}"
+
+    async def _fake_connect(*args, **kwargs):
+        return _FakeWS()
+
+    # The provider may use websockets.connect or a similar entry — patch
+    # the symbol at module level so we don't need to know which.
+    monkeypatch.setattr(svc, "websockets_connect", _fake_connect, raising=False)
+    # Some implementations import via ``from websockets import connect``;
+    # patch both shapes so the test is robust.
+    import websockets
+    monkeypatch.setattr(websockets, "connect", _fake_connect)
+
+    provider = OpenAIRealtimeProvider()
+    handle = await provider.start_session(
+        user_id="u1", child_id="c1", target_age=7, persona="buddy_default",
+    )
+
+    if handle.provider_state.get("provider_unavailable"):
+        pytest.skip("upstream WS path not exercised in this env")
+
+    # Find the session.update payload among the sent events.
+    updates = [
+        json.loads(p) for p in sent_payloads if "session.update" in p
+    ]
+    assert updates, "session.update was never sent to upstream"
+    session_block = updates[0].get("session") or {}
+    tools = session_block.get("tools")
+    assert isinstance(tools, list), "tools list missing from session.update"
+    assert tools, "tools list is empty — model would not know which tools exist"
+    tool_names = {t.get("name") for t in tools if isinstance(t, dict)}
+    # The six tools E3 (#655) defined.
+    expected = {
+        "launch_image_story",
+        "launch_interactive_story",
+        "launch_kids_daily",
+        "recall_memory",
+        "safety_review_reply",
+        "end_call",
+    }
+    assert expected.issubset(tool_names), (
+        f"missing tools in session.update: {expected - tool_names}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (3) _ev_to_reply_events handles function_call_arguments.done
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ev_to_reply_events_translates_function_call():
+    """An upstream ``response.function_call_arguments.done`` event must
+    surface as a ``function_call`` ReplyEvent carrying call_id, name,
+    and parsed args."""
+    ev = {
+        "type": "response.function_call_arguments.done",
+        "call_id": "call_abc",
+        "name": "launch_image_story",
+        "arguments": json.dumps({"child_id": "c1", "age_group": "6-8"}),
+    }
+    out: List[ReplyEvent] = [r async for r in _ev_to_reply_events(ev)]
+    assert len(out) == 1
+    assert out[0].kind == "function_call"
+    assert out[0].call_id == "call_abc"
+    assert out[0].name == "launch_image_story"
+    assert out[0].args == {"child_id": "c1", "age_group": "6-8"}
+
+
+@pytest.mark.asyncio
+async def test_ev_to_reply_events_function_call_malformed_args_coerces_to_empty():
+    """If the model sends malformed JSON args, the broker must not crash
+    — it gets an empty dict and the handler's error path responds."""
+    ev = {
+        "type": "response.function_call_arguments.done",
+        "call_id": "call_bad",
+        "name": "launch_image_story",
+        "arguments": "{not-json",
+    }
+    out: List[ReplyEvent] = [r async for r in _ev_to_reply_events(ev)]
+    assert len(out) == 1
+    assert out[0].kind == "function_call"
+    assert out[0].args == {}
+
+
+# ---------------------------------------------------------------------------
+# (4) send_function_call_output sends the two-event sequence
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_function_call_output_emits_item_create_then_response_create():
+    """OpenAI Realtime requires every function call to be paired with a
+    function_call_output AND a response.create. Skipping either leaves
+    the model waiting."""
+    provider = OpenAIRealtimeProvider()
+    sent: List[Dict[str, Any]] = []
+
+    class _CapturingWS:
+        async def send(self, payload: str) -> None:
+            sent.append(json.loads(payload))
+
+    handle = SessionHandle(
+        session_id="s1", user_id="u1", child_id="c1",
+        target_age=7, persona="buddy_default",
+        provider_state={"upstream_ws": _CapturingWS()},
+    )
+
+    await provider.send_function_call_output(
+        handle, call_id="call_xyz", output='{"status":"launched"}',
+    )
+
+    assert len(sent) == 2, f"expected 2 upstream events, got {len(sent)}: {sent}"
+    assert sent[0]["type"] == "conversation.item.create"
+    assert sent[0]["item"]["type"] == "function_call_output"
+    assert sent[0]["item"]["call_id"] == "call_xyz"
+    assert sent[0]["item"]["output"] == '{"status":"launched"}'
+    assert sent[1]["type"] == "response.create"
+
+
+@pytest.mark.asyncio
+async def test_send_function_call_output_silent_when_degraded():
+    """A degraded session (no upstream WS) silently drops — the broker
+    must not crash a turn just because the upstream went away."""
+    provider = OpenAIRealtimeProvider()
+    handle = SessionHandle(
+        session_id="s1", user_id="u1", child_id="c1",
+        target_age=7, persona="buddy_default",
+        provider_state={},  # no upstream_ws
+    )
+    # Should not raise.
+    await provider.send_function_call_output(
+        handle, call_id="call_xyz", output="{}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# (5) Broker's _dispatch_function_call routes envelopes correctly
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dispatch_launch_flow_emits_ws_event_and_acks_model(monkeypatch):
+    """When a tool call returns a ``launch_flow`` envelope, the client
+    gets a WS event AND the model gets a function_call_output ack."""
+    from backend.src.api.routes import voice_realtime as broker
+
+    async def _fake_handle_tool_call(name, args, ctx):
+        return {
+            "type": "launch_flow",
+            "payload": {
+                "flow_type": "image_story",
+                "route": "/image-to-story",
+                "prefill": {"child_id": "c1"},
+            },
+        }
+
+    monkeypatch.setattr(broker, "handle_tool_call", _fake_handle_tool_call)
+
+    ws_events: List[Dict[str, Any]] = []
+
+    async def _capture_send_event(ws, event):
+        ws_events.append(event)
+
+    monkeypatch.setattr(broker, "_send_event", _capture_send_event)
+
+    provider = SimpleNamespace(send_function_call_output=AsyncMock())
+    handle = SessionHandle(
+        session_id="s1", user_id="u1", child_id="c1",
+        target_age=7, persona="buddy_default", provider_state={},
+    )
+    state: Dict[str, Any] = {}
+    ev = ReplyEvent(
+        kind="function_call",
+        call_id="call_1",
+        name="launch_image_story",
+        args={"child_id": "c1"},
+    )
+
+    await broker._dispatch_function_call(
+        websocket=object(),
+        provider=provider,
+        handle=handle,
+        target_age=7,
+        ev=ev,
+        state=state,
+    )
+
+    # WS event was emitted with the launch_flow payload merged in.
+    assert any(e.get("type") == "launch_flow" for e in ws_events), (
+        f"no launch_flow WS event emitted; got: {ws_events}"
+    )
+    flow_event = next(e for e in ws_events if e["type"] == "launch_flow")
+    assert flow_event["flow_type"] == "image_story"
+    assert flow_event["route"] == "/image-to-story"
+
+    # Model got an ack.
+    provider.send_function_call_output.assert_awaited_once()
+    call = provider.send_function_call_output.await_args
+    assert call.kwargs["call_id"] == "call_1"
+    ack_payload = json.loads(call.kwargs["output"])
+    assert ack_payload == {"status": "launched", "flow_type": "image_story"}
+
+    # No end_call triggered.
+    assert not state.get("end_call_requested")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_end_call_sets_state_flag_and_skips_ack(monkeypatch):
+    """``end_call`` envelopes flag the outer broker loop to close —
+    no ack is sent because we're closing anyway."""
+    from backend.src.api.routes import voice_realtime as broker
+
+    async def _fake_handle_tool_call(name, args, ctx):
+        return {
+            "type": "end_call",
+            "payload": {"ended_reason": "voice_tool_end_call", "reason": "kid_said_bye"},
+        }
+
+    monkeypatch.setattr(broker, "handle_tool_call", _fake_handle_tool_call)
+    monkeypatch.setattr(broker, "_send_event", AsyncMock())
+
+    provider = SimpleNamespace(send_function_call_output=AsyncMock())
+    handle = SessionHandle(
+        session_id="s1", user_id="u1", child_id="c1",
+        target_age=7, persona="buddy_default", provider_state={},
+    )
+    state: Dict[str, Any] = {}
+
+    await broker._dispatch_function_call(
+        websocket=object(),
+        provider=provider,
+        handle=handle,
+        target_age=7,
+        ev=ReplyEvent(kind="function_call", call_id="cz", name="end_call", args={}),
+        state=state,
+    )
+
+    assert state.get("end_call_requested") is True
+    assert state.get("end_call_reason") == "voice_tool_end_call"
+    provider.send_function_call_output.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_tool_result_acks_with_full_payload(monkeypatch):
+    """Non-launch / non-end envelopes (the ``tool_result`` lane —
+    including handler error envelopes) feed the whole payload back to
+    the model so it can continue the conversation with the lookup."""
+    from backend.src.api.routes import voice_realtime as broker
+
+    payload = {"matches": [{"title": "the dragon story", "id": "story_42"}]}
+
+    async def _fake_handle_tool_call(name, args, ctx):
+        return {"type": "tool_result", "payload": payload}
+
+    monkeypatch.setattr(broker, "handle_tool_call", _fake_handle_tool_call)
+    monkeypatch.setattr(broker, "_send_event", AsyncMock())
+
+    provider = SimpleNamespace(send_function_call_output=AsyncMock())
+    handle = SessionHandle(
+        session_id="s1", user_id="u1", child_id="c1",
+        target_age=7, persona="buddy_default", provider_state={},
+    )
+
+    await broker._dispatch_function_call(
+        websocket=object(),
+        provider=provider,
+        handle=handle,
+        target_age=7,
+        ev=ReplyEvent(
+            kind="function_call", call_id="rm1",
+            name="recall_memory", args={"query": "dragon"},
+        ),
+        state={},
+    )
+
+    provider.send_function_call_output.assert_awaited_once()
+    call = provider.send_function_call_output.await_args
+    assert call.kwargs["call_id"] == "rm1"
+    assert json.loads(call.kwargs["output"]) == payload
+
+
+@pytest.mark.asyncio
+async def test_dispatch_passes_correct_age_group_to_handler(monkeypatch):
+    """The broker pre-binds child_id + age_group into ToolContext — the
+    model can never inject another child's ID by accident."""
+    from backend.src.api.routes import voice_realtime as broker
+
+    captured = {}
+
+    async def _fake_handle_tool_call(name, args, ctx):
+        captured["ctx"] = ctx
+        return {"type": "tool_result", "payload": {}}
+
+    monkeypatch.setattr(broker, "handle_tool_call", _fake_handle_tool_call)
+    monkeypatch.setattr(broker, "_send_event", AsyncMock())
+
+    provider = SimpleNamespace(send_function_call_output=AsyncMock())
+    handle = SessionHandle(
+        session_id="sess_xyz", user_id="user_a", child_id="child_b",
+        target_age=4, persona="buddy_default", provider_state={},
+    )
+
+    await broker._dispatch_function_call(
+        websocket=object(),
+        provider=provider,
+        handle=handle,
+        target_age=4,
+        ev=ReplyEvent(kind="function_call", call_id="c1", name="recall_memory", args={}),
+        state={},
+    )
+
+    ctx = captured["ctx"]
+    assert ctx.user_id == "user_a"
+    assert ctx.child_id == "child_b"
+    assert ctx.age_group == "3-5"  # target_age=4 → 3-5 band
+    assert ctx.session_id == "sess_xyz"


### PR DESCRIPTION
## Summary

E2 ([#657](https://github.com/xenophobed/Demi_Creative/pull/657)) shipped the broker integration. E3 ([#655](https://github.com/xenophobed/Demi_Creative/pull/655)) shipped the tool definitions. They couldn't wire each other up in flight without serial blocking, so this PR closes the loop — after merge, the kid actually sees \`launch_flow\` handoffs from voice mode, recall_memory + safety_review_reply tools work, and \`end_call\` from a kid saying goodbye closes the session with the documented reason.

## Why this PR exists

After #657 landed, the OpenAI system prompt literally said: \"Tool calls are owned by a separate orchestration layer. Do not invoke tools in this session — focus on conversation only.\" Every #655 tool definition was dead code at runtime. This PR is the bridge.

## What it does

### \`realtime_voice_service.py\` (+74 lines)
- **System prompt:** flipped \"Do not invoke tools\" to list the six tools by name + tell the model to speak a short age-friendly handoff sentence before \`launch_*\` calls
- **\`session.update\`:** now includes \`tools: get_tool_definitions()\` so the model sees the surface
- **New \`ReplyEvent\` kind \`function_call\`** with \`call_id\`, \`name\`, \`args\` fields
- **\`_ev_to_reply_events\`** translates \`response.function_call_arguments.done\` → \`function_call\` ReplyEvent. Malformed args coerce to \`{}\` so #655's error envelope path responds rather than crashing the stream.
- **New public method \`OpenAIRealtimeProvider.send_function_call_output\`** — sends the OpenAI-Realtime-mandated two-event sequence (\`conversation.item.create\` of type \`function_call_output\` + \`response.create\`). Skipping either leaves the model waiting.

### \`voice_realtime.py\` (+116 lines)
- **\`_dispatch_function_call\`** routes envelopes per #655's contract:
  - \`launch_flow\` → WS event to client (byte-for-byte parity with text-mode SSE per #655's parity test) + \`{status: \"launched\", flow_type}\` ack to model
  - \`tool_result\` → full payload as JSON ack so the model continues with the lookup
  - \`end_call\` → flag \`state[\"end_call_requested\"]\`; outer loop closes with \`ended_reason=\"voice_tool_end_call\"\`
- **Pre-bound \`ToolContext\`** — \`user_id\` + \`child_id\` come from broker-authenticated session, NEVER from model args. Same kid-safety isolation #655 emphasized.
- **\`_stream_openai_reply\`** consumes \`function_call\` ReplyEvents during the model's turn

### Tests (+349 lines, +10 contract tests)
\`test_voice_tool_calls_glue_contract.py\` locks:
- System prompt no longer suppresses tools + lists tool names
- \`session.update\` carries tool definitions (skip-clean when upstream-WS opt-in env isn't set)
- \`_ev_to_reply_events\` translates function calls; malformed args coerce to \`{}\`
- \`send_function_call_output\` emits both events; silent no-op when degraded
- \`_dispatch_function_call\` routes all three envelope types correctly
- ToolContext is built from broker-authenticated IDs, NOT model args — the security invariant

**All 119 voice-related contract tests pass** (1 skipped on the upstream-WS opt-in env path).

## Trade-offs to flag

- **Extra \`_age_group_for_target\` helper** in \`voice_realtime.py\` mirrors the band split \`realtime_voice_service\` uses for safety thresholds. Keeping these aligned is a minor invariant worth not duplicating long-term — could fold into the service module later.
- **PR is bigger than the original 30-50 line estimate** (+187 prod lines, +349 test lines) because the broker needed both the envelope router AND the two-event upstream ack. The 30-50 line estimate was for the conditional rewrites alone; the test coverage was an explicit asset, not bloat.

## What's still pending

- **\`#608\` (Phase C — \`enabled_skills\`):** \`_validate_enabled_skills_for_voice\` still returns None. Tool registration is unconditional; #608 will pre-filter \`get_tool_definitions()\` per-session once the whitelist policy is defined. No PR-blocking work.
- **\`#647\` (E4 WebRTC):** the tool dispatch lives in \`_stream_openai_reply\`, which runs server-side regardless of transport. When E4 lands, browser-direct WebRTC sessions still need the broker to bridge tool calls (or we'd lose \`launch_flow\` routing).

## Test plan

- [x] \`pytest backend/tests/contracts/test_voice_*.py backend/tests/contracts/test_*realtime_voice*.py\` — all 119 voice tests pass + 1 cleanly skipped
- [x] No regression on Hybrid/Mock provider paths (covered by existing parameterized tests)
- [ ] Manual: smoke-test on /my-agent with \`REALTIME_VOICE_PROVIDER=openai\` — kid says \"let's make a story about a dragon\" → buddy says \"Cool, let's do that!\" → frontend navigates to /image-to-story → buddy speaks the handoff narration before nav

Fixes #605 (wires E2 + E3 together — the user-felt end-to-end voice loop with \`launch_flow\` handoff)
Related to #655, #657
Unblocks #647 (E4 WebRTC), #648 (cost telemetry), #649 (launch prereqs doc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)