### PR TITLE
feat(my-agent): Start Talking header pill + composer swap on AgentChatPanel (#636)

### DIFF
--- a/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
+++ b/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   nextPendingGate,
   pickIndicator,
   shouldShowEntryButton,
+  shouldShowHeaderTalkPill,
   TALK_PANEL_STATE_COPY,
 } from "@/pages/MyAgentPage/talkToBuddyHelpers";
 import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
@@ -172,5 +173,47 @@ describe("nextPendingGate (#620)", () => {
 
   it("treats undefined voice consent as not-granted when mic is true", () => {
     expect(nextPendingGate({ micConsent: true })).toBe("voice");
+  });
+});
+
+describe("shouldShowHeaderTalkPill (#636)", () => {
+  const allGranted = {
+    supportsVoice: true,
+    micConsentGranted: true,
+    voiceConversationConsentGranted: true,
+    hasCurrentChild: true,
+  };
+
+  it("shows the pill when consents + capability are ready and no stream/bubble is active", () => {
+    expect(shouldShowHeaderTalkPill(allGranted, false, false)).toBe(true);
+  });
+
+  it("hides while the chat is streaming a text response", () => {
+    // Pressing Start mid-stream would race the AbortController flow.
+    expect(shouldShowHeaderTalkPill(allGranted, true, false)).toBe(false);
+  });
+
+  it("hides while the inline voice bubble is already open", () => {
+    // The bubble has replaced the composer; a second entry point in
+    // the header would be redundant + confusing.
+    expect(shouldShowHeaderTalkPill(allGranted, false, true)).toBe(false);
+  });
+
+  it("hides when both streaming and talk-open are true (sanity)", () => {
+    expect(shouldShowHeaderTalkPill(allGranted, true, true)).toBe(false);
+  });
+
+  it("delegates capability/consent gating to shouldShowEntryButton", () => {
+    // Any single precondition failure must hide the pill, no matter
+    // what the streaming/talk-open state is.
+    const cases = [
+      { ...allGranted, supportsVoice: false },
+      { ...allGranted, micConsentGranted: false },
+      { ...allGranted, voiceConversationConsentGranted: false },
+      { ...allGranted, hasCurrentChild: false },
+    ];
+    for (const broken of cases) {
+      expect(shouldShowHeaderTalkPill(broken, false, false)).toBe(false);
+    }
   });
 });

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -38,10 +38,13 @@ import useAgentChatStore from "@/store/useAgentChatStore";
 import useChildStore from "@/store/useChildStore";
 import VoiceInputButton from "@/components/common/VoiceInputButton";
 import ParentConsentGate from "@/components/common/ParentConsentGate";
-import TalkToBuddyPanel from "./TalkToBuddyPanel";
+import TalkToBuddyPanel, {
+  type TalkToBuddyPanelVariant,
+} from "./TalkToBuddyPanel";
 import {
   nextPendingGate,
   shouldShowEntryButton,
+  shouldShowHeaderTalkPill,
   type PendingGate,
 } from "./talkToBuddyHelpers";
 import {
@@ -255,7 +258,21 @@ export default function AgentChatPanel({
     [],
   );
   const [isTalkOpen, setIsTalkOpen] = useState(false);
+  const wasTalkOpenRef = useRef(false);
   const [pendingTalkGate, setPendingTalkGate] = useState<PendingGate>(null);
+
+  // #636: when the inline voice bubble unmounts (user tapped End), put
+  // focus back on the textarea so the kid can immediately keep typing
+  // without a second tap. Only fires on the true → false transition so
+  // typing in the textarea between sessions doesn't get stolen.
+  useEffect(() => {
+    if (wasTalkOpenRef.current && !isTalkOpen) {
+      // Defer one tick so the composer form has remounted.
+      const id = setTimeout(() => textareaRef.current?.focus(), 0);
+      return () => clearTimeout(id);
+    }
+    wasTalkOpenRef.current = isTalkOpen;
+  }, [isTalkOpen]);
 
   const talkEntryReady = shouldShowEntryButton({
     supportsVoice: voiceCaps.supported,
@@ -270,6 +287,25 @@ export default function AgentChatPanel({
   // entirely when the browser lacks capabilities or the flag is off.
   const showTalkEntry =
     TALK_TO_BUDDY_ENABLED && voiceCaps.supported && Boolean(currentChild?.child_id);
+
+  // #636: the new "Start Talking" header pill — only when the
+  // capability + consent preconditions are met AND nothing else is
+  // contending for the composer area (no in-flight text stream, no
+  // already-open inline bubble). Truth table locked by
+  // shouldShowHeaderTalkPill's contract tests.
+  const showHeaderStartTalking =
+    TALK_TO_BUDDY_ENABLED &&
+    shouldShowHeaderTalkPill(
+      {
+        supportsVoice: voiceCaps.supported,
+        micConsentGranted: currentChild?.microphone_consent === true,
+        voiceConversationConsentGranted:
+          currentChild?.voice_conversation_consent === true,
+        hasCurrentChild: Boolean(currentChild?.child_id),
+      },
+      isStreaming,
+      isTalkOpen,
+    );
 
   const handleOpenTalk = () => {
     if (talkEntryReady) {
@@ -430,29 +466,33 @@ export default function AgentChatPanel({
               aria-label="Streaming"
             />
           )}
-          {showTalkEntry && (
+          {showHeaderStartTalking && (
             <button
               type="button"
               onClick={handleOpenTalk}
-              disabled={isStreaming}
-              className={
-                talkEntryReady
-                  ? "inline-flex items-center gap-1 rounded-full bg-violet-600 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-violet-700 disabled:opacity-50"
-                  : "inline-flex items-center gap-1 rounded-full border border-violet-300 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-100 disabled:opacity-50"
-              }
-              title={
-                talkEntryReady
-                  ? `Talk to ${agent.agent_name}`
-                  : "Ask a grown-up to turn on voice chat"
-              }
-              aria-label={
-                talkEntryReady
-                  ? `Talk to ${agent.agent_name}`
-                  : "Ask a grown-up to turn on voice chat"
-              }
+              className="inline-flex items-center gap-1 rounded-full bg-violet-600 px-3 py-1.5 text-xs font-bold text-white shadow hover:bg-violet-700"
+              title={`Start talking with ${agent.agent_name}`}
+              aria-label={`Start talking with ${agent.agent_name}`}
             >
               <span aria-hidden="true">💬</span>
-              <span>{talkEntryReady ? "Talk" : "Ask"}</span>
+              <span>Start Talking</span>
+            </button>
+          )}
+          {/* Consents-missing fallback: surface the entry as "Ask"
+              while the per-#633 onboarding banner is unshipped, so the
+              feature stays discoverable for first-run kids. Hidden
+              once consents are granted (the Start Talking pill takes
+              over) and hidden while streaming or the bubble is open. */}
+          {showTalkEntry && !talkEntryReady && !isStreaming && !isTalkOpen && (
+            <button
+              type="button"
+              onClick={handleOpenTalk}
+              className="inline-flex items-center gap-1 rounded-full border border-violet-300 bg-violet-50 px-3 py-1.5 text-xs font-semibold text-violet-700 hover:bg-violet-100"
+              title="Ask a grown-up to turn on voice chat"
+              aria-label="Ask a grown-up to turn on voice chat"
+            >
+              <span aria-hidden="true">💬</span>
+              <span>Ask</span>
             </button>
           )}
           {onConfigure && (
@@ -577,6 +617,18 @@ export default function AgentChatPanel({
         </div>
       )}
 
+      {isTalkOpen ? (
+        <div className="border-t border-gray-100 bg-white px-4 py-3">
+          <TalkToBuddyContainer
+            childId={childId}
+            persona={agent.agent_name}
+            ageGroup={ageGroup}
+            childAge={ageGroupToRepresentativeAge(ageGroup)}
+            variant="inline"
+            onClose={() => setIsTalkOpen(false)}
+          />
+        </div>
+      ) : (
       <form
         className="border-t border-gray-100 bg-white px-4 py-3"
         onSubmit={onSubmit}
@@ -686,6 +738,7 @@ export default function AgentChatPanel({
           )}
         </div>
       </form>
+      )}
       {showMicConsentGate && ageGroup && (
         <ParentConsentGate
           kind="microphone"
@@ -711,15 +764,6 @@ export default function AgentChatPanel({
           childId={childId}
           onGranted={advancePendingGate}
           onDismiss={() => setPendingTalkGate(null)}
-        />
-      )}
-      {isTalkOpen && (
-        <TalkToBuddyContainer
-          childId={childId}
-          persona={agent.agent_name}
-          ageGroup={ageGroup}
-          childAge={ageGroupToRepresentativeAge(ageGroup)}
-          onClose={() => setIsTalkOpen(false)}
         />
       )}
     </section>
@@ -756,12 +800,16 @@ function TalkToBuddyContainer({
   ageGroup,
   childAge,
   onClose,
+  variant = "overlay",
 }: {
   childId: string;
   persona: string;
   ageGroup?: AgeGroup | null;
   childAge?: number | null;
   onClose: () => void;
+  /** When `inline`, the End button also unmounts the bubble (no
+   *  separate X close affordance — see PRD §3.16.5 v2 + #635). */
+  variant?: TalkToBuddyPanelVariant;
 }) {
   void ageGroup; // Future: thread per-age TTS preset overrides (Phase C, #608).
   const appendVoiceCaption = useAgentChatStore((s) => s.appendVoiceCaption);
@@ -786,6 +834,18 @@ function TalkToBuddyContainer({
       ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
       : false;
 
+  // Inline mode collapses End + Close into a single affordance: the
+  // user expects "End" to dismiss the bubble and return the textarea,
+  // not just transition to idle. Audio cleanup still runs via the
+  // hook's useEffect on unmount (#617), so eager close is safe.
+  const handleEnd =
+    variant === "inline"
+      ? () => {
+          voice.end();
+          onClose();
+        }
+      : voice.end;
+
   return (
     <TalkToBuddyPanel
       state={voice.state}
@@ -796,9 +856,10 @@ function TalkToBuddyContainer({
       childAge={childAge}
       prefersReducedMotion={prefersReducedMotion}
       onStart={() => voice.start(true)}
-      onEnd={voice.end}
+      onEnd={handleEnd}
       onRetry={voice.retry}
       onClose={onClose}
+      variant={variant}
     />
   );
 }

--- a/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
@@ -129,3 +129,31 @@ export function nextPendingGate(
   if (!child.voiceConsent) return "voice";
   return null;
 }
+
+/**
+ * Whether the new "Start Talking" header pill in AgentChatPanel should
+ * render (#636). Three conditions, all of them gating:
+ *
+ * 1. Capability + consent + child preconditions are met (delegates to
+ *    `shouldShowEntryButton`).
+ * 2. The chat is not currently streaming a text response — pressing
+ *    Start Talking mid-stream would race the existing AbortController
+ *    flow and create a confusing "buddy is typing AND listening?" state.
+ * 3. The inline voice bubble is not already open — when `isTalkOpen` is
+ *    true, the bubble has replaced the composer and there's no second
+ *    entry point to surface in the header.
+ *
+ * Pure helper so the composer-swap story (#636) can lock the truth
+ * table without mounting AgentChatPanel — same pattern as the entry
+ * button (#618) and the variant CSS (#635).
+ */
+export function shouldShowHeaderTalkPill(
+  preconditions: TalkButtonPreconditions,
+  isStreaming: boolean,
+  isTalkOpen: boolean,
+): boolean {
+  if (!shouldShowEntryButton(preconditions)) return false;
+  if (isStreaming) return false;
+  if (isTalkOpen) return false;
+  return true;
+}


### PR DESCRIPTION
> Replaces [#642](https://github.com/xenophobed/Demi_Creative/pull/642), which GitHub auto-closed when its base branch (`feat/635-talk-to-buddy-inline-variant`) was deleted on the #641 squash-merge. Same branch, rebased onto current main, retargeted to main.

## Summary

The headline UX change from PRD §3.16.5 v2. The old "Talk"/"Ask" pill is replaced with two distinct entry points; tapping "Start Talking" swaps the composer `<form>` for the inline `TalkToBuddyPanel` from #635, so the kid sees their chat history above and just toggles between typing and talking in the same slot.

## What's in the rebase

The original branch (commit `c57f5cc8`) was created off `feat/635-talk-to-buddy-inline-variant`. Since then four PRs have landed on main:
- #641 (inline variant)
- #653 (OpenAIRealtimeProvider scaffold)
- #654 (BuddyOrb audio-reactive UI — introduces `childAge`/`outputLevel` threading through `TalkToBuddyContainer`)
- #657 (OpenAI Realtime broker integration)

Rebase conflict in `AgentChatPanel.tsx`:
- HEAD (post-#654) kept the **overlay**-mode `TalkToBuddyContainer` mount at the bottom of the section (legacy from before #636).
- #636's commit DELETES that overlay mount and replaces it with an **inline** mount inside the composer slot — that's the whole point of the PR.

Resolution: took #636's deletion of the overlay mount (the inline mount is its replacement) and **threaded `childAge={ageGroupToRepresentativeAge(ageGroup)}` through #636's inline mount** so the BuddyOrb from #654 still gets the per-age sizing prop. Without this glue, BuddyOrb would render at its default size on the new composer-slot path.

## Changes

### `talkToBuddyHelpers.ts`
- New pure helper `shouldShowHeaderTalkPill(preconds, isStreaming, isTalkOpen)` — delegates capability/consent to `shouldShowEntryButton`, adds two contextual gates (no streaming, no bubble already open).

### `AgentChatPanel.tsx`
**Header pill:**
- New **"Start Talking"** pill (granted-consent path), gated on `shouldShowHeaderTalkPill(...)`.
- Existing **"Ask"** pill (consents-missing) kept as discovery fallback. The original AC said "hide in favor of #633's onboarding banner," but #633 closed unmerged. Without this fallback, first-run kids without consent would have no entry point. Marked with a comment to remove once #633's replacement ships.

**Composer slot:**
- When `isTalkOpen === true`, the `<form>` unmounts and `<TalkToBuddyContainer variant="inline" childAge={...} .../>` renders in its place.
- Removed the old overlay mount at the bottom of the section — there's now a single canonical mount point.

**End behavior:**
- `TalkToBuddyContainer` accepts `variant?: "overlay" | "inline"` (default `overlay` keeps prior callers working).
- Inline mode collapses End + Close into one tap: `voice.end()` → `onClose()`. Audio cleanup runs on unmount via `useVoiceConversation`'s effect cleanup, so eager close is safe.
- New `useEffect` on `isTalkOpen` restores focus to the textarea on the true → false transition.

### `talkToBuddyHelpers.test.ts` — 5 new contract tests
- Pill shows when all preconditions pass + not streaming + bubble closed
- Pill hides while streaming
- Pill hides while bubble is open
- Pill hides when both flags are true (sanity)
- Pill delegates capability/consent gating

## Acceptance Criteria

- [x] Header pill renders only when `talkEntryReady && !isStreaming && !isTalkOpen`
- [x] Tapping the pill sets `isTalkOpen = true` and unmounts the composer `<form>`; inline bubble mounts in its place
- [x] Ending the bubble unmounts the bubble and re-mounts the composer; textarea regains focus
- [x] Voice transcripts continue to merge into `useAgentChatStore.appendVoiceCaption`
- [x] Pressing Start Talking is impossible while `isStreaming === true` (button hidden)
- [⚠] When consents are missing, header pill is hidden — implemented, with "Ask" fallback retained until #633's replacement ships
- [x] No regression: existing text-chat flow still works
- [x] (NEW from rebase) BuddyOrb's `childAge` prop is threaded through the inline mount

## Test plan

- [x] `npx tsc -b` — clean
- [x] `npx vitest run` — **387 / 387 pass** (5 new contract tests + 376 existing + 6 from intervening landings)
- [ ] Manual on `/my-agent`:
  - Consents granted: header shows "Start Talking" → tap → composer becomes bubble (with age-sized BuddyOrb) → tap End → composer returns with cursor in textarea
  - Mid-stream: pill hidden until assistant finishes
  - Without consents: header shows "Ask" → tap → consent gate flow
  - Resize to mobile width — bubble stays in composer slot

Fixes #636
Related to #605 (Epic: Talk to Buddy — Realtime Voice)
Related to PRD §3.16.5 v2 (landed in #639)

🤖 Generated with [Claude Code](https://claude.com/claude-code)