### PR TITLE
fix: stabilize storage, MCP tools, and resume state

### DIFF
--- a/backend/src/agents/image_to_story_agent.py
+++ b/backend/src/agents/image_to_story_agent.py
@@ -6,6 +6,7 @@ Supports streaming responses to reduce timeouts and improve user experience.
 """
 
 import json
+import inspect
 import os
 from pathlib import Path
 from typing import Any, AsyncGenerator, AsyncIterator, Dict, List, Optional
@@ -190,7 +191,8 @@ async def _search_story_dedup(
     if not child_id or not description:
         return ""
     try:
-        result = await search_similar_stories(
+        result = await _call_mcp_tool(
+            search_similar_stories,
             {
                 "child_id": child_id,
                 "story_description": description,
@@ -215,6 +217,20 @@ Please create a FRESH, DIFFERENT story with a new angle, different plot structur
 """
     except Exception:
         return ""  # Best-effort: proceed without dedup
+
+
+async def _call_mcp_tool(tool_ref: Any, args: Dict[str, Any]) -> Dict[str, Any]:
+    """Invoke an MCP tool, unwrapping SDK tool objects when needed.
+
+    claude_agent_sdk's @tool decorator returns an SdkMcpTool wrapper with a
+    `.handler` coroutine instead of a directly-callable async function.
+    The direct production pipeline must support both shapes.
+    """
+    handler = getattr(tool_ref, "handler", tool_ref)
+    result = handler(args)
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 def _should_use_mock() -> bool:
@@ -695,7 +711,10 @@ async def _direct_stream_image_to_story(
     # Step 1: Vision analysis
     yield {"type": "tool_use", "data": {"tool": "mcp__vision-analysis__analyze_children_drawing", "message": "Analyzing drawing..."}}
 
-    analysis_result = await analyze_children_drawing({"image_path": image_path, "child_age": child_age})
+    analysis_result = await _call_mcp_tool(
+        analyze_children_drawing,
+        {"image_path": image_path, "child_age": child_age},
+    )
     analysis_text = analysis_result.get("content", [{}])[0].get("text", "{}")
     try:
         analysis_data = json.loads(analysis_text)
@@ -827,12 +846,15 @@ Return your response as JSON:
     if art_theme and art_theme != "none":
         yield {"type": "tool_use", "data": {"tool": "mcp__image-style__transform_art_style", "message": "Applying art style..."}}
         try:
-            style_result = await transform_art_style({
-                "image_path": image_path,
-                "theme": art_theme,
-                "child_age": child_age,
-                "session_id": child_id,
-            })
+            style_result = await _call_mcp_tool(
+                transform_art_style,
+                {
+                    "image_path": image_path,
+                    "theme": art_theme,
+                    "child_age": child_age,
+                    "session_id": child_id,
+                },
+            )
             style_text = style_result.get("content", [{}])[0].get("text", "{}")
             style_data = json.loads(style_text)
             styled_image_path = style_data.get("styled_image_path")
@@ -845,13 +867,16 @@ Return your response as JSON:
     if should_generate_audio:
         yield {"type": "tool_use", "data": {"tool": "mcp__tts-generation__generate_story_audio", "message": "Generating audio..."}}
         try:
-            audio_result = await generate_story_audio({
-                "story_text": story_data.get("story", ""),
-                "voice": actual_voice,
-                "speed": audio_speed,
-                "child_age": child_age,
-                "provider": provider or "openai",
-            })
+            audio_result = await _call_mcp_tool(
+                generate_story_audio,
+                {
+                    "story_text": story_data.get("story", ""),
+                    "voice": actual_voice,
+                    "speed": audio_speed,
+                    "child_age": child_age,
+                    "provider": provider or "openai",
+                },
+            )
             audio_text = audio_result.get("content", [{}])[0].get("text", "{}")
             audio_data = json.loads(audio_text)
             audio_path = audio_data.get("audio_path")

--- a/backend/src/api/routes/kids_daily.py
+++ b/backend/src/api/routes/kids_daily.py
@@ -45,6 +45,7 @@ from ...services.models.artifact_models import (
 )
 from ...services.tts_service import generate_multi_speaker_audio
 from ...services.user_service import UserData
+from ...services.storage_adapter import storage
 from ...utils.text import count_words
 from ...paths import AUDIO_DIR, UPLOAD_DIR
 from ..deps import (
@@ -124,16 +125,65 @@ def _is_live_illustration_enabled() -> bool:
     return True
 
 
-def _save_placeholder_illustration(
+async def _store_illustration_asset(
+    filename: str,
+    content: bytes,
+    content_type: str,
+) -> str:
+    """Persist an illustration locally and via the active storage backend."""
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    path = UPLOAD_DIR / filename
+    path.write_bytes(content)
+    return await storage.upload("uploads", filename, content, content_type)
+
+
+async def _save_placeholder_illustration(
     episode_id: str,
     idx: int,
     kid_title: str,
     subtitle: str,
 ) -> str:
     filename = f"kids_daily_{episode_id}_{idx}.svg"
-    path = UPLOAD_DIR / filename
-    path.write_text(_make_placeholder_svg(kid_title, subtitle), encoding="utf-8")
-    return f"/data/uploads/{filename}"
+    svg = _make_placeholder_svg(kid_title, subtitle)
+    return await _store_illustration_asset(
+        filename,
+        svg.encode("utf-8"),
+        "image/svg+xml",
+    )
+
+
+async def get_legacy_kids_daily_svg_for_upload(filename: str) -> str | None:
+    """Rebuild placeholder SVGs for old kids-daily relative upload URLs.
+
+    Older production rows stored `/data/uploads/kids_daily_<episode>_0.svg`
+    without mirroring the file to durable storage. In Supabase-backed prod we
+    can synthesize the same placeholder from persisted episode metadata.
+    """
+    if not filename.startswith("kids_daily_") or not filename.endswith(".svg"):
+        return None
+
+    stem = Path(filename).stem
+    payload = stem.removeprefix("kids_daily_")
+    if "_" not in payload:
+        return None
+
+    episode_id, idx_text = payload.rsplit("_", 1)
+    if not idx_text.isdigit():
+        return None
+
+    story = await story_repo.get_by_id(episode_id)
+    if not story or story.get("story_type") not in {
+        "kids_daily",
+        "morning_show",
+        "news_to_kids",
+    }:
+        return None
+
+    analysis = story.get("analysis", {}) or {}
+    kid_title = analysis.get("kid_title") or "Kids Daily"
+    category = str(analysis.get("category") or "general")
+    subtitle = f"{category.title()} scene {int(idx_text) + 1}"
+    return _make_placeholder_svg(kid_title, subtitle)
 
 
 def _scene_prompt(kid_title: str, topic: str, age_group: str, idx: int) -> str:
@@ -186,8 +236,6 @@ async def _generate_illustrations(
 ) -> List[EpisodeIllustration]:
     count = _illustration_count(age_group)
     animation_types = ["pan", "zoom", "ken_burns"]
-    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
-
     live_enabled = _is_live_illustration_enabled()
     openai_client = None
     if live_enabled and OpenAI is not None:
@@ -239,17 +287,23 @@ async def _generate_illustrations(
                 if item_b64:
                     image_bytes = base64.b64decode(item_b64)
                     filename = f"kids_daily_{episode_id}_{idx}.png"
-                    path = UPLOAD_DIR / filename
-                    path.write_bytes(image_bytes)
-                    generated_url = f"/data/uploads/{filename}"
+                    generated_url = await _store_illustration_asset(
+                        filename,
+                        image_bytes,
+                        "image/png",
+                    )
                 elif item_url:
                     generated_url = str(item_url)
                 else:
                     raise RuntimeError("OpenAI image response did not include image data")
             except Exception:
-                generated_url = _save_placeholder_illustration(episode_id, idx, kid_title, subtitle)
+                generated_url = await _save_placeholder_illustration(
+                    episode_id, idx, kid_title, subtitle
+                )
         else:
-            generated_url = _save_placeholder_illustration(episode_id, idx, kid_title, subtitle)
+            generated_url = await _save_placeholder_illustration(
+                episode_id, idx, kid_title, subtitle
+            )
 
         safe_description = await _safe_illustration_description(description, age_group)
 

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -10,6 +10,7 @@ import os
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
+from pathlib import PurePosixPath
 
 from dotenv import load_dotenv
 
@@ -24,7 +25,7 @@ load_dotenv(_backend_dir / ".env")
 from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from .api.models import ErrorDetail, ErrorResponse, HealthCheckResponse
@@ -40,6 +41,7 @@ from .services.database import db_manager, session_repo
 from .services.database.schema import init_schema, migrate_json_sessions
 from .services.kids_daily_scheduler import daily_drop_scheduler
 from .services.retention_scheduler import retention_scheduler
+from .services.storage_adapter import storage
 
 logger = logging.getLogger(__name__)
 
@@ -337,6 +339,30 @@ if os.getenv("STORAGE_BACKEND", "local").lower() != "supabase":
     app.mount("/data/uploads", StaticFiles(directory=str(UPLOAD_DIR)), name="uploads")
     app.mount("/data/videos", StaticFiles(directory=str(VIDEO_DIR)), name="videos")
     app.mount("/data/styled", StaticFiles(directory=str(STYLED_DIR)), name="styled")
+else:
+
+    @app.get("/data/uploads/{file_path:path}", include_in_schema=False)
+    async def resolve_remote_upload(file_path: str):
+        """Serve legacy relative upload URLs when production storage is remote.
+
+        - Old rows still reference `/data/uploads/...`
+        - New remote files should redirect to the public storage URL
+        - Legacy kids-daily placeholder SVGs are rebuilt from episode metadata
+        """
+        normalized = PurePosixPath(file_path)
+        if normalized.is_absolute() or any(part in {"", ".", ".."} for part in normalized.parts):
+            return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content={"detail": "Not found"})
+
+        filename = normalized.name
+        if filename.startswith("kids_daily_") and filename.endswith(".svg"):
+            from .api.routes.kids_daily import get_legacy_kids_daily_svg_for_upload
+
+            svg = await get_legacy_kids_daily_svg_for_upload(filename)
+            if svg is not None:
+                return Response(content=svg, media_type="image/svg+xml")
+
+        target = await storage.get_url("uploads", normalized.as_posix())
+        return RedirectResponse(url=target, status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
 
 # ============================================================================

--- a/backend/tests/api/test_image_to_story_mcp_tools.py
+++ b/backend/tests/api/test_image_to_story_mcp_tools.py
@@ -1,0 +1,110 @@
+import json
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from backend.src.agents import image_to_story_agent
+
+
+class _FakeMessagesAPI:
+    async def create(self, **_kwargs):
+        payload = {
+            "story": "A brave rabbit found a glowing map and shared the treasure with friends.",
+            "themes": ["friendship"],
+            "concepts": ["sharing"],
+            "moral": "Kindness makes adventures brighter.",
+            "characters": [{"name": "Rabbit", "description": "A brave helper"}],
+        }
+        return SimpleNamespace(
+            content=[SimpleNamespace(text=json.dumps(payload))]
+        )
+
+
+class _FakeAnthropicClient:
+    def __init__(self, *args, **kwargs):
+        self.messages = _FakeMessagesAPI()
+
+
+class _FakeSdkTool:
+    def __init__(self, handler):
+        self.handler = handler
+
+
+@pytest.mark.asyncio
+async def test_direct_stream_pipeline_accepts_sdk_wrapped_mcp_tools(monkeypatch):
+    async def fake_memory_prompt(*args, **kwargs):
+        return ""
+
+    async def fake_story_dedup(*args, **kwargs):
+        return ""
+
+    async def fake_analyze(args):
+        assert args["child_age"] == 7
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "objects": ["rabbit", "map"],
+                            "scene": "forest",
+                            "mood": "curious",
+                            "confidence_score": 0.98,
+                        }
+                    ),
+                }
+            ]
+        }
+
+    async def fake_safety(args):
+        assert args["content_type"] == "story"
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps({"safety_score": 0.96, "passed": True}),
+                }
+            ]
+        }
+
+    monkeypatch.setattr(
+        image_to_story_agent,
+        "analyze_children_drawing",
+        _FakeSdkTool(fake_analyze),
+    )
+    monkeypatch.setattr(
+        image_to_story_agent,
+        "check_content_safety",
+        _FakeSdkTool(fake_safety),
+    )
+    monkeypatch.setattr(
+        image_to_story_agent,
+        "get_story_memory_prompt",
+        fake_memory_prompt,
+    )
+    monkeypatch.setattr(
+        image_to_story_agent,
+        "_search_story_dedup",
+        fake_story_dedup,
+    )
+
+    fake_anthropic = ModuleType("anthropic")
+    fake_anthropic.AsyncAnthropic = _FakeAnthropicClient
+    monkeypatch.setitem(sys.modules, "anthropic", fake_anthropic)
+
+    events = []
+    async for event in image_to_story_agent._direct_stream_image_to_story(
+        image_path="/tmp/fake-image.png",
+        child_id="child-123",
+        child_age=7,
+        interests=["adventure"],
+        enable_audio=False,
+        art_theme=None,
+    ):
+        events.append(event)
+
+    result_event = next(event for event in events if event["type"] == "result")
+    assert result_event["data"]["story"].startswith("A brave rabbit")
+    assert result_event["data"]["analysis"]["scene"] == "forest"
+    assert result_event["data"]["safety_score"] == 0.96

--- a/backend/tests/api/test_image_to_story_mcp_tools.py
+++ b/backend/tests/api/test_image_to_story_mcp_tools.py
@@ -32,12 +32,31 @@ class _FakeSdkTool:
 
 
 @pytest.mark.asyncio
+async def test_call_mcp_tool_accepts_sdk_wrapped_tool():
+    async def fake_handler(args):
+        assert args == {"value": "demo"}
+        return {"ok": True}
+
+    result = await image_to_story_agent._call_mcp_tool(
+        _FakeSdkTool(fake_handler),
+        {"value": "demo"},
+    )
+
+    assert result == {"ok": True}
+
+
+@pytest.mark.asyncio
 async def test_direct_stream_pipeline_accepts_sdk_wrapped_mcp_tools(monkeypatch):
     async def fake_memory_prompt(*args, **kwargs):
         return ""
 
     async def fake_story_dedup(*args, **kwargs):
         return ""
+
+    async def fake_post_gen_safety(story_text, *args, **kwargs):
+        assert kwargs["content_type"] == "image_story"
+        assert kwargs["age_group"] == "6-8"
+        return story_text, 0.96, False
 
     async def fake_analyze(args):
         assert args["child_age"] == 7
@@ -87,6 +106,11 @@ async def test_direct_stream_pipeline_accepts_sdk_wrapped_mcp_tools(monkeypatch)
         image_to_story_agent,
         "_search_story_dedup",
         fake_story_dedup,
+    )
+    monkeypatch.setattr(
+        image_to_story_agent,
+        "enforce_post_gen_safety",
+        fake_post_gen_safety,
     )
 
     fake_anthropic = ModuleType("anthropic")

--- a/backend/tests/api/test_kids_daily_storage.py
+++ b/backend/tests/api/test_kids_daily_storage.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.src.api.routes import kids_daily
+
+
+@pytest.mark.asyncio
+async def test_generate_illustrations_uploads_placeholder_via_storage(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(kids_daily, "UPLOAD_DIR", tmp_path)
+    monkeypatch.setattr(kids_daily, "_is_live_illustration_enabled", lambda: False)
+
+    async def fake_safe_description(description: str, age_group: str) -> str:
+        assert age_group == "6-8"
+        return description
+
+    storage = SimpleNamespace(
+        upload=AsyncMock(return_value="https://cdn.example.com/uploads/kids_daily_ep-1_0.svg")
+    )
+    monkeypatch.setattr(kids_daily, "_safe_illustration_description", fake_safe_description)
+    monkeypatch.setattr(kids_daily, "storage", storage)
+
+    illustrations = await kids_daily._generate_illustrations(
+        episode_id="ep-1",
+        kid_title="Science Time",
+        topic="science",
+        age_group="6-8",
+    )
+
+    assert len(illustrations) == 1
+    assert illustrations[0].url == "https://cdn.example.com/uploads/kids_daily_ep-1_0.svg"
+    assert (tmp_path / "kids_daily_ep-1_0.svg").exists()
+    storage.upload.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_legacy_kids_daily_svg_rebuilds_from_story_metadata(monkeypatch):
+    monkeypatch.setattr(
+        kids_daily.story_repo,
+        "get_by_id",
+        AsyncMock(
+            return_value={
+                "story_type": "kids_daily",
+                "analysis": {
+                    "kid_title": "Ocean Rescue",
+                    "category": "science",
+                },
+            }
+        ),
+    )
+
+    svg = await kids_daily.get_legacy_kids_daily_svg_for_upload(
+        "kids_daily_713dd9f8-5bef-4ad5-a4b4-bda6ed7f3505_0.svg"
+    )
+
+    assert svg is not None
+    assert "Ocean Rescue" in svg
+    assert "Science scene 1" in svg
+
+
+@pytest.mark.asyncio
+async def test_legacy_kids_daily_svg_returns_none_when_story_missing(monkeypatch):
+    monkeypatch.setattr(
+        kids_daily.story_repo,
+        "get_by_id",
+        AsyncMock(return_value=None),
+    )
+
+    svg = await kids_daily.get_legacy_kids_daily_svg_for_upload(
+        "kids_daily_missing_0.svg"
+    )
+
+    assert svg is None

--- a/frontend/src/__tests__/api/authProvider.test.ts
+++ b/frontend/src/__tests__/api/authProvider.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const signOut = vi.fn()
+const performFullLogout = vi.fn()
+const setLoading = vi.fn()
+
+vi.mock('@/lib/supabase', () => ({
+  __esModule: true,
+  default: {
+    auth: {
+      signOut,
+    },
+  },
+  isSupabaseEnabled: vi.fn(() => true),
+}))
+
+vi.mock('@/utils/logout', () => ({
+  performFullLogout,
+}))
+
+vi.mock('@/store/useAuthStore', () => ({
+  __esModule: true,
+  default: {
+    getState: () => ({
+      setLoading,
+    }),
+  },
+}))
+
+describe('recoverFromFailedBackendSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('signs out Supabase and clears app auth after a 401 backend sync failure', async () => {
+    const { recoverFromFailedBackendSync } = await import('@/providers/AuthProvider')
+
+    signOut.mockResolvedValue(undefined)
+
+    await recoverFromFailedBackendSync({
+      isAxiosError: true,
+      response: { status: 401 },
+    })
+
+    expect(signOut).toHaveBeenCalledTimes(1)
+    expect(performFullLogout).toHaveBeenCalledTimes(1)
+    expect(setLoading).not.toHaveBeenCalled()
+  })
+
+  it('only clears the loading state for non-auth backend sync failures', async () => {
+    const { recoverFromFailedBackendSync } = await import('@/providers/AuthProvider')
+
+    await recoverFromFailedBackendSync({
+      isAxiosError: true,
+      response: { status: 500 },
+    })
+
+    expect(signOut).not.toHaveBeenCalled()
+    expect(performFullLogout).not.toHaveBeenCalled()
+    expect(setLoading).toHaveBeenCalledWith(false)
+  })
+})

--- a/frontend/src/__tests__/api/authService.test.ts
+++ b/frontend/src/__tests__/api/authService.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import apiClient from '@/api/client'
+import { authService } from '@/api/services/authService'
+
+vi.mock('@/api/client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+  },
+  getErrorMessage: vi.fn(),
+}))
+
+describe('authService._syncUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('deduplicates concurrent syncs for the same access token', async () => {
+    const user = {
+      user_id: 'user-1',
+      username: 'demo',
+      email: 'demo@example.com',
+      display_name: 'Demo',
+      avatar_url: null,
+      is_active: true,
+      is_verified: true,
+      role: 'child',
+      membership_tier: 'free',
+      referral_code: 'demo1234',
+      created_at: '2026-04-12T00:00:00.000Z',
+      last_login_at: null,
+    }
+
+    const getSpy = vi
+      .mocked(apiClient.get)
+      .mockResolvedValue({ data: user })
+
+    const firstRequest = authService._syncUser('same-token')
+    const secondRequest = authService._syncUser('same-token')
+
+    await expect(firstRequest).resolves.toEqual(user)
+    await expect(secondRequest).resolves.toEqual(user)
+    expect(getSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries with a fresh request after a failed sync', async () => {
+    const getSpy = vi
+      .mocked(apiClient.get)
+      .mockRejectedValueOnce(new Error('Unauthorized'))
+      .mockResolvedValueOnce({
+        data: {
+          user_id: 'user-2',
+          username: 'demo2',
+          email: 'demo2@example.com',
+          display_name: 'Demo 2',
+          avatar_url: null,
+          is_active: true,
+          is_verified: true,
+          role: 'child',
+          membership_tier: 'free',
+          referral_code: 'demo5678',
+          created_at: '2026-04-12T00:00:00.000Z',
+          last_login_at: null,
+        },
+      })
+
+    await expect(authService._syncUser('retry-token')).rejects.toThrow('Unauthorized')
+    await expect(authService._syncUser('retry-token')).resolves.toMatchObject({
+      user_id: 'user-2',
+    })
+    expect(getSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/__tests__/pages/interactiveStoryPageState.test.ts
+++ b/frontend/src/__tests__/pages/interactiveStoryPageState.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { getInteractiveStoryPageState } from "@/pages/InteractiveStoryPage/pageState";
+
+describe("getInteractiveStoryPageState", () => {
+  it("keeps the page in resuming mode while session data is loading", () => {
+    expect(
+      getInteractiveStoryPageState({
+        isResuming: true,
+        isCompleted: false,
+        hasCurrentSegment: false,
+      }),
+    ).toBe("resuming");
+  });
+
+  it("switches to playing once a segment is available", () => {
+    expect(
+      getInteractiveStoryPageState({
+        isResuming: false,
+        isCompleted: false,
+        hasCurrentSegment: true,
+      }),
+    ).toBe("playing");
+  });
+});

--- a/frontend/src/pages/InteractiveStoryPage/index.tsx
+++ b/frontend/src/pages/InteractiveStoryPage/index.tsx
@@ -29,8 +29,10 @@ import type { AnimationPhase } from "@/types/streaming";
 import ShareToHubModal from "@/components/hub/ShareToHubModal";
 import LoginPrompt from "@/components/common/LoginPrompt";
 import SuggestedThemes from "@/components/common/SuggestedThemes";
-
-type PageState = "setup" | "playing" | "completed";
+import {
+  getInteractiveStoryPageState,
+  type InteractiveStoryPageState,
+} from "./pageState";
 
 const AGE_GROUPS: { value: AgeGroup; label: string; emoji: string }[] = [
   { value: "3-5", label: "3-5 yrs", emoji: "🧒" },
@@ -49,20 +51,11 @@ const STORY_LENGTHS: {
   { value: "unlimited", label: "Endless Adventure", sublabel: "No limit", emoji: "🌟" },
 ];
 
-function InteractiveStoryPage() {
+function InteractiveStoryPageContent() {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const { isAuthenticated } = useAuthStore();
   const { currentChild, defaultChildId } = useChildStore();
   const childId = currentChild?.child_id || defaultChildId;
-
-  if (!isAuthenticated) {
-    return (
-      <div className="max-w-lg mx-auto mt-12">
-        <LoginPrompt feature="play interactive stories" />
-      </div>
-    );
-  }
 
   // Local form state
   const [selectedAge, setSelectedAge] = useState<AgeGroup | null>(
@@ -208,7 +201,7 @@ function InteractiveStoryPage() {
       const timer = setTimeout(() => setIsRevealing(false), 2000);
       return () => clearTimeout(timer);
     }
-  }, [currentSegment?.segment_id, streaming.isStreaming]);
+  }, [currentSegment, streaming.isStreaming]);
 
   // Reset on-demand audio when segment changes
   useEffect(() => {
@@ -241,14 +234,11 @@ function InteractiveStoryPage() {
   }, [isCompleted, triggerConfetti]);
 
   // Determine page state — show setup while resuming/validating
-  const getPageState = (): PageState => {
-    if (isResuming) return "setup";
-    if (isCompleted) return "completed";
-    if (currentSegment) return "playing";
-    return "setup";
-  };
-
-  const pageState = getPageState();
+  const pageState: InteractiveStoryPageState = getInteractiveStoryPageState({
+    isResuming,
+    isCompleted,
+    hasCurrentSegment: !!currentSegment,
+  });
 
   // Toggle interest selection
   const toggleInterest = (interest: string) => {
@@ -683,6 +673,26 @@ function InteractiveStoryPage() {
         </motion.div>
       )}
 
+      {/* Resume loading view */}
+      {pageState === "resuming" && (
+        <motion.div
+          className="space-y-6"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+        >
+          <Card>
+            <StreamingVisualizer
+              phase="connecting"
+              message="Opening your story..."
+              thinkingContent=""
+              layout="card"
+              showParticles={false}
+              showSparkles
+            />
+          </Card>
+        </motion.div>
+      )}
+
       {/* Playing View */}
       {pageState === "playing" && currentSegment && (
         <motion.div
@@ -867,6 +877,20 @@ function InteractiveStoryPage() {
       )}
     </div>
   );
+}
+
+function InteractiveStoryPage() {
+  const { isAuthenticated } = useAuthStore();
+
+  if (!isAuthenticated) {
+    return (
+      <div className="max-w-lg mx-auto mt-12">
+        <LoginPrompt feature="play interactive stories" />
+      </div>
+    );
+  }
+
+  return <InteractiveStoryPageContent />;
 }
 
 export default InteractiveStoryPage;

--- a/frontend/src/pages/InteractiveStoryPage/pageState.ts
+++ b/frontend/src/pages/InteractiveStoryPage/pageState.ts
@@ -1,0 +1,16 @@
+export type InteractiveStoryPageState =
+  | "setup"
+  | "resuming"
+  | "playing"
+  | "completed";
+
+export function getInteractiveStoryPageState(params: {
+  isResuming: boolean;
+  isCompleted: boolean;
+  hasCurrentSegment: boolean;
+}): InteractiveStoryPageState {
+  if (params.isResuming) return "resuming";
+  if (params.isCompleted) return "completed";
+  if (params.hasCurrentSegment) return "playing";
+  return "setup";
+}

--- a/scripts/railway-power.sh
+++ b/scripts/railway-power.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Power on/off the Railway prod service on demand.
+#
+# Usage:
+#   scripts/railway-power.sh up        # bring service online (uses last build, ~30s)
+#   scripts/railway-power.sh down      # take service offline (stops billing for RAM)
+#   scripts/railway-power.sh status    # show current deployment + live URL state
+#   scripts/railway-power.sh window    # idempotent: ensure up if inside WINDOW, down otherwise
+#
+# Schedule example (macOS launchd or crontab):
+#   # weekdays 8pm: up; 10pm: down
+#   0 20 * * 1-5  /path/to/scripts/railway-power.sh up
+#   0 22 * * 1-5  /path/to/scripts/railway-power.sh down
+#
+# Cost note: `down` removes the running container (no RAM billing). `up` redeploys
+# the last successful build with no rebuild step — typical wake time ~20-40s.
+# Build time is only paid on commits, not on power cycles.
+
+set -euo pipefail
+
+# Linked project assumed via `railway link`. Verify with: railway status
+PROJECT_NAME="${RAILWAY_POWER_PROJECT:-kids-creative-backend}"
+SERVICE_NAME="${RAILWAY_POWER_SERVICE:-kids-creative-backend}"
+HEALTH_URL="${RAILWAY_POWER_HEALTH_URL:-https://kids-creative-backend-production.up.railway.app/health}"
+
+# Window mode: hours in 24h local time. Defaults to 20:00-22:00 (8pm-10pm).
+WINDOW_START_HOUR="${RAILWAY_POWER_START_HOUR:-20}"
+WINDOW_END_HOUR="${RAILWAY_POWER_END_HOUR:-22}"
+
+log() { printf '[railway-power] %s\n' "$*" >&2; }
+
+require_link() {
+  if ! railway status >/dev/null 2>&1; then
+    log "ERROR: not linked. Run: railway link --project $PROJECT_NAME"
+    exit 2
+  fi
+}
+
+cmd_up() {
+  require_link
+  log "starting service $SERVICE_NAME ..."
+  railway redeploy --yes --service "$SERVICE_NAME"
+  log "redeploy triggered. polling $HEALTH_URL ..."
+  for i in $(seq 1 60); do
+    code="$(curl -sS -o /dev/null -w '%{http_code}' -m 5 "$HEALTH_URL" || echo 000)"
+    if [ "$code" = "200" ]; then
+      log "service is UP after ${i}0s (HTTP 200)"
+      exit 0
+    fi
+    sleep 10
+  done
+  log "WARNING: service did not return 200 within 10 minutes. Check: railway logs --deployment"
+  exit 1
+}
+
+cmd_down() {
+  require_link
+  log "stopping service $SERVICE_NAME ..."
+  railway down --yes --service "$SERVICE_NAME"
+  log "service stopped. RAM billing paused."
+}
+
+cmd_status() {
+  require_link
+  echo "=== Railway status ==="
+  railway status
+  echo
+  echo "=== Live health check ==="
+  code="$(curl -sS -o /dev/null -w '%{http_code}' -m 5 "$HEALTH_URL" || echo 000)"
+  echo "$HEALTH_URL -> HTTP $code"
+}
+
+cmd_window() {
+  require_link
+  hour="$(date +%H)"
+  hour="${hour#0}" # strip leading zero
+  : "${hour:=0}"
+  if [ "$hour" -ge "$WINDOW_START_HOUR" ] && [ "$hour" -lt "$WINDOW_END_HOUR" ]; then
+    log "inside window ($WINDOW_START_HOUR-$WINDOW_END_HOUR), ensuring UP"
+    cmd_up
+  else
+    log "outside window ($WINDOW_START_HOUR-$WINDOW_END_HOUR), ensuring DOWN"
+    cmd_down
+  fi
+}
+
+case "${1:-}" in
+  up)     cmd_up ;;
+  down)   cmd_down ;;
+  status) cmd_status ;;
+  window) cmd_window ;;
+  *)
+    sed -n '2,18p' "$0"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
Clean up and preserve the useful local work on top of the latest main. This adds durable Kids Daily illustration storage handling, makes the direct image-to-story fallback compatible with SDK-wrapped MCP tools, fixes the interactive story resume loading state, and adds focused frontend auth coverage plus a Railway utility script.

## Changes
- Persist Kids Daily generated/placeholder illustrations through the active storage backend and serve legacy upload URLs for Supabase-backed storage.
- Add SDK MCP tool wrapper handling in the direct image-to-story pipeline.
- Keep interactive story resume in an explicit loading state and move auth gating outside the hook-heavy content component.
- Add frontend auth sync/recovery tests.
- Add `scripts/railway-power.sh` for manual Railway service up/down/status/window operations.

## Test Coverage
| Layer | Tests | Status |
|-------|-------|--------|
| Backend targeted API | `python -m pytest backend/tests/api/test_kids_daily_storage.py backend/tests/api/test_image_to_story_mcp_tools.py -q` | Pass: 5 passed |
| Frontend targeted | `npm --prefix frontend test -- src/__tests__/pages/interactiveStoryPageState.test.ts src/__tests__/api/authProvider.test.ts src/__tests__/api/authService.test.ts` | Pass: 3 files, 6 tests |
| Frontend full | `npm --prefix frontend test` | Pass: 48 files, 418 tests |
| Frontend build | `npm --prefix frontend run build` | Pass |
| Backend broad API | `python -m pytest backend/tests/api -q` | Fails: 50 failed, 208 passed, 3 errors; failures are broad existing endpoint/test-fixture issues such as child-profile 404s before payload validation and an existing `image_to_story.py` streaming error-generator closure bug. |

## Notes
- Generated Playwright/log/screenshot files and obsolete HomePage helper work were preserved in a named stash instead of being pushed.
- No linked issue inferred from the local cleanup branch name or commit messages.
