### PR TITLE
fix(hub): reject orphan interactive shares

### DIFF
--- a/backend/src/api/routes/hub/posts.py
+++ b/backend/src/api/routes/hub/posts.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Optional
+from typing import Iterable, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
@@ -37,7 +37,7 @@ from ...models import (
     ListHubPostsResponse,
 )
 from ....mcp_servers import check_content_safety
-from ....services.database import group_repo, hub_post_repo
+from ....services.database import group_repo, hub_post_repo, session_repo
 from ....services.achievement_service import FIRST_SHARED_POST, achievement_service
 from ....services.user_service import UserData
 
@@ -139,6 +139,56 @@ async def _ensure_member(group_id: str, user: UserData, child_id: str) -> None:
         )
 
 
+async def _ensure_source_resolves(
+    source_artifact_type: str,
+    source_id: str,
+    *,
+    user: UserData,
+    child_id: str,
+) -> None:
+    """Reject transient interactive shares whose session cannot resume.
+
+    Art-story and Kids Daily shares point at durable story rows. The
+    dangling-post bug in #656 is specific to interactive-story posts
+    pointing at transient `sessions` rows, so this keeps the fix scoped
+    to that high-risk source type.
+    """
+    if source_artifact_type != "interactive_story":
+        return
+
+    session = await session_repo.get_session(source_id)
+    if (
+        session is None
+        or session.user_id != user.user_id
+        or session.child_id != child_id
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail={"code": "SOURCE_NOT_FOUND"},
+        )
+
+
+async def _hide_unresolvable_posts(posts: Iterable) -> list:
+    """Filter and soft-remove visible posts whose interactive source vanished."""
+    visible = []
+    for post in posts:
+        if post.source_artifact_type != "interactive_story":
+            visible.append(post)
+            continue
+
+        session = await session_repo.get_session(post.source_id)
+        if (
+            session is None
+            or session.user_id != post.author_user_id
+            or session.child_id != post.author_child_id
+        ):
+            await hub_post_repo.soft_delete(post.post_id, reason="source_not_found")
+            continue
+
+        visible.append(post)
+    return visible
+
+
 # ---------------------------------------------------------------------------
 # Create
 # ---------------------------------------------------------------------------
@@ -175,6 +225,13 @@ async def create_post(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"code": "INVALID_SOURCE_TYPE"},
         )
+
+    await _ensure_source_resolves(
+        body.source_artifact_type,
+        body.source_id,
+        user=user,
+        child_id=child_id,
+    )
 
     safety_score = 1.0
     caption = body.caption
@@ -260,13 +317,14 @@ async def list_posts(
     if cursor_created_at and cursor_post_id:
         before = (cursor_created_at, cursor_post_id)
 
-    posts = await hub_post_repo.list_by_group(
+    raw_posts = await hub_post_repo.list_by_group(
         group_id, limit=limit, before=before
     )
+    posts = await _hide_unresolvable_posts(raw_posts)
     items = [_to_response(p) for p in posts]
     next_cursor: Optional[dict] = None
-    if posts and len(posts) == limit:
-        last = posts[-1]
+    if raw_posts and len(raw_posts) == limit:
+        last = raw_posts[-1]
         next_cursor = {
             "cursor_created_at": last.created_at,
             "cursor_post_id": last.post_id,

--- a/backend/tests/contracts/test_hub_posts_endpoint_contract.py
+++ b/backend/tests/contracts/test_hub_posts_endpoint_contract.py
@@ -33,6 +33,7 @@ from backend.src.services.database import (
     db_manager,
     group_repo,
     hub_post_repo,
+    session_repo,
 )
 from backend.src.services.database.connection import DatabaseManager
 from backend.src.services.database.schema import init_schema
@@ -279,6 +280,136 @@ class TestCreateGates:
             )
         assert r.status_code == 201, r.text
         assert r.json()["source_artifact_type"] == "kids_daily"
+
+
+# ---------------------------------------------------------------------------
+# Source validation (#656)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceValidation:
+    @pytest.mark.asyncio
+    async def test_missing_interactive_source_is_rejected_without_post(self, client):
+        await _seed_buddy(_OWNER)
+        gid = await _create_public_group(client)
+
+        r = await client.post(
+            f"/api/v1/hub/groups/{gid}/posts",
+            json={
+                "source_artifact_type": "interactive_story",
+                "source_id": "missing-session",
+            },
+        )
+
+        assert r.status_code == 412
+        assert r.json()["detail"]["code"] == "SOURCE_NOT_FOUND"
+        row = await db_manager.fetchone(
+            "SELECT 1 FROM hub_posts WHERE source_id = ?",
+            ("missing-session",),
+        )
+        assert row is None
+
+    @pytest.mark.asyncio
+    async def test_valid_interactive_source_can_be_shared(self, client):
+        await _seed_buddy(_OWNER)
+        gid = await _create_public_group(client)
+        session = await session_repo.create_session(
+            child_id=_OWNER.default_child_id,
+            story_title="River Quest",
+            age_group="6-8",
+            interests=["nature"],
+            user_id=_OWNER.user_id,
+        )
+
+        r = await client.post(
+            f"/api/v1/hub/groups/{gid}/posts",
+            json={
+                "source_artifact_type": "interactive_story",
+                "source_id": session.session_id,
+            },
+        )
+
+        assert r.status_code == 201, r.text
+        assert r.json()["source_id"] == session.session_id
+
+    @pytest.mark.asyncio
+    async def test_other_child_interactive_source_is_rejected_without_post(self, client):
+        await _seed_buddy(_OWNER)
+        gid = await _create_public_group(client)
+        session = await session_repo.create_session(
+            child_id=_PEER.default_child_id,
+            story_title="Peer Quest",
+            age_group="6-8",
+            interests=["nature"],
+            user_id=_PEER.user_id,
+        )
+
+        r = await client.post(
+            f"/api/v1/hub/groups/{gid}/posts",
+            json={
+                "source_artifact_type": "interactive_story",
+                "source_id": session.session_id,
+            },
+        )
+
+        assert r.status_code == 412
+        assert r.json()["detail"]["code"] == "SOURCE_NOT_FOUND"
+        row = await db_manager.fetchone(
+            "SELECT 1 FROM hub_posts WHERE source_id = ?",
+            (session.session_id,),
+        )
+        assert row is None
+
+    @pytest.mark.asyncio
+    async def test_orphaned_interactive_post_is_hidden_from_feed(self, client):
+        await _seed_buddy(_OWNER)
+        gid = await _create_public_group(client)
+        orphan = await hub_post_repo.create_post(
+            group_id=gid,
+            user_id=_OWNER.user_id,
+            child_id=_OWNER.default_child_id,
+            source_artifact_type="interactive_story",
+            source_id="missing-session",
+        )
+
+        r = await client.get(f"/api/v1/hub/groups/{gid}/posts")
+
+        assert r.status_code == 200
+        source_ids = {item["source_id"] for item in r.json()["items"]}
+        assert "missing-session" not in source_ids
+        hidden = await hub_post_repo.get_by_id(orphan.post_id)
+        assert hidden is not None
+        assert hidden.removed_at is not None
+        assert hidden.removed_reason == "source_not_found"
+
+    @pytest.mark.asyncio
+    async def test_mismatched_interactive_post_is_hidden_from_feed(self, client):
+        await _seed_buddy(_OWNER)
+        gid = await _create_public_group(client)
+        session = await session_repo.create_session(
+            child_id=_PEER.default_child_id,
+            story_title="Peer Quest",
+            age_group="6-8",
+            interests=["nature"],
+            user_id=_PEER.user_id,
+        )
+        stale = await hub_post_repo.create_post(
+            group_id=gid,
+            user_id=_OWNER.user_id,
+            child_id=_OWNER.default_child_id,
+            source_artifact_type="interactive_story",
+            source_id=session.session_id,
+        )
+
+        r = await client.get(f"/api/v1/hub/groups/{gid}/posts")
+
+        assert r.status_code == 200
+        source_ids = {item["source_id"] for item in r.json()["items"]}
+        assert session.session_id not in source_ids
+        hidden = await hub_post_repo.get_by_id(stale.post_id)
+        assert hidden is not None
+        assert hidden.removed_at is not None
+        assert hidden.removed_reason == "source_not_found"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes dangling Content Hub interactive-story posts by validating that shared interactive sessions exist and belong to the posting child before creating a Hub post. Existing visible interactive posts with missing or mismatched session sources are soft-hidden from feeds so they no longer resume to 404 targets.

## Changes
- Add publish-time source validation for interactive_story Hub posts.
- Hide and soft-delete legacy interactive posts whose source session is missing or mismatched.
- Add contract coverage for missing, valid, cross-child, orphaned, and mismatched interactive sources.

## Test Coverage

| Layer | Tests | Status |
|-------|-------|--------|
| L4 API | python -m pytest backend/tests/contracts/test_hub_posts_endpoint_contract.py::TestSourceValidation -q | Pass, 5 tests |
| L4 API | python -m pytest backend/tests/contracts/test_hub_posts_endpoint_contract.py backend/tests/contracts/test_hub_reactions_endpoint_contract.py backend/tests/contracts/test_admin_hub_endpoint_contract.py backend/tests/contracts/test_hub_coppa_invariant.py -q | Pass, 33 tests |

## Related Issues
Fixes #656
