### PR TITLE
feat(my-agent): persist Talk-to-Buddy voice telemetry

### DIFF
--- a/backend/src/agents/my_agent_proxy.py
+++ b/backend/src/agents/my_agent_proxy.py
@@ -1072,6 +1072,8 @@ async def stream_my_agent_chat(
     image_path: Optional[str] = None,
     age_group: Optional[str] = None,
     interests: Optional[list[str]] = None,
+    input_modality: str = "text",
+    output_modality: str = "text",
 ) -> AsyncGenerator[str, None]:
     """Stream an SDK-orchestrated My Agent chat response as SSE."""
     chat_session = await agent_chat_repo.get_or_create_session(
@@ -1090,7 +1092,11 @@ async def stream_my_agent_chat(
             )
             session_title = derived_title
     await agent_chat_repo.add_message(
-        session_id=chat_session.session_id, role="user", text=message
+        session_id=chat_session.session_id,
+        role="user",
+        text=message,
+        input_modality=input_modality,
+        output_modality="text",
     )
 
     yield _sse(
@@ -1152,6 +1158,8 @@ async def stream_my_agent_chat(
             session_id=chat_session.session_id,
             role="assistant",
             text=final_text,
+            input_modality="text",
+            output_modality=output_modality,
             result_metadata=result_payload,
         )
         yield _sse("result", result_payload)
@@ -1183,6 +1191,8 @@ async def stream_my_agent_chat(
             session_id=chat_session.session_id,
             role="assistant",
             text=final_text,
+            input_modality="text",
+            output_modality=output_modality,
             result_metadata=result_payload,
         )
         yield _sse("result", result_payload)
@@ -1385,6 +1395,8 @@ async def stream_my_agent_chat(
         session_id=chat_session.session_id,
         role="assistant",
         text=final_text,
+        input_modality="text",
+        output_modality=output_modality,
         result_metadata=result_payload,
     )
     yield _sse("result", result_payload)

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -1228,6 +1228,8 @@ class AgentChatMessageItem(BaseModel):
     message_id: str = Field(..., description="Stable message identifier")
     role: str = Field(..., description="'user' or 'assistant'")
     text: str = Field(..., description="Message text")
+    input_modality: Literal["text", "voice"] = Field(default="text")
+    output_modality: Literal["text", "voice"] = Field(default="text")
     result_metadata: dict = Field(default_factory=dict, description="Structured launch/result payload, if any")
     created_at: str = Field(..., description="When the message was stored")
 

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -491,6 +491,8 @@ async def get_agent_session_messages(
                 message_id=m.message_id,
                 role=m.role,
                 text=m.text,
+                input_modality=m.input_modality,
+                output_modality=m.output_modality,
                 result_metadata=m.result_metadata,
                 created_at=m.created_at,
             )

--- a/backend/src/api/routes/voice_realtime.py
+++ b/backend/src/api/routes/voice_realtime.py
@@ -75,6 +75,7 @@ from ...services.voice_ephemeral_token import (
     verify_voice_token,
 )
 from ...mcp_servers import check_content_safety
+from ...agents.my_agent_proxy import stream_my_agent_chat
 
 logger = logging.getLogger(__name__)
 
@@ -720,6 +721,25 @@ async def _stream_openai_reply(
             state["first_audio_ms"] = max(0, elapsed_ms)
 
 
+def _parse_sse_event(chunk: str) -> tuple[str, Dict[str, Any]]:
+    """Parse one SSE chunk from stream_my_agent_chat into (event, data)."""
+    event_type = "message"
+    data_lines: list[str] = []
+    for raw_line in chunk.splitlines():
+        line = raw_line.strip()
+        if line.startswith("event:"):
+            event_type = line.split(":", 1)[1].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line.split(":", 1)[1].strip())
+    if not data_lines:
+        return event_type, {}
+    try:
+        data = json.loads("\n".join(data_lines))
+    except ValueError:
+        data = {}
+    return event_type, data if isinstance(data, dict) else {}
+
+
 async def _stream_legacy_reply(
     *,
     websocket: WebSocket,
@@ -728,18 +748,47 @@ async def _stream_legacy_reply(
     transcript: FinalTranscript,
     target_age: int,
     state: Dict[str, Any],
-) -> None:
-    """Hybrid / Mock provider path — text is determined locally then TTS.
+    chat_session_id: Optional[str] = None,
+) -> Optional[str]:
+    """Hybrid / Mock provider path — My Agent proxy text then TTS.
 
-    The reply text for these providers is a stand-in until the
-    ``stream_my_agent_chat`` integration lands. The pre-TTS safety gate
-    still runs so the parity invariant holds across providers.
+    The existing My Agent proxy owns buddy orchestration, durable chat
+    history, launch-flow metadata, and its own reply safety gate. The
+    voice broker translates that SSE stream into WS envelopes and still
+    runs the voice-surface pre-TTS safety gate before audio leaves.
     """
-    # Stand-in reply. The mock provider's canned transcript flows
-    # through unchanged for contract-test stability; the hybrid path
-    # will later route through ``stream_my_agent_chat`` (out of scope
-    # for this story — E3 / #646).
-    reply_text = f"Heard you say: {transcript.text}"
+    reply_text = ""
+
+    async for chunk in stream_my_agent_chat(
+        user_id=handle.user_id,
+        child_id=handle.child_id,
+        message=transcript.text,
+        session_id=chat_session_id,
+        input_modality="voice",
+        output_modality="voice",
+    ):
+        event_type, event_data = _parse_sse_event(chunk)
+        if event_type == "session":
+            chat_session_id = str(event_data.get("session_id") or "") or chat_session_id
+        elif event_type == "launch_flow":
+            await _send_event(websocket, {"type": "launch_flow", "payload": event_data})
+        elif event_type == "safety_blocked":
+            await _send_event(websocket, {
+                "type": "safety_block",
+                "direction": "reply",
+                "fallback_text": _SAFETY_FALLBACK_REPLY,
+            })
+        elif event_type == "error":
+            await _emit_error(
+                websocket,
+                code=str(event_data.get("error") or "agent_error"),
+                message=str(event_data.get("message") or ""),
+            )
+        elif event_type == "result":
+            reply_text = str(event_data.get("message") or "").strip()
+
+    if not reply_text:
+        reply_text = "I'm here and ready to create with you."
 
     safe = await _run_safety_gate(text=reply_text, target_age=target_age)
     if not safe:
@@ -748,7 +797,7 @@ async def _stream_legacy_reply(
             "direction": "reply",
             "fallback_text": _SAFETY_FALLBACK_REPLY,
         })
-        return
+        return chat_session_id
 
     await _send_event(websocket, {
         "type": "assistant_text",
@@ -779,6 +828,7 @@ async def _stream_legacy_reply(
             handle.session_id, exc,
         )
         await _emit_error(websocket, code="tts_failed", message=str(exc))
+    return chat_session_id
 
 
 async def _run_assistant_turn(
@@ -789,7 +839,8 @@ async def _run_assistant_turn(
     transcript: FinalTranscript,
     target_age: int,
     state: Dict[str, Any],
-) -> None:
+    chat_session_id: Optional[str] = None,
+) -> Optional[str]:
     """Dispatch to the provider-appropriate reply flow.
 
     OpenAI Realtime exposes ``stream_assistant_reply`` — text + audio
@@ -805,10 +856,12 @@ async def _run_assistant_turn(
             websocket=websocket, provider=provider, handle=handle,
             target_age=target_age, state=state,
         )
+        return chat_session_id
     else:
-        await _stream_legacy_reply(
+        return await _stream_legacy_reply(
             websocket=websocket, provider=provider, handle=handle,
             transcript=transcript, target_age=target_age, state=state,
+            chat_session_id=chat_session_id,
         )
 
 
@@ -847,6 +900,7 @@ async def stream_voice_session(websocket: WebSocket) -> None:
     target_age = _target_age_for(profile.age_group)
     age_group = profile.age_group
     handle: Optional[SessionHandle] = None
+    chat_session_id: Optional[str] = None
     started_at = time.monotonic()
     termination_reason = "user_ended"
     # Per-session mutable state shared with helpers — telemetry,
@@ -983,13 +1037,14 @@ async def stream_voice_session(websocket: WebSocket) -> None:
                         "safety_passed": True,
                     },
                 )
-                await _run_assistant_turn(
+                chat_session_id = await _run_assistant_turn(
                     websocket=websocket,
                     provider=provider,
                     handle=handle,
                     transcript=transcript,
                     target_age=target_age,
                     state=state,
+                    chat_session_id=chat_session_id,
                 )
                 # A tool dispatched an end_call envelope this turn —
                 # close cleanly with the dedicated reason so Parent

--- a/backend/src/services/database/agent_chat_repository.py
+++ b/backend/src/services/database/agent_chat_repository.py
@@ -35,6 +35,8 @@ class AgentChatMessage:
     session_id: str
     role: str
     text: str
+    input_modality: str
+    output_modality: str
     result_metadata: dict[str, Any]
     created_at: str
 
@@ -164,7 +166,9 @@ class AgentChatRepository:
         if before_created_at:
             rows = await self._db.fetchall(
                 """
-                SELECT message_id, session_id, role, text, result_metadata, created_at
+                SELECT message_id, session_id, role, text,
+                       input_modality, output_modality,
+                       result_metadata, created_at
                 FROM agent_chat_messages
                 WHERE session_id = ? AND created_at < ?
                 ORDER BY created_at ASC
@@ -175,7 +179,9 @@ class AgentChatRepository:
         else:
             rows = await self._db.fetchall(
                 """
-                SELECT message_id, session_id, role, text, result_metadata, created_at
+                SELECT message_id, session_id, role, text,
+                       input_modality, output_modality,
+                       result_metadata, created_at
                 FROM agent_chat_messages
                 WHERE session_id = ?
                 ORDER BY created_at ASC
@@ -248,22 +254,30 @@ class AgentChatRepository:
         session_id: str,
         role: str,
         text: str,
+        input_modality: str = "text",
+        output_modality: str = "text",
         result_metadata: Optional[dict[str, Any]] = None,
     ) -> AgentChatMessage:
         now = datetime.now().isoformat()
         message_id = f"agtmsg_{uuid4().hex[:16]}"
         metadata = result_metadata or {}
+        normalized_input = _normalize_modality(input_modality)
+        normalized_output = _normalize_modality(output_modality)
         await self._db.execute(
             """
             INSERT INTO agent_chat_messages (
-                message_id, session_id, role, text, result_metadata, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?)
+                message_id, session_id, role, text,
+                input_modality, output_modality,
+                result_metadata, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 message_id,
                 session_id,
                 role,
                 text,
+                normalized_input,
+                normalized_output,
                 json.dumps(metadata, ensure_ascii=False),
                 now,
             ),
@@ -291,6 +305,8 @@ class AgentChatRepository:
             session_id=session_id,
             role=role,
             text=text,
+            input_modality=normalized_input,
+            output_modality=normalized_output,
             result_metadata=metadata,
             created_at=now,
         )
@@ -300,7 +316,9 @@ class AgentChatRepository:
     ) -> list[AgentChatMessage]:
         rows = await self._db.fetchall(
             """
-            SELECT message_id, session_id, role, text, result_metadata, created_at
+            SELECT message_id, session_id, role, text,
+                   input_modality, output_modality,
+                   result_metadata, created_at
             FROM agent_chat_messages
             WHERE session_id = ?
             ORDER BY created_at DESC
@@ -335,9 +353,15 @@ class AgentChatRepository:
             session_id=row["session_id"],
             role=row["role"],
             text=row["text"],
+            input_modality=row.get("input_modality") or "text",
+            output_modality=row.get("output_modality") or "text",
             result_metadata=metadata,
             created_at=row["created_at"],
         )
+
+
+def _normalize_modality(value: str) -> str:
+    return value if value in {"text", "voice"} else "text"
 
 
 agent_chat_repo = AgentChatRepository()

--- a/backend/src/services/database/schema.py
+++ b/backend/src/services/database/schema.py
@@ -368,6 +368,8 @@ CREATE TABLE IF NOT EXISTS agent_chat_messages (
     session_id TEXT NOT NULL,
     role TEXT NOT NULL,
     text TEXT NOT NULL,
+    input_modality TEXT NOT NULL DEFAULT 'text',
+    output_modality TEXT NOT NULL DEFAULT 'text',
     result_metadata TEXT NOT NULL DEFAULT '{}',
     created_at TEXT NOT NULL,
     FOREIGN KEY(session_id) REFERENCES agent_chat_sessions(session_id) ON DELETE CASCADE
@@ -586,6 +588,7 @@ async def init_schema(db: "DatabaseManager") -> None:
     await _migrate_add_user_agent_config_columns(db)
     await _migrate_create_agent_chat_tables(db)
     await _migrate_add_agent_chat_session_columns(db)
+    await _migrate_add_agent_chat_message_modality_columns(db)
     await _migrate_create_hub_groups_table(db)
     await _migrate_create_hub_group_memberships_table(db)
     await _migrate_create_hub_posts_table(db)
@@ -1219,6 +1222,30 @@ async def _migrate_add_agent_chat_session_columns(db: "DatabaseManager") -> None
     if added:
         await db.commit()
         print("Agent chat session columns migration completed")
+
+
+async def _migrate_add_agent_chat_message_modality_columns(db: "DatabaseManager") -> None:
+    """Migration: tag My Agent chat messages by input/output modality (#668)."""
+    columns = [
+        (
+            "input_modality",
+            "ALTER TABLE agent_chat_messages ADD COLUMN input_modality TEXT NOT NULL DEFAULT 'text'",
+        ),
+        (
+            "output_modality",
+            "ALTER TABLE agent_chat_messages ADD COLUMN output_modality TEXT NOT NULL DEFAULT 'text'",
+        ),
+    ]
+    added = False
+    for column_name, ddl in columns:
+        if not await column_exists(db, "agent_chat_messages", column_name):
+            if not added:
+                print("Migrating agent_chat_messages: adding modality columns...")
+                added = True
+            await db.execute(ddl)
+    if added:
+        await db.commit()
+        print("Agent chat message modality migration completed")
 
 
 async def _migrate_create_hub_groups_table(db: "DatabaseManager") -> None:

--- a/backend/tests/contracts/test_agent_chat_repository_contract.py
+++ b/backend/tests/contracts/test_agent_chat_repository_contract.py
@@ -75,6 +75,12 @@ class TestSchemaColumns:
         assert await column_exists(db, "agent_chat_sessions", "last_message_preview")
         assert await column_exists(db, "agent_chat_sessions", "archived_at")
 
+    @pytest.mark.asyncio
+    async def test_message_modality_columns_exist_after_migration(self, repo):
+        db = repo._db
+        assert await column_exists(db, "agent_chat_messages", "input_modality")
+        assert await column_exists(db, "agent_chat_messages", "output_modality")
+
 
 class TestListSessionsForUser:
     @pytest.mark.asyncio
@@ -152,6 +158,32 @@ class TestListMessages:
 
         msgs = await repo.list_messages(s.session_id, user_id=_USER_A)
         assert [m.text for m in msgs] == ["first", "second"]
+        assert [m.input_modality for m in msgs] == ["text", "text"]
+        assert [m.output_modality for m in msgs] == ["text", "text"]
+
+    @pytest.mark.asyncio
+    async def test_add_message_persists_voice_modalities(self, repo):
+        s = await repo.get_or_create_session(user_id=_USER_A, child_id=_CHILD_1)
+        await repo.add_message(
+            session_id=s.session_id,
+            role="user",
+            text="spoken words",
+            input_modality="voice",
+            output_modality="text",
+        )
+        await repo.add_message(
+            session_id=s.session_id,
+            role="assistant",
+            text="spoken reply",
+            input_modality="text",
+            output_modality="voice",
+        )
+
+        msgs = await repo.list_messages(s.session_id, user_id=_USER_A)
+        assert [(m.role, m.input_modality, m.output_modality) for m in msgs] == [
+            ("user", "voice", "text"),
+            ("assistant", "text", "voice"),
+        ]
 
     @pytest.mark.asyncio
     async def test_foreign_user_gets_empty_list(self, repo):

--- a/backend/tests/contracts/test_agent_chat_sessions_endpoint_contract.py
+++ b/backend/tests/contracts/test_agent_chat_sessions_endpoint_contract.py
@@ -172,13 +172,30 @@ class TestGetSessionMessages:
         s = await agent_chat_repo.get_or_create_session(
             user_id=_USER_A.user_id, child_id=_CHILD_A
         )
-        await agent_chat_repo.add_message(session_id=s.session_id, role="user", text="first")
-        await agent_chat_repo.add_message(session_id=s.session_id, role="assistant", text="second")
+        await agent_chat_repo.add_message(
+            session_id=s.session_id,
+            role="user",
+            text="first",
+            input_modality="voice",
+            output_modality="text",
+        )
+        await agent_chat_repo.add_message(
+            session_id=s.session_id,
+            role="assistant",
+            text="second",
+            input_modality="text",
+            output_modality="voice",
+        )
 
         r = await client.get(f"/api/v1/me/agent/sessions/{s.session_id}/messages")
         assert r.status_code == 200, r.text
         texts = [m["text"] for m in r.json()["messages"]]
         assert texts == ["first", "second"]
+        modalities = [
+            (m["input_modality"], m["output_modality"])
+            for m in r.json()["messages"]
+        ]
+        assert modalities == [("voice", "text"), ("text", "voice")]
 
     @pytest.mark.asyncio
     async def test_foreign_session_returns_404(self, client):

--- a/backend/tests/contracts/test_voice_broker_contract.py
+++ b/backend/tests/contracts/test_voice_broker_contract.py
@@ -292,7 +292,7 @@ class TestWebSocketBroker:
 
     @pytest.mark.asyncio
     async def test_happy_path_vad_end_emits_transcript_and_audio(
-        self, test_db, consented_child,
+        self, test_db, consented_child, monkeypatch,
     ):
         # First mint a valid token via REST so the token has a real
         # session_id row in voice_sessions (end_session lookup needs it).
@@ -307,6 +307,19 @@ class TestWebSocketBroker:
             session_id=persisted.session_id,
             user_id=PARENT_USER.user_id,
             child_id=consented_child.child_id,
+        )
+
+        async def fake_stream_my_agent_chat(**_kwargs):
+            yield (
+                "event: result\n"
+                "data: {\"response_type\":\"chat\",\"message\":\"A real buddy reply\",\"session_id\":\"agtchat_voice_1\"}\n\n"
+            )
+            yield "event: complete\ndata: {\"status\":\"completed\"}\n\n"
+
+        monkeypatch.setattr(
+            voice_realtime,
+            "stream_my_agent_chat",
+            fake_stream_my_agent_chat,
         )
 
         client = self._setup_sync_test_client()
@@ -457,6 +470,8 @@ class TestSessionRowPersistence:
                 f"/api/v1/me/agent/voice/stream?token={token}"
             ) as ws:
                 ws.send_json({"type": "client_done"})
+                envelope = ws.receive_json()
+                assert envelope["type"] == "session_end"
         finally:
             app.dependency_overrides.pop(get_current_user, None)
             voice_realtime._set_test_provider_override(None)
@@ -467,3 +482,111 @@ class TestSessionRowPersistence:
         assert call_kwargs["reason"] == "user_ended"
         assert call_kwargs["duration_seconds"] is not None
         assert call_kwargs["duration_seconds"] >= 0
+
+
+# ============================================================================
+# Chat telemetry persistence
+# ============================================================================
+
+class TestVoiceChatTelemetry:
+    @pytest.mark.asyncio
+    async def test_voice_turn_persists_into_agent_chat_messages(
+        self, test_db, consented_child, monkeypatch,
+    ):
+        """A finalized voice utterance should be durable My Agent chat history.
+
+        The real stream_my_agent_chat path owns persistence. This test stubs
+        the stream so the broker contract verifies that it passes the voice
+        modality flags and forwards the resulting reply over the WS.
+        """
+        from backend.src.services.voice_ephemeral_token import mint_voice_token
+
+        persisted = await voice_session_repo.create_session(
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+            provider="mock",
+        )
+        token = mint_voice_token(
+            session_id=persisted.session_id,
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+        )
+
+        calls = []
+
+        async def fake_stream_my_agent_chat(**kwargs):
+            calls.append(kwargs)
+            yield (
+                "event: session\n"
+                "data: {\"session_id\":\"agtchat_voice_1\",\"story_title\":\"Voice chat\"}\n\n"
+            )
+            yield (
+                "event: result\n"
+                "data: {\"response_type\":\"chat\",\"message\":\"A real buddy reply\",\"session_id\":\"agtchat_voice_1\"}\n\n"
+            )
+            yield "event: complete\ndata: {\"status\":\"completed\"}\n\n"
+
+        monkeypatch.setattr(
+            voice_realtime,
+            "stream_my_agent_chat",
+            fake_stream_my_agent_chat,
+        )
+
+        app.dependency_overrides[get_current_user] = _override_current_user
+        voice_realtime._set_test_provider_override(MockRealtimeVoiceProvider())
+        monkeypatch.setattr(
+            voice_realtime, "_safety_check_text", _bypass_safety,
+        )
+        client = TestClient(app)
+        try:
+            with client.websocket_connect(
+                f"/api/v1/me/agent/voice/stream?token={token}"
+            ) as ws:
+                audio_b64 = base64.b64encode(b"\x00" * 200).decode("ascii")
+                ws.send_json({
+                    "type": "audio_chunk",
+                    "seq": 0,
+                    "audio_b64": audio_b64,
+                })
+                ws.send_json({"type": "vad_end", "seq": 0})
+
+                events = []
+                while True:
+                    ev = ws.receive_json()
+                    events.append(ev)
+                    if ev["type"] == "audio_chunk":
+                        break
+
+                ws.send_json({
+                    "type": "audio_chunk",
+                    "seq": 1,
+                    "audio_b64": audio_b64,
+                })
+                ws.send_json({"type": "vad_end", "seq": 1})
+                while True:
+                    ev = ws.receive_json()
+                    events.append(ev)
+                    if (
+                        ev["type"] == "audio_chunk"
+                        and len([e for e in events if e["type"] == "audio_chunk"]) >= 2
+                    ):
+                        break
+
+                ws.send_json({"type": "client_done"})
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            voice_realtime._set_test_provider_override(None)
+
+        assert calls, "broker must delegate finalized voice turns to My Agent"
+        assert calls[0]["message"] == "hello buddy this is a mock transcript"
+        assert calls[0]["input_modality"] == "voice"
+        assert calls[0]["output_modality"] == "voice"
+        assert len(calls) == 2
+        assert calls[1]["session_id"] == "agtchat_voice_1"
+        event_types = [e["type"] for e in events]
+        assert "final_transcript" in event_types
+        assert {
+            "type": "assistant_text",
+            "delta": "A real buddy reply",
+            "is_final": True,
+        } in events

--- a/frontend/src/__tests__/store/useAgentChatStore.test.ts
+++ b/frontend/src/__tests__/store/useAgentChatStore.test.ts
@@ -5,7 +5,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@/api/services/agentService", () => ({
   agentService: {
     listAgentSessions: vi.fn(),
-    getAgentSession: vi.fn(),
+    getAgentSessionMessages: vi.fn(),
     createAgentSession: vi.fn(),
     renameAgentSession: vi.fn(),
     archiveAgentSession: vi.fn(),
@@ -16,15 +16,63 @@ vi.mock("@/api/services/agentService", () => ({
 type AgentChatStore = typeof import("../../store/useAgentChatStore").default;
 
 let useAgentChatStore: AgentChatStore;
+let agentService: typeof import("@/api/services/agentService").agentService;
 
 beforeAll(async () => {
   useAgentChatStore = (
     await import("../../store/useAgentChatStore")
   ).default;
+  agentService = (await import("@/api/services/agentService")).agentService;
 });
 
 beforeEach(() => {
   useAgentChatStore.getState().reset();
+});
+
+describe("useAgentChatStore.selectSession modality mapping (#668)", () => {
+  it("tags server-loaded voice messages with source=voice", async () => {
+    vi.mocked(agentService.getAgentSessionMessages).mockResolvedValueOnce({
+      session_id: "s1",
+      messages: [
+        {
+          message_id: "m1",
+          role: "user",
+          text: "spoken prompt",
+          input_modality: "voice",
+          output_modality: "text",
+          result_metadata: {},
+          created_at: "2026-06-13T00:00:00",
+        },
+        {
+          message_id: "m2",
+          role: "assistant",
+          text: "spoken reply",
+          input_modality: "text",
+          output_modality: "voice",
+          result_metadata: {},
+          created_at: "2026-06-13T00:00:01",
+        },
+        {
+          message_id: "m3",
+          role: "user",
+          text: "typed prompt",
+          input_modality: "text",
+          output_modality: "text",
+          result_metadata: {},
+          created_at: "2026-06-13T00:00:02",
+        },
+      ],
+    });
+
+    await useAgentChatStore.getState().selectSession("s1");
+
+    const messages = useAgentChatStore.getState().messages;
+    expect(messages.map((m) => m.source)).toEqual([
+      "voice",
+      "voice",
+      undefined,
+    ]);
+  });
 });
 
 describe("useAgentChatStore.appendVoiceCaption (#619)", () => {

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -775,8 +775,8 @@ export default function AgentChatPanel({
  * is mounted. Keeps the WebSocket / MediaStream / AudioContext out of
  * the always-rendered parent so idle cost stays zero.
  *
- * Voice transcripts flow into `useAgentChatStore.appendVoiceCaption`
- * so they merge into the same chat history the text panel renders.
+ * Voice captions stay inside the panel while the backend persists the
+ * durable voice turns through the My Agent chat history (#668).
  */
 /**
  * Map an AgeGroup band to a representative numeric age so BuddyOrb
@@ -812,21 +812,10 @@ function TalkToBuddyContainer({
   variant?: TalkToBuddyPanelVariant;
 }) {
   void ageGroup; // Future: thread per-age TTS preset overrides (Phase C, #608).
-  const appendVoiceCaption = useAgentChatStore((s) => s.appendVoiceCaption);
 
   const voice = useVoiceConversation({
     childId,
     persona,
-    onCaption: (caption) => {
-      // Only persist finalized turns so the chat history doesn't get
-      // spammed with partial-transcript noise. Safety-blocked utterances
-      // also surface in the timeline so the kid can see what happened.
-      if (caption.kind === "final") {
-        appendVoiceCaption({ role: "user", text: caption.text });
-      } else if (caption.kind === "assistant" && caption.isFinal) {
-        appendVoiceCaption({ role: "assistant", text: caption.text });
-      }
-    },
   });
 
   const prefersReducedMotion =

--- a/frontend/src/store/useAgentChatStore.ts
+++ b/frontend/src/store/useAgentChatStore.ts
@@ -95,6 +95,10 @@ const useAgentChatStore = create<AgentChatState>((set, get) => ({
           id: m.message_id,
           role: m.role,
           text: m.text,
+          source:
+            m.input_modality === "voice" || m.output_modality === "voice"
+              ? "voice"
+              : undefined,
         })),
       });
     } catch (err) {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -679,6 +679,8 @@ export interface AgentChatMessageItem {
   message_id: string;
   role: "user" | "assistant";
   text: string;
+  input_modality?: "text" | "voice";
+  output_modality?: "text" | "voice";
   result_metadata: Record<string, unknown>;
   created_at: string;
 }


### PR DESCRIPTION
## Summary
- route finalized Talk-to-Buddy voice turns through `stream_my_agent_chat` so user/assistant voice messages persist in My Agent chat history
- add input/output modality metadata to `agent_chat_messages`, repository models, API responses, and frontend chat hydration
- keep live Talk-to-Buddy captions panel-local so durable history comes from the backend telemetry stream

## Tests
- `/Users/xenodennis/Fun/python101/projects/claude_code/creative_agent/backend/.venv/bin/pytest backend/tests/contracts/test_agent_chat_repository_contract.py backend/tests/contracts/test_agent_chat_sessions_endpoint_contract.py backend/tests/contracts/test_voice_broker_contract.py backend/tests/contracts/test_my_agent_proxy.py -q`
- `/Users/xenodennis/Fun/python101/projects/claude_code/creative_agent/frontend/node_modules/.bin/vitest run src/__tests__/store/useAgentChatStore.test.ts`

Fixes #668
Parent Epic: #605