### PR TITLE
feat(my-agent): voice session telemetry events (#609 track)

### DIFF
--- a/backend/src/api/routes/voice_realtime.py
+++ b/backend/src/api/routes/voice_realtime.py
@@ -74,6 +74,7 @@ from ...services.voice_ephemeral_token import (
     mint_voice_token,
     verify_voice_token,
 )
+from ...services import voice_telemetry
 from ...mcp_servers import check_content_safety
 
 logger = logging.getLogger(__name__)
@@ -307,6 +308,21 @@ async def _validate_enabled_skills_for_voice(
         # canonical list so the client can surface which to re-enable.
         return "all_launch_skills_disabled"
     return None
+
+
+async def _agent_id_for_voice(
+    *, user_id: str, child_id: str,
+) -> Optional[str]:
+    """Best-effort lookup of the persona's surrogate ``agent_id`` for the
+    ``voice_session_started`` telemetry event. Returns ``None`` on lookup
+    failure or a default (no-persona) buddy — telemetry must never block
+    a session, so this swallows errors and lets the event carry a null
+    agent_id rather than raising."""
+    try:
+        agent = await agent_repo.get_agent(user_id=user_id, child_id=child_id)
+    except Exception:
+        return None
+    return agent.agent_id if agent is not None else None
 
 
 async def _enabled_skills_for_voice(
@@ -606,6 +622,12 @@ async def _dispatch_function_call(
         # model so the client transition feels in sync with the buddy's
         # spoken handoff sentence.
         await _send_event(websocket, {"type": "launch_flow", **payload})
+        # #609 telemetry — voice drove the kid INTO a creation flow; the
+        # target flow type is the key engagement signal for the surface.
+        voice_telemetry.emit_voice_session_launch_flow_emitted(
+            session_id=handle.session_id,
+            flow=str(payload.get("flow_type") or "unknown"),
+        )
         ack_output = json.dumps({"status": "launched", "flow_type": payload.get("flow_type")})
     elif envelope_type == "end_call":
         # Don't ack the model — we're closing. Just remember to break.
@@ -694,6 +716,14 @@ async def _stream_openai_reply(
             "direction": "reply",
             "fallback_text": _SAFETY_FALLBACK_REPLY,
         })
+        # #609 telemetry — the buddy's reply text failed the pre-TTS gate
+        # and was never forwarded. Category is a bounded reason code; the
+        # rejected text itself is never logged.
+        voice_telemetry.emit_voice_session_safety_rejection(
+            session_id=handle.session_id,
+            direction="reply",
+            category="reply_unsafe",
+        )
         return
 
     # Safe path: emit the assistant text + forward the audio chunks.
@@ -748,6 +778,14 @@ async def _stream_legacy_reply(
             "direction": "reply",
             "fallback_text": _SAFETY_FALLBACK_REPLY,
         })
+        # #609 telemetry — the buddy's reply text failed the pre-TTS gate
+        # and was never forwarded. Category is a bounded reason code; the
+        # rejected text itself is never logged.
+        voice_telemetry.emit_voice_session_safety_rejection(
+            session_id=handle.session_id,
+            direction="reply",
+            category="reply_unsafe",
+        )
         return
 
     await _send_event(websocket, {
@@ -856,6 +894,11 @@ async def stream_voice_session(websocket: WebSocket) -> None:
         "started_at_monotonic": started_at,
         "first_audio_ms": None,
         "last_activity_monotonic": started_at,
+        # #609 telemetry — barge-in tracking. No interruption signal is
+        # wired in the broker yet (full-duplex barge-in is a follow-up),
+        # so this stays 0 until that lands; the event still fires at close
+        # so the histogram schema exists from day one.
+        "interruption_count": 0,
     }
 
     idle_timeout = _idle_timeout_for(age_group)
@@ -888,6 +931,18 @@ async def stream_voice_session(websocket: WebSocket) -> None:
                 user_id=claims.user_id, child_id=claims.child_id,
             )
         handle = await provider.start_session(**start_kwargs)
+
+        # #609 telemetry — session opened. agent_id is a best-effort
+        # lookup so the dashboard can slice voice engagement by persona;
+        # a null agent_id just means a default (no-persona) buddy.
+        voice_telemetry.emit_voice_session_started(
+            session_id=claims.session_id,
+            age_group=age_group,
+            agent_id=await _agent_id_for_voice(
+                user_id=claims.user_id, child_id=claims.child_id,
+            ),
+            provider=provider.name,
+        )
 
         while True:
             # Compute the next deadline — whichever fires first wins.
@@ -972,6 +1027,16 @@ async def stream_voice_session(websocket: WebSocket) -> None:
                             "direction": "utterance",
                             "fallback_text": _SAFETY_FALLBACK_REPLY,
                         },
+                    )
+                    # #609 telemetry — record WHICH side tripped the gate
+                    # without ever logging the (unsafe) transcript text.
+                    voice_telemetry.emit_voice_session_safety_rejection(
+                        session_id=claims.session_id,
+                        direction="utterance",
+                        category=(
+                            "empty_transcript" if not transcript.text
+                            else "transcript_unsafe"
+                        ),
                     )
                     continue
 
@@ -1064,6 +1129,26 @@ async def stream_voice_session(websocket: WebSocket) -> None:
             prompt_cache_hit=prompt_cache_hit,
             first_audio_ms=state.get("first_audio_ms") or 0,
             ended_reason=termination_reason,
+        )
+        # #609 product/engagement telemetry — distinct from the cost line
+        # above. ``voice_session_ended`` powers the abnormal-termination
+        # alerting; the first-audio + interruption events feed the latency
+        # histogram and the reply-length tuning signal. All fire exactly
+        # once per session because they live in the broker's finally block.
+        voice_telemetry.emit_voice_session_ended(
+            session_id=claims.session_id,
+            duration_seconds=elapsed,
+            ended_reason=termination_reason,
+        )
+        if state.get("first_audio_ms") is not None:
+            voice_telemetry.emit_voice_session_first_audio_ms(
+                session_id=claims.session_id,
+                first_audio_ms=state["first_audio_ms"],
+                age_group=age_group,
+            )
+        voice_telemetry.emit_voice_session_interruption_count(
+            session_id=claims.session_id,
+            count=int(state.get("interruption_count") or 0),
         )
         if handle is not None:
             try:

--- a/backend/src/services/voice_telemetry.py
+++ b/backend/src/services/voice_telemetry.py
@@ -1,0 +1,166 @@
+"""
+Voice session telemetry (#609 Phase D — Talk to Buddy).
+
+Structured-event emitters for the realtime voice surface. Each emitter
+writes a single flat ``logger.info(..., extra={...})`` record carrying an
+``event`` discriminator plus a small set of typed fields. A downstream
+JSON formatter (e.g. ``python-json-logger``) serialises them un-nested so
+the ops dashboards + Parent Dashboard pipeline can scrape them with a
+plain ``event=<name>`` filter.
+
+Design rules (PRD §3.16 — child-safety):
+
+  * **PII-free by construction.** Emitters accept IDs, durations, and
+    categorical fields ONLY. There is deliberately no ``text`` /
+    ``transcript`` parameter on any emitter, so a caller cannot leak a
+    child's speech or the buddy's reply into the telemetry stream even
+    by accident. Categories are bounded enums, never free-form content.
+  * **Fire-and-forget.** Telemetry must never break a live voice turn,
+    so ``_emit`` swallows any logging error. A dropped metric is always
+    preferable to a crashed session.
+  * **Flat fields.** No nested dicts — keeps the record cheap to index.
+
+This sits alongside ``realtime_voice_service.log_voice_session_end``
+(the cost-ops line, ``event=voice_session_end``). That helper stays the
+single source of per-session COST aggregation; this module covers the
+product/engagement + safety + latency events the dashboards need.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Canonical event names — referenced by tests + the dashboard scrapers.
+# ---------------------------------------------------------------------------
+
+VOICE_SESSION_STARTED = "voice_session_started"
+VOICE_SESSION_ENDED = "voice_session_ended"
+VOICE_SESSION_SAFETY_REJECTION = "voice_session_safety_rejection"
+VOICE_SESSION_LAUNCH_FLOW_EMITTED = "voice_session_launch_flow_emitted"
+VOICE_SESSION_FIRST_AUDIO_MS = "voice_session_first_audio_ms"
+VOICE_SESSION_INTERRUPTION_COUNT = "voice_session_interruption_count"
+
+# ``direction`` is a bounded enum — anything else collapses to "unknown"
+# so a wiring bug can't push a free-form string (potentially derived from
+# content) into the metrics pipeline.
+_VALID_DIRECTIONS = frozenset({"utterance", "reply"})
+
+
+def _emit(event: str, fields: Dict[str, Any]) -> None:
+    """Write one structured telemetry record. Never raises.
+
+    The ``event`` discriminator and every field land in the record's
+    ``__dict__`` via the logging ``extra`` mechanism, so a JSON handler
+    serialises them flat. We log at INFO — voice sessions are infrequent
+    (one per child play session) so this won't spam suppressed envs.
+    """
+    extra = {"event": event, **fields}
+    try:
+        # A compact human-readable message; the structured fields ride in
+        # ``extra`` for the JSON formatter. ``%s`` pairs keep it greppable.
+        message = "%s %s" % (
+            event,
+            " ".join(f"{k}={v}" for k, v in fields.items()),
+        )
+        logger.info(message, extra=extra)
+    except Exception:  # pragma: no cover - telemetry must never break a turn
+        pass
+
+
+def emit_voice_session_started(
+    *,
+    session_id: str,
+    age_group: Optional[str],
+    agent_id: Optional[str],
+    provider: Optional[str] = None,
+) -> None:
+    """A voice session opened. ``age_group`` + ``agent_id`` let the
+    dashboard slice engagement by cohort and persona without joining
+    back to the DB."""
+    _emit(VOICE_SESSION_STARTED, {
+        "session_id": session_id,
+        "age_group": age_group,
+        "agent_id": agent_id,
+        "provider": provider,
+    })
+
+
+def emit_voice_session_ended(
+    *,
+    session_id: str,
+    duration_seconds: int,
+    ended_reason: str,
+) -> None:
+    """A voice session closed. ``ended_reason`` distinguishes a graceful
+    goodbye from a timeout / quota / disconnect so we can alert on a
+    spike in abnormal terminations."""
+    _emit(VOICE_SESSION_ENDED, {
+        "session_id": session_id,
+        "duration_seconds": int(duration_seconds or 0),
+        "ended_reason": ended_reason,
+    })
+
+
+def emit_voice_session_safety_rejection(
+    *,
+    session_id: str,
+    direction: str,
+    category: str,
+) -> None:
+    """A turn was blocked by the safety gate. ``direction`` says which
+    side tripped it (``utterance`` = child speech, ``reply`` = buddy
+    text); ``category`` is a bounded reason code (never content)."""
+    safe_direction = direction if direction in _VALID_DIRECTIONS else "unknown"
+    _emit(VOICE_SESSION_SAFETY_REJECTION, {
+        "session_id": session_id,
+        "direction": safe_direction,
+        "category": category,
+    })
+
+
+def emit_voice_session_launch_flow_emitted(
+    *,
+    session_id: str,
+    flow: str,
+) -> None:
+    """The buddy handed off to a launch-flow specialist (image story,
+    interactive story, kids daily). ``flow`` is the target flow type —
+    the key engagement signal that voice drives kids INTO creation."""
+    _emit(VOICE_SESSION_LAUNCH_FLOW_EMITTED, {
+        "session_id": session_id,
+        "flow": flow,
+    })
+
+
+def emit_voice_session_first_audio_ms(
+    *,
+    session_id: str,
+    first_audio_ms: int,
+    age_group: Optional[str] = None,
+) -> None:
+    """Time-to-first-audio for the session's first buddy reply. Feeds the
+    latency histogram behind the p50 ≤ 1500ms / p95 ≤ 2500ms AC."""
+    _emit(VOICE_SESSION_FIRST_AUDIO_MS, {
+        "session_id": session_id,
+        "first_audio_ms": int(first_audio_ms or 0),
+        "age_group": age_group,
+    })
+
+
+def emit_voice_session_interruption_count(
+    *,
+    session_id: str,
+    count: int,
+) -> None:
+    """How many times the child barged in over the buddy during the
+    session. A high count hints the replies are too long for the age
+    band — a tuning signal, emitted once at session close."""
+    _emit(VOICE_SESSION_INTERRUPTION_COUNT, {
+        "session_id": session_id,
+        "count": int(count or 0),
+    })

--- a/backend/tests/contracts/test_voice_broker_contract.py
+++ b/backend/tests/contracts/test_voice_broker_contract.py
@@ -15,6 +15,7 @@ import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
+from starlette.websockets import WebSocketDisconnect
 
 from backend.src.api.deps import get_current_user
 from backend.src.api.routes import voice_realtime
@@ -457,6 +458,15 @@ class TestSessionRowPersistence:
                 f"/api/v1/me/agent/voice/stream?token={token}"
             ) as ws:
                 ws.send_json({"type": "client_done"})
+                # Drain until the server closes the socket so the broker's
+                # finally block (where end_session is called) has fully run
+                # before we assert. Without this the assertion races the
+                # portal thread — any added latency on the session-start
+                # path (e.g. the #609 telemetry agent_id lookup) could let
+                # the assertion fire before end_session is awaited.
+                with pytest.raises(WebSocketDisconnect):
+                    while True:
+                        ws.receive_json()
         finally:
             app.dependency_overrides.pop(get_current_user, None)
             voice_realtime._set_test_provider_override(None)

--- a/backend/tests/contracts/test_voice_telemetry_contract.py
+++ b/backend/tests/contracts/test_voice_telemetry_contract.py
@@ -1,0 +1,353 @@
+"""
+Voice session telemetry contract tests (#609 Phase D).
+
+Locks the structured-event layer the ops dashboards + Parent Dashboard
+scrape for the Talk-to-Buddy realtime voice surface. The contract:
+
+  1. ``voice_telemetry`` exposes a canonical emitter per event, each
+     writing a flat structured log record (``event=<name>`` in the
+     record's ``extra``) so a JSON formatter serialises them un-nested.
+  2. The events are PII-free: emitters take IDs, durations, and
+     categorical fields ONLY — never transcript text or raw audio. The
+     emitter signatures encode this (there is no ``text`` parameter).
+  3. ``direction`` on a safety rejection is constrained to
+     ``utterance`` | ``reply`` (any other value normalises to
+     ``unknown`` rather than leaking a free-form string downstream).
+  4. The broker fires ``voice_session_started`` once at session open and
+     ``voice_session_ended`` once at close during a real mock WS session.
+  5. The broker fires ``voice_session_safety_rejection`` when a turn is
+     blocked, carrying the direction.
+
+No network: the Mock provider + a bypassed safety MCP keep the broker
+deterministic, mirroring ``test_voice_broker_contract.py``.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from backend.src.api.deps import get_current_user
+from backend.src.api.routes import voice_realtime
+from backend.src.main import app
+from backend.src.services import voice_telemetry as vt
+from backend.src.services.database import (
+    db_manager,
+    voice_session_repo,
+)
+from backend.src.services.database.child_profile_repository import (
+    ChildProfileRepository,
+)
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+from backend.src.services.realtime_voice_service import MockRealtimeVoiceProvider
+from backend.src.services.user_service import UserData
+from backend.src.services.voice_ephemeral_token import mint_voice_token
+
+
+# ---------------------------------------------------------------------------
+# 1. Each emitter writes a structured record with event=<name> + fields.
+# ---------------------------------------------------------------------------
+
+def _records_for(caplog, event: str):
+    return [r for r in caplog.records if getattr(r, "event", "") == event]
+
+
+class TestEmitterRecords:
+    def test_started_emits_canonical_fields(self, caplog):
+        with caplog.at_level(logging.INFO, logger=vt.__name__):
+            vt.emit_voice_session_started(
+                session_id="voice_sess_1",
+                age_group="6-8",
+                agent_id="agent_42",
+                provider="mock",
+            )
+        rec = _records_for(caplog, vt.VOICE_SESSION_STARTED)
+        assert rec, "expected a voice_session_started record"
+        r = rec[-1]
+        assert r.session_id == "voice_sess_1"
+        assert r.age_group == "6-8"
+        assert r.agent_id == "agent_42"
+        assert r.provider == "mock"
+
+    def test_ended_emits_duration_and_reason(self, caplog):
+        with caplog.at_level(logging.INFO, logger=vt.__name__):
+            vt.emit_voice_session_ended(
+                session_id="voice_sess_2",
+                duration_seconds=187,
+                ended_reason="user_ended",
+            )
+        r = _records_for(caplog, vt.VOICE_SESSION_ENDED)[-1]
+        assert r.session_id == "voice_sess_2"
+        assert r.duration_seconds == 187
+        assert r.ended_reason == "user_ended"
+
+    def test_safety_rejection_emits_direction_and_category(self, caplog):
+        with caplog.at_level(logging.INFO, logger=vt.__name__):
+            vt.emit_voice_session_safety_rejection(
+                session_id="voice_sess_3",
+                direction="reply",
+                category="reply_unsafe",
+            )
+        r = _records_for(caplog, vt.VOICE_SESSION_SAFETY_REJECTION)[-1]
+        assert r.session_id == "voice_sess_3"
+        assert r.direction == "reply"
+        assert r.category == "reply_unsafe"
+
+    def test_launch_flow_emitted_carries_flow(self, caplog):
+        with caplog.at_level(logging.INFO, logger=vt.__name__):
+            vt.emit_voice_session_launch_flow_emitted(
+                session_id="voice_sess_4",
+                flow="image_story",
+            )
+        r = _records_for(caplog, vt.VOICE_SESSION_LAUNCH_FLOW_EMITTED)[-1]
+        assert r.session_id == "voice_sess_4"
+        assert r.flow == "image_story"
+
+    def test_first_audio_ms_carries_value(self, caplog):
+        with caplog.at_level(logging.INFO, logger=vt.__name__):
+            vt.emit_voice_session_first_audio_ms(
+                session_id="voice_sess_5",
+                first_audio_ms=812,
+                age_group="9-12",
+            )
+        r = _records_for(caplog, vt.VOICE_SESSION_FIRST_AUDIO_MS)[-1]
+        assert r.session_id == "voice_sess_5"
+        assert r.first_audio_ms == 812
+        assert r.age_group == "9-12"
+
+    def test_interruption_count_carries_count(self, caplog):
+        with caplog.at_level(logging.INFO, logger=vt.__name__):
+            vt.emit_voice_session_interruption_count(
+                session_id="voice_sess_6",
+                count=3,
+            )
+        r = _records_for(caplog, vt.VOICE_SESSION_INTERRUPTION_COUNT)[-1]
+        assert r.session_id == "voice_sess_6"
+        assert r.count == 3
+
+
+# ---------------------------------------------------------------------------
+# 2 + 3. PII-free + direction normalisation.
+# ---------------------------------------------------------------------------
+
+class TestSafetyInvariants:
+    def test_emitters_take_no_transcript_text(self):
+        # Structural guarantee: none of the emitters accept a ``text`` or
+        # ``transcript`` kwarg, so a caller cannot accidentally leak child
+        # speech into the telemetry stream.
+        import inspect
+
+        for name in (
+            "emit_voice_session_started",
+            "emit_voice_session_ended",
+            "emit_voice_session_safety_rejection",
+            "emit_voice_session_launch_flow_emitted",
+            "emit_voice_session_first_audio_ms",
+            "emit_voice_session_interruption_count",
+        ):
+            params = set(inspect.signature(getattr(vt, name)).parameters)
+            assert "text" not in params, f"{name} must not accept text"
+            assert "transcript" not in params, f"{name} must not accept transcript"
+
+    def test_unknown_direction_normalises(self, caplog):
+        with caplog.at_level(logging.INFO, logger=vt.__name__):
+            vt.emit_voice_session_safety_rejection(
+                session_id="voice_sess_norm",
+                direction="sideways",  # not utterance|reply
+                category="x",
+            )
+        r = _records_for(caplog, vt.VOICE_SESSION_SAFETY_REJECTION)[-1]
+        assert r.direction == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Broker integration — events fire during a real mock WS session.
+# ---------------------------------------------------------------------------
+
+PARENT_USER = UserData(
+    user_id="voice_telemetry_parent",
+    username="voice_telemetry_parent",
+    email="parent@telemetry-test.com",
+    password_hash="h",
+    display_name="Parent",
+    role="parent",
+    created_at="",
+    updated_at="",
+)
+
+
+async def _override_current_user() -> UserData:
+    return PARENT_USER
+
+
+@pytest_asyncio.fixture
+async def test_db():
+    fresh = DatabaseManager(":memory:")
+    await fresh.connect()
+    await init_schema(fresh)
+    saved_adapter = db_manager._adapter
+    db_manager._adapter = fresh._adapter
+
+    now = datetime.now().isoformat()
+    await db_manager.execute(
+        """
+        INSERT INTO users (user_id, username, email, password_hash, display_name,
+                           is_active, is_verified, role, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            PARENT_USER.user_id, PARENT_USER.username, PARENT_USER.email,
+            PARENT_USER.password_hash, PARENT_USER.display_name, 1, 1, "parent",
+            now, now,
+        ),
+    )
+    await db_manager.commit()
+    yield fresh
+    db_manager._adapter = saved_adapter
+    await fresh.disconnect()
+
+
+@pytest_asyncio.fixture
+async def consented_child(test_db):
+    repo = ChildProfileRepository(db_manager)
+    profile = await repo.create(
+        user_id=PARENT_USER.user_id,
+        child_id="child_telemetry_alpha",
+        name="Ada",
+        age_group="6-8",
+        is_default=True,
+    )
+    await repo.update_consent(
+        user_id=PARENT_USER.user_id,
+        child_id=profile.child_id,
+        microphone_consent=True,
+        voice_conversation_consent=True,
+        voice_session_quota_seconds=600,
+    )
+    return profile
+
+
+async def _bypass_safety(text: str, target_age: int):
+    return {"safety_score": 0.99, "passed": True}
+
+
+async def _fail_safety(text: str, target_age: int):
+    return {"safety_score": 0.10, "passed": False}
+
+
+class TestBrokerEmitsLifecycleEvents:
+    @pytest.mark.asyncio
+    async def test_started_and_ended_fire_during_session(
+        self, test_db, consented_child, monkeypatch, caplog,
+    ):
+        persisted = await voice_session_repo.create_session(
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+            provider="mock",
+        )
+        token = mint_voice_token(
+            session_id=persisted.session_id,
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+        )
+
+        app.dependency_overrides[get_current_user] = _override_current_user
+        voice_realtime._set_test_provider_override(MockRealtimeVoiceProvider())
+        monkeypatch.setattr(voice_realtime, "_safety_check_text", _bypass_safety)
+        try:
+            with caplog.at_level(logging.INFO, logger=vt.__name__):
+                client = TestClient(app)
+                with client.websocket_connect(
+                    f"/api/v1/me/agent/voice/stream?token={token}"
+                ) as ws:
+                    # Drive one full turn so the server deterministically
+                    # progresses past start_session (emitting `started`)
+                    # and forwards audio (emitting `first_audio_ms`). A
+                    # bare client_done can race the portal thread's close
+                    # before the broker reaches those emit points.
+                    audio_b64 = base64.b64encode(b"\x00" * 200).decode("ascii")
+                    ws.send_json({"type": "audio_chunk", "seq": 0, "audio_b64": audio_b64})
+                    ws.send_json({"type": "vad_end", "seq": 0})
+                    while True:
+                        ev = ws.receive_json()
+                        if ev["type"] == "audio_chunk":
+                            break
+                    ws.send_json({"type": "client_done"})
+                    # Drain until the server closes the socket. The broker's
+                    # finally block sends `session_end` and THEN closes the
+                    # WS — by the time the client observes the close, every
+                    # close-time telemetry emit (ended/first_audio/
+                    # interruption) has already fired.
+                    with pytest.raises(WebSocketDisconnect):
+                        while True:
+                            ws.receive_json()
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            voice_realtime._set_test_provider_override(None)
+
+        started = _records_for(caplog, vt.VOICE_SESSION_STARTED)
+        ended = _records_for(caplog, vt.VOICE_SESSION_ENDED)
+        first_audio = _records_for(caplog, vt.VOICE_SESSION_FIRST_AUDIO_MS)
+        interruptions = _records_for(caplog, vt.VOICE_SESSION_INTERRUPTION_COUNT)
+        assert len(started) == 1, "expected exactly one started event"
+        assert len(ended) == 1, "expected exactly one ended event"
+        assert started[0].session_id == persisted.session_id
+        assert started[0].age_group == "6-8"
+        assert ended[0].session_id == persisted.session_id
+        assert ended[0].ended_reason == "user_ended"
+        assert ended[0].duration_seconds >= 0
+        # A completed turn forwarded audio → first-audio + interruption
+        # (count 0) events fire exactly once at close.
+        assert len(first_audio) == 1
+        assert first_audio[0].first_audio_ms >= 0
+        assert len(interruptions) == 1
+        assert interruptions[0].count == 0
+
+    @pytest.mark.asyncio
+    async def test_safety_rejection_fires_on_blocked_reply(
+        self, test_db, consented_child, monkeypatch, caplog,
+    ):
+        persisted = await voice_session_repo.create_session(
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+            provider="mock",
+        )
+        token = mint_voice_token(
+            session_id=persisted.session_id,
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+        )
+
+        app.dependency_overrides[get_current_user] = _override_current_user
+        voice_realtime._set_test_provider_override(MockRealtimeVoiceProvider())
+        # Force the reply-side safety gate to fail so a safety_block fires.
+        monkeypatch.setattr(voice_realtime, "_safety_check_text", _fail_safety)
+        try:
+            with caplog.at_level(logging.INFO, logger=vt.__name__):
+                client = TestClient(app)
+                with client.websocket_connect(
+                    f"/api/v1/me/agent/voice/stream?token={token}"
+                ) as ws:
+                    audio_b64 = base64.b64encode(b"\x00" * 200).decode("ascii")
+                    ws.send_json({"type": "audio_chunk", "seq": 0, "audio_b64": audio_b64})
+                    ws.send_json({"type": "vad_end", "seq": 0})
+                    # Drain until the safety_block envelope arrives.
+                    while True:
+                        ev = ws.receive_json()
+                        if ev["type"] == "safety_block":
+                            break
+                    ws.send_json({"type": "client_done"})
+        finally:
+            app.dependency_overrides.pop(get_current_user, None)
+            voice_realtime._set_test_provider_override(None)
+
+        rejections = _records_for(caplog, vt.VOICE_SESSION_SAFETY_REJECTION)
+        assert rejections, "expected a safety rejection telemetry event"
+        assert rejections[-1].direction == "reply"

--- a/frontend/src/__tests__/utils/voiceTelemetry.test.ts
+++ b/frontend/src/__tests__/utils/voiceTelemetry.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  setVoiceTelemetrySink,
+  voiceTelemetry,
+  type VoiceTelemetryEvent,
+} from "@/utils/voiceTelemetry";
+
+describe("voiceTelemetry (#609)", () => {
+  afterEach(() => {
+    setVoiceTelemetrySink(null); // restore default console sink
+  });
+
+  function captureEvents() {
+    const events: VoiceTelemetryEvent[] = [];
+    setVoiceTelemetrySink((e) => events.push(e));
+    return events;
+  }
+
+  it("emits a started event with the provided fields", () => {
+    const events = captureEvents();
+    voiceTelemetry.sessionStarted({ sessionId: "s1", provider: "mock" });
+    expect(events).toEqual([
+      { event: "voice_session_started", sessionId: "s1", provider: "mock" },
+    ]);
+  });
+
+  it("rounds + floors duration on ended", () => {
+    const events = captureEvents();
+    voiceTelemetry.sessionEnded({
+      sessionId: "s2",
+      durationSeconds: 12.7,
+      endedReason: "client_closed",
+    });
+    expect(events[0]).toEqual({
+      event: "voice_session_ended",
+      sessionId: "s2",
+      durationSeconds: 13,
+      endedReason: "client_closed",
+    });
+  });
+
+  it("never emits a negative duration", () => {
+    const events = captureEvents();
+    voiceTelemetry.sessionEnded({
+      sessionId: "s2b",
+      durationSeconds: -5,
+      endedReason: "ws_1006",
+    });
+    expect((events[0] as { durationSeconds: number }).durationSeconds).toBe(0);
+  });
+
+  it("passes through valid safety directions", () => {
+    const events = captureEvents();
+    voiceTelemetry.safetyRejection({
+      sessionId: "s3",
+      direction: "reply",
+      category: "reply_blocked",
+    });
+    expect(events[0]).toEqual({
+      event: "voice_session_safety_rejection",
+      sessionId: "s3",
+      direction: "reply",
+      category: "reply_blocked",
+    });
+  });
+
+  it("collapses an unexpected direction to 'unknown'", () => {
+    const events = captureEvents();
+    voiceTelemetry.safetyRejection({ sessionId: "s4", direction: "sideways" });
+    expect((events[0] as { direction: string }).direction).toBe("unknown");
+  });
+
+  it("emits launch-flow + first-audio events", () => {
+    const events = captureEvents();
+    voiceTelemetry.launchFlowEmitted({ sessionId: "s5", flow: "image_story" });
+    voiceTelemetry.firstAudioMs({ sessionId: "s5", firstAudioMs: 812.4 });
+    expect(events).toEqual([
+      { event: "voice_session_launch_flow_emitted", sessionId: "s5", flow: "image_story" },
+      { event: "voice_session_first_audio_ms", sessionId: "s5", firstAudioMs: 812 },
+    ]);
+  });
+
+  it("is fire-and-forget: a throwing sink never propagates", () => {
+    setVoiceTelemetrySink(() => {
+      throw new Error("analytics down");
+    });
+    expect(() =>
+      voiceTelemetry.sessionStarted({ sessionId: "s6" }),
+    ).not.toThrow();
+  });
+
+  it("never carries transcript text on any event (PII guard)", () => {
+    const events = captureEvents();
+    voiceTelemetry.sessionStarted({ sessionId: "s7", provider: "mock" });
+    voiceTelemetry.safetyRejection({ sessionId: "s7", direction: "utterance" });
+    for (const e of events) {
+      const keys = Object.keys(e);
+      expect(keys).not.toContain("text");
+      expect(keys).not.toContain("transcript");
+    }
+  });
+});

--- a/frontend/src/hooks/useVoiceConversation.ts
+++ b/frontend/src/hooks/useVoiceConversation.ts
@@ -44,6 +44,7 @@ import {
   type VoiceConversationEvent,
   type VoiceConversationState,
 } from "./voiceConversationStateMachine";
+import { voiceTelemetry } from "@/utils/voiceTelemetry";
 
 export type VoiceErrorKind =
   | "auth"
@@ -189,6 +190,13 @@ export function useVoiceConversation(
   const lastSpeechAtRef = useRef<number | null>(null);
   const firstAboveAtRef = useRef<number | null>(null);
   const sentVadEndRef = useRef(false);
+  // #609 telemetry — session id + start timestamp read from inside WS
+  // callbacks (avoids the stale-closure trap of reading `sessionId`
+  // state). first-audio/ended guards ensure each fires at most once.
+  const sessionIdRef = useRef<string | null>(null);
+  const sessionStartedAtRef = useRef<number | null>(null);
+  const firstAudioEmittedRef = useRef(false);
+  const endedEmittedRef = useRef(false);
 
   const send = useCallback(
     (event: VoiceConversationEvent) => dispatch(event),
@@ -393,6 +401,22 @@ export function useVoiceConversation(
     });
   }
 
+  // #609 telemetry — emit the client-perceived session-end event at most
+  // once per session. Both ws.onclose and the WebRTC teardown can race to
+  // close, so the ref guard keeps the histogram honest.
+  function emitSessionEndedOnce(reason: string) {
+    if (endedEmittedRef.current) return;
+    const sid = sessionIdRef.current;
+    if (!sid) return;
+    endedEmittedRef.current = true;
+    const startedAt = sessionStartedAtRef.current;
+    voiceTelemetry.sessionEnded({
+      sessionId: sid,
+      durationSeconds: startedAt != null ? (nowMs() - startedAt) / 1000 : 0,
+      endedReason: reason,
+    });
+  }
+
   function handleServerFrame(raw: string) {
     const event = parseServerEvent(raw);
     if (event.type === "bad_json") return;
@@ -427,6 +451,20 @@ export function useVoiceConversation(
           for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
           ttsChunksRef.current.push(bytes);
           lastTtsChunkAtRef.current = nowMs();
+          // #609 telemetry — client-perceived time-to-first-audio: the
+          // gap from session open to the first audio byte the device
+          // actually received. Fires once; complements the server-side
+          // forward-time histogram.
+          if (!firstAudioEmittedRef.current && sessionIdRef.current) {
+            firstAudioEmittedRef.current = true;
+            const startedAt = sessionStartedAtRef.current;
+            if (startedAt != null) {
+              voiceTelemetry.firstAudioMs({
+                sessionId: sessionIdRef.current,
+                firstAudioMs: nowMs() - startedAt,
+              });
+            }
+          }
           scheduleTtsEndProbe();
         } catch {
           onError?.("network", "Failed to decode audio chunk");
@@ -441,6 +479,15 @@ export function useVoiceConversation(
         // the panel (#608). Reset on the next start().
         setSafetyBlockedSeen(true);
         onCaption?.({ kind: "safety_block", text: event.fallback_text });
+        // #609 telemetry — a turn was blocked; record which side without
+        // ever logging the (unsafe) text. category mirrors the direction.
+        if (sessionIdRef.current) {
+          voiceTelemetry.safetyRejection({
+            sessionId: sessionIdRef.current,
+            direction: event.direction,
+            category: `${event.direction}_blocked`,
+          });
+        }
         break;
       case "quota_exhausted":
         onError?.("quota", `Voice quota exhausted. Remaining: ${event.seconds_remaining ?? 0}s`);
@@ -775,6 +822,16 @@ export function useVoiceConversation(
       }
       send({ type: "tokenReceived" });
       setSessionId(response.session_id);
+      // #609 telemetry — client-perceived session open. Refs (not state)
+      // so the WS callbacks below read a fresh value, not a stale closure.
+      sessionIdRef.current = response.session_id;
+      sessionStartedAtRef.current = nowMs();
+      firstAudioEmittedRef.current = false;
+      endedEmittedRef.current = false;
+      voiceTelemetry.sessionStarted({
+        sessionId: response.session_id,
+        provider: response.provider_config?.provider,
+      });
 
       // #647: branch on the negotiated transport. The WebRTC path is
       // strictly an optimization — any failure path retries once with
@@ -792,6 +849,10 @@ export function useVoiceConversation(
       wsRef.current = ws;
       ws.onopen = () => send({ type: "wsOpen" });
       ws.onclose = (ev) => {
+        // #609 telemetry — client-perceived session end. Fires once for
+        // both graceful (1000) and abnormal closes; ended_reason maps the
+        // WS close code to a coarse bucket the dashboard can group on.
+        emitSessionEndedOnce(ev.code === 1000 ? "client_closed" : `ws_${ev.code}`);
         if (ev.code !== 1000) {
           send({ type: "streamError" });
           onError?.("network", `WebSocket closed: ${ev.code}`);

--- a/frontend/src/utils/voiceTelemetry.ts
+++ b/frontend/src/utils/voiceTelemetry.ts
@@ -1,0 +1,133 @@
+/**
+ * Voice session telemetry — client emit layer (#609 Phase D).
+ *
+ * Mirrors the backend `voice_telemetry` module: a small set of typed,
+ * PII-free events for the Talk-to-Buddy realtime voice surface. The
+ * backend broker is the authoritative source for session lifecycle (it
+ * owns the DB row + safety verdicts); these client events add the
+ * user-PERCEIVED view — e.g. time-to-first-audio as the kid's device
+ * actually heard it, which can differ from the server's forward time.
+ *
+ * Design rules (PRD §3.16 — child safety):
+ *   - PII-free by construction. Payloads carry IDs, durations, and
+ *     bounded categorical fields ONLY. No transcript text, no audio.
+ *   - Fire-and-forget. `emit` never throws — a dropped metric must
+ *     never break a live voice turn.
+ *   - Pluggable sink. The default routes to `console.debug` (visible in
+ *     dev, harmless in prod). Wire a real analytics client later via
+ *     `setVoiceTelemetrySink` without touching call sites.
+ */
+
+export type VoiceTelemetryEvent =
+  | {
+      event: "voice_session_started";
+      sessionId: string;
+      provider?: string;
+      ageGroup?: string;
+      agentId?: string;
+    }
+  | {
+      event: "voice_session_ended";
+      sessionId: string;
+      durationSeconds: number;
+      endedReason: string;
+    }
+  | {
+      event: "voice_session_safety_rejection";
+      sessionId: string;
+      direction: "utterance" | "reply" | "unknown";
+      category?: string;
+    }
+  | {
+      event: "voice_session_launch_flow_emitted";
+      sessionId: string;
+      flow: string;
+    }
+  | {
+      event: "voice_session_first_audio_ms";
+      sessionId: string;
+      firstAudioMs: number;
+    };
+
+export type VoiceTelemetrySink = (event: VoiceTelemetryEvent) => void;
+
+function defaultSink(event: VoiceTelemetryEvent): void {
+  // Dev-visible, prod-harmless. The integration seam for a real
+  // analytics provider (PostHog/GA/etc.) is `setVoiceTelemetrySink`.
+  if (typeof console !== "undefined" && typeof console.debug === "function") {
+    console.debug("[voice-telemetry]", event.event, event);
+  }
+}
+
+let sink: VoiceTelemetrySink = defaultSink;
+
+/**
+ * Swap the telemetry sink (e.g. install a real analytics client, or a
+ * spy in tests). Pass `null` to restore the default console sink.
+ */
+export function setVoiceTelemetrySink(next: VoiceTelemetrySink | null): void {
+  sink = next ?? defaultSink;
+}
+
+function emit(event: VoiceTelemetryEvent): void {
+  try {
+    sink(event);
+  } catch {
+    // Telemetry must never break a voice turn — swallow sink errors.
+  }
+}
+
+const VALID_DIRECTIONS = new Set(["utterance", "reply"]);
+
+export const voiceTelemetry = {
+  sessionStarted(args: {
+    sessionId: string;
+    provider?: string;
+    ageGroup?: string;
+    agentId?: string;
+  }): void {
+    emit({ event: "voice_session_started", ...args });
+  },
+
+  sessionEnded(args: {
+    sessionId: string;
+    durationSeconds: number;
+    endedReason: string;
+  }): void {
+    emit({
+      event: "voice_session_ended",
+      sessionId: args.sessionId,
+      durationSeconds: Math.max(0, Math.round(args.durationSeconds)),
+      endedReason: args.endedReason,
+    });
+  },
+
+  safetyRejection(args: {
+    sessionId: string;
+    direction: string;
+    category?: string;
+  }): void {
+    emit({
+      event: "voice_session_safety_rejection",
+      sessionId: args.sessionId,
+      // Collapse any unexpected value so a wiring bug can't push a
+      // free-form (possibly content-derived) string downstream.
+      direction: VALID_DIRECTIONS.has(args.direction)
+        ? (args.direction as "utterance" | "reply")
+        : "unknown",
+      category: args.category,
+    });
+  },
+
+  launchFlowEmitted(args: { sessionId: string; flow: string }): void {
+    emit({ event: "voice_session_launch_flow_emitted", ...args });
+  },
+
+  firstAudioMs(args: { sessionId: string; firstAudioMs: number }): void {
+    emit({
+      event: "voice_session_first_audio_ms",
+      sessionId: args.sessionId,
+      firstAudioMs: Math.max(0, Math.round(args.firstAudioMs)),
+    });
+  },
+};


### PR DESCRIPTION
## Summary

First track of **#609 (Phase D — Polish, parent visibility, and telemetry for Talk to Buddy)**: the **telemetry vertical**. Adds the structured event layer the ops dashboards + Parent Dashboard need so we can measure the realtime-voice surface — session lifecycle, safety rejections, time-to-first-audio, and launch-flow engagement.

This is intentionally scoped to telemetry; the other #609 tracks (Parent Dashboard voice section, quota UX, accessibility pass, docs) are separate PRs.

## Backend

- **`backend/src/services/voice_telemetry.py`** — 6 canonical, **PII-free** emitters: `voice_session_started`, `voice_session_ended`, `voice_session_safety_rejection`, `voice_session_launch_flow_emitted`, `voice_session_first_audio_ms`, `voice_session_interruption_count`. Each writes a flat `event=<name>` structured-log record (matches the existing `log_voice_session_end` cost line). Emitters accept IDs / durations / bounded enums **only** — there is deliberately no `text`/`transcript` parameter, so child speech can't leak into the metrics stream. `_emit` is fire-and-forget (never breaks a live turn).
- **`voice_realtime.py` broker** — wired emitters at their natural points: session open (`started`, with best-effort `agent_id`), both safety-block sides (`safety_rejection` with `direction`), launch-flow dispatch, and close-time lifecycle events in the `finally` block (fire-once by construction).

## Frontend

- **`frontend/src/utils/voiceTelemetry.ts`** — mirrors the backend events with a **pluggable sink** (default `console.debug`, swap a real analytics client via `setVoiceTelemetrySink`). PII-free + fire-and-forget, with `direction` normalisation.
- **`useVoiceConversation.ts`** — emits client-*perceived* `started` / `first_audio_ms` / `safety_rejection` / `ended` via refs (avoids the stale-closure trap on `sessionId`). Client first-audio is the latency the device actually heard, complementing the server forward-time.

## Tests

- **`test_voice_telemetry_contract.py`** (new) — per-emitter record shape, PII + `direction` invariants, and a broker integration test (started/ended/first-audio/interruption + safety rejection fire during a mock WS session).
- **`voiceTelemetry.test.ts`** (new) — event shapes, direction normalisation, PII guard, fire-and-forget.
- **`test_voice_broker_contract.py`** — made the existing `end_session` contract test deterministic (drain-until-close); it was racy and the new start-path `agent_id` lookup exposed it.

`backend: 212 passed / 1 skipped` (voice contracts) · `frontend: 160 passed`.

## Acceptance criteria addressed

- [x] All voice telemetry events fire correctly; verified by inspecting the telemetry log in dev (backend contract test asserts the structured records)
- [ ] (other #609 ACs handled in follow-up track PRs)

## Out of scope / follow-ups

- Parent Dashboard "Voice & Microphone" section, quota UX, accessibility pass, and the 4 docs files (separate #609 tracks).
- Backend barge-in interruption signal isn't wired yet, so `interruption_count` emits `0` until that lands (frontend already detects barge-in; backend counter is the follow-up).

Related to #609
Parent Epic: #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)