### PR TITLE
docs(voice): document Talk-to-Buddy provider setup

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,10 +7,17 @@ CLAUDE_AGENT_MODEL=claude-haiku-4-5
 SAFETY_CHECK_MODEL=claude-haiku-4-5
 VISION_ANALYSIS_MODEL=claude-haiku-4-5
 
-# OpenAI TTS (optional)
+# OpenAI TTS + Whisper STT for Talk-to-Buddy hybrid voice
 OPENAI_API_KEY=your_openai_api_key_here
 
-# ElevenLabs TTS (optional — SOTA expressive voices, #243)
+# Talk-to-Buddy local provider:
+#   mock   = deterministic offline provider; every utterance transcribes as
+#            "hello buddy this is a mock transcript"
+#   hybrid = OpenAI Whisper STT + My Agent + ElevenLabs TTS
+REALTIME_VOICE_PROVIDER=mock
+
+# ElevenLabs TTS (required for spoken Talk-to-Buddy audio when provider=hybrid;
+# optional for story narration fallback paths)
 ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
 
 # ============================================================================

--- a/docs/learning/backend/overview.md
+++ b/docs/learning/backend/overview.md
@@ -89,6 +89,16 @@ event: result    → Final story data
 event: complete  → Generation finished
 ```
 
+### Talk-to-Buddy Voice Provider
+Realtime voice sessions use `backend/src/services/realtime_voice_service.py` to pick a provider from `REALTIME_VOICE_PROVIDER`.
+
+| Provider | Local behavior |
+|----------|----------------|
+| `mock` | Deterministic offline path for UI and contract tests. It always returns the canned transcript `hello buddy this is a mock transcript`. |
+| `hybrid` | Real local path: OpenAI Whisper STT → My Agent reply → ElevenLabs TTS audio. Requires `OPENAI_API_KEY` for transcription and `ELEVENLABS_API_KEY` for spoken reply audio. |
+
+If the provider flag is unset, local development falls back to `mock`, so hearing or seeing the canned transcript usually means the backend is not running with `REALTIME_VOICE_PROVIDER=hybrid`. Restart the backend after changing this env var; existing voice WebSocket sessions keep the provider they started with.
+
 ## Key Concepts
 
 **FastAPI**: A modern Python web framework that uses type hints for automatic request validation, documentation generation, and async support. Think of it as the receptionist who takes requests and routes them to the right department.

--- a/docs/learning/infrastructure/environment-variables.md
+++ b/docs/learning/infrastructure/environment-variables.md
@@ -26,14 +26,15 @@ Production (Railway + Vercel):
 | Variable | Purpose | Where to Get It |
 |----------|---------|-----------------|
 | `ANTHROPIC_API_KEY` | Claude API for agents, vision, safety checks | console.anthropic.com |
-| `OPENAI_API_KEY` | TTS audio generation (OpenAI voices) | platform.openai.com |
+| `OPENAI_API_KEY` | OpenAI services: story TTS, Whisper STT for Talk-to-Buddy `hybrid` voice | platform.openai.com |
 | `DATABASE_URL` | PostgreSQL connection string | Supabase project settings |
 | `SUPABASE_URL` | Supabase project URL (for JWKS fetch) | Supabase project settings |
 | `SUPABASE_JWT_SECRET` | JWT validation fallback (HS256) | Supabase project settings |
 | `SUPABASE_SERVICE_ROLE_KEY` | Admin operations (bypass RLS) | Supabase project settings |
 | `RESEND_API_KEY` | Email delivery via Resend SMTP | resend.com dashboard |
 | `TAVILY_API_KEY` | News headline search for Kids Daily | tavily.com |
-| `ELEVENLABS_API_KEY` | ElevenLabs TTS voices | elevenlabs.io |
+| `ELEVENLABS_API_KEY` | ElevenLabs TTS voices; required for spoken Talk-to-Buddy audio in `hybrid` mode | elevenlabs.io |
+| `REALTIME_VOICE_PROVIDER` | Talk-to-Buddy provider: `mock` for deterministic offline testing, `hybrid` for Whisper + My Agent + ElevenLabs | Set manually |
 | `ALLOWED_ORIGINS` | CORS whitelist for frontend URLs | Set manually |
 | `ADMIN_API_KEY` | Admin endpoint authentication | Generate a random secret |
 
@@ -54,6 +55,19 @@ Production (Railway + Vercel):
 **.env File**: A plain text file (`KEY=value`, one per line) that's loaded at startup. `.env` is in `.gitignore` — it never gets committed to GitHub. `.env.example` shows the required keys without real values, so new developers know what to set up.
 
 **Build-Time vs Runtime**: Vite `VITE_*` variables are replaced during `npm run build` — they become literal strings in the output JavaScript. Backend `os.environ` variables are read at runtime — you can change them by restarting the server without rebuilding.
+
+## Local Talk-to-Buddy Voice
+
+Talk-to-Buddy uses `REALTIME_VOICE_PROVIDER` on the backend:
+
+| Value | Behavior | Required Keys |
+|-------|----------|---------------|
+| `mock` | Offline deterministic provider. Every finalized utterance returns the canned transcript `hello buddy this is a mock transcript`; useful for contract tests and UI plumbing. | None |
+| `hybrid` | Real local voice path: OpenAI Whisper transcribes the child, My Agent generates the reply, and ElevenLabs streams spoken audio. | `OPENAI_API_KEY`, `ELEVENLABS_API_KEY` |
+
+If `REALTIME_VOICE_PROVIDER` is missing, the current local-safe default is the mock provider. If `hybrid` is set but `ELEVENLABS_API_KEY` is missing, transcription and text replies can still work, but spoken reply audio may be silent.
+
+After changing `REALTIME_VOICE_PROVIDER` or voice keys, restart the backend process. Existing WebSocket voice sessions keep using the provider selected when that session started.
 
 ## Connections
 


### PR DESCRIPTION
## Summary
- document `REALTIME_VOICE_PROVIDER=mock` vs `hybrid` for local Talk-to-Buddy testing
- clarify OpenAI Whisper and ElevenLabs key requirements for the hybrid path
- add provider guidance to `backend/.env.example` and learning docs

## Checks
- `rg -n "REALTIME_VOICE_PROVIDER|hello buddy this is a mock transcript|ELEVENLABS_API_KEY|OPENAI_API_KEY" backend/.env.example docs/learning/infrastructure/environment-variables.md docs/learning/backend/overview.md`

Fixes #671