### PR TITLE
chore(dev): harden backend startup script

### DIFF
--- a/backend/scripts/start_server.py
+++ b/backend/scripts/start_server.py
@@ -1,51 +1,81 @@
 #!/usr/bin/env python3
 """
-Start FastAPI server
+Start FastAPI server.
+
+This script is intentionally runnable from both the repository root:
+
+    python backend/scripts/start_server.py
+
+and the backend directory:
+
+    cd backend
+    python scripts/start_server.py
 """
 
+from __future__ import annotations
+
+import os
 import sys
 from pathlib import Path
 
-# Add project path
-project_root = Path(__file__).parent
-sys.path.insert(0, str(project_root))
 
-print("=== Starting Creative Agent API Service ===\n")
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
 
-try:
-    print("1. Importing FastAPI...")
-    import fastapi
-    print(f"   ✅ FastAPI version: {fastapi.__version__}")
 
-    print("2. Importing uvicorn...")
-    import uvicorn
-    print(f"   ✅ Uvicorn imported")
+def _configure_import_path() -> None:
+    root = str(_repo_root())
+    if root not in sys.path:
+        sys.path.insert(0, root)
 
-    print("3. Importing application...")
-    from backend.src.main import app
-    print("   ✅ Application imported successfully")
 
-    print("\n4. Starting server...")
-    print("   Address: http://localhost:8000")
-    print("   Docs: http://localhost:8000/api/docs")
-    print("   Press Ctrl+C to stop the server\n")
+def main() -> int:
+    _configure_import_path()
 
-    uvicorn.run(
-        app,
-        host="0.0.0.0",
-        port=8000,
-        log_level="info"
-    )
+    print("=== Starting Creative Agent API Service ===\n")
 
-except ImportError as e:
-    print(f"\n❌ Import error: {e}")
-    print("\nPlease ensure all dependencies are installed:")
-    print("  cd backend")
-    print("  pip install -r requirements.txt")
-    sys.exit(1)
+    try:
+        print("1. Importing FastAPI...")
+        import fastapi
+        print(f"   ✅ FastAPI version: {fastapi.__version__}")
 
-except Exception as e:
-    print(f"\n❌ Startup failed: {e}")
-    import traceback
-    traceback.print_exc()
-    sys.exit(1)
+        print("2. Importing uvicorn...")
+        import uvicorn
+        print("   ✅ Uvicorn imported")
+
+        print("3. Importing application...")
+        from backend.src.main import app
+        print("   ✅ Application imported successfully")
+
+        if os.getenv("CREATIVE_AGENT_STARTUP_IMPORT_CHECK") == "1":
+            return 0
+
+        print("\n4. Starting server...")
+        print("   Address: http://localhost:8000")
+        print("   Docs: http://localhost:8000/api/docs")
+        print("   Press Ctrl+C to stop the server\n")
+
+        uvicorn.run(
+            app,
+            host="0.0.0.0",
+            port=8000,
+            log_level="info",
+        )
+        return 0
+
+    except ImportError as e:
+        print(f"\n❌ Import error: {e}")
+        print("\nPlease ensure all dependencies are installed:")
+        print("  cd backend")
+        print("  pip install -r requirements.txt")
+        return 1
+
+    except Exception as e:
+        print(f"\n❌ Startup failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/unit/test_start_server_script.py
+++ b/backend/tests/unit/test_start_server_script.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BACKEND_DIR = REPO_ROOT / "backend"
+
+
+def _run_import_check(*, cwd: Path, script: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["CREATIVE_AGENT_STARTUP_IMPORT_CHECK"] = "1"
+    env.pop("PYTHONPATH", None)
+    return subprocess.run(
+        [sys.executable, script],
+        cwd=cwd,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def test_start_server_imports_app_from_repo_root():
+    result = _run_import_check(
+        cwd=REPO_ROOT,
+        script="backend/scripts/start_server.py",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Application imported successfully" in result.stdout
+
+
+def test_start_server_imports_app_from_backend_cwd():
+    result = _run_import_check(
+        cwd=BACKEND_DIR,
+        script="scripts/start_server.py",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Application imported successfully" in result.stdout


### PR DESCRIPTION
## Summary
- make `backend/scripts/start_server.py` configure the repo root on `sys.path`
- support import-check mode for startup verification without binding a port
- cover startup imports from both repo root and `backend/` working directories

## Tests
- `/Users/xenodennis/Fun/python101/projects/claude_code/creative_agent/backend/.venv/bin/pytest backend/tests/unit/test_start_server_script.py -q`

Fixes #672