### PR TITLE
fix(auth): validate registration usernames

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,38 @@
+/* @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+import { AxiosError } from "axios";
+
+import { getErrorMessage } from "./client";
+
+describe("getErrorMessage", () => {
+  it("surfaces the first backend validation detail", () => {
+    const error = new AxiosError(
+      "Request failed with status code 422",
+      "ERR_BAD_REQUEST",
+      undefined,
+      undefined,
+      {
+        status: 422,
+        statusText: "Unprocessable Entity",
+        headers: {},
+        config: {} as never,
+        data: {
+          error: "ValidationError",
+          message: "Request parameter validation failed",
+          details: [
+            {
+              field: "body.username",
+              message:
+                "Value error, Username can only contain letters, numbers, underscores, and hyphens",
+              code: "value_error",
+            },
+          ],
+          timestamp: "2026-06-14T00:00:00",
+        },
+      },
+    );
+
+    expect(getErrorMessage(error)).toContain("Username can only contain");
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -74,6 +74,11 @@ export function getErrorMessage(error: unknown): string {
     // FastAPI uses "detail", custom APIs use "message"
     const detail = data?.detail
     if (typeof detail === 'string') return detail
+    const details = data?.details
+    if (Array.isArray(details) && details.length > 0) {
+      const first = details[0] as Record<string, unknown>
+      if (typeof first.message === 'string') return first.message
+    }
     if (data?.message && typeof data.message === 'string') return data.message
     if (axiosError.message) return axiosError.message
   }

--- a/frontend/src/pages/LoginPage/LoginPage.validation.test.ts
+++ b/frontend/src/pages/LoginPage/LoginPage.validation.test.ts
@@ -1,0 +1,16 @@
+/* @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { isValidRegistrationUsername } from "./validation";
+
+describe("LoginPage registration validation", () => {
+  it("accepts backend-compatible usernames", () => {
+    expect(isValidRegistrationUsername("parent_1")).toBe(true);
+    expect(isValidRegistrationUsername("kid-test")).toBe(true);
+  });
+
+  it("rejects email-shaped usernames before submit", () => {
+    expect(isValidRegistrationUsername("parent@example.com")).toBe(false);
+  });
+});

--- a/frontend/src/pages/LoginPage/index.tsx
+++ b/frontend/src/pages/LoginPage/index.tsx
@@ -8,6 +8,7 @@ import { getErrorMessage } from '@/api/client'
 import useAuthStore from '@/store/useAuthStore'
 import useChildStore, { DEFAULT_INTERESTS, generateChildId } from '@/store/useChildStore'
 import type { AgeGroup } from '@/types/api'
+import { isValidRegistrationUsername } from './validation'
 
 type AuthMode = 'login' | 'register'
 type RegistrationRole = 'parent' | 'child'
@@ -83,6 +84,8 @@ function LoginPage() {
       if (!password) return 'Please enter your password'
     } else {
       if (!username.trim()) return 'Please enter a username'
+      if (!isValidRegistrationUsername(username))
+        return 'Username can only contain letters, numbers, underscores, and hyphens'
       if (!email.trim()) return 'Please enter your email'
       if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) return 'Please enter a valid email'
       if (registrationRole === 'parent') {
@@ -209,12 +212,14 @@ function LoginPage() {
 
   // Switch between login and register
   const switchMode = () => {
-    setMode(mode === 'login' ? 'register' : 'login')
+    const nextMode = mode === 'login' ? 'register' : 'login'
+    setMode(nextMode)
     setError(null)
     setConfirmationPending(false)
     setEmailConfirmation(false)
     setConfirmationEmail('')
     setConfirmationNotice(null)
+    if (nextMode === 'register' && username.includes('@')) setUsername('')
     setPassword('')
     setConfirmPassword('')
     setParentEmail('')

--- a/frontend/src/pages/LoginPage/validation.ts
+++ b/frontend/src/pages/LoginPage/validation.ts
@@ -1,0 +1,5 @@
+const USERNAME_PATTERN = /^[A-Za-z0-9_-]+$/
+
+export function isValidRegistrationUsername(username: string): boolean {
+  return USERNAME_PATTERN.test(username.trim())
+}


### PR DESCRIPTION
## Summary
- validate registration usernames before submitting to the backend
- clear email-shaped dev login values when switching into register mode
- surface backend validation detail messages from `details[]` in shared API errors

## Tests
- `/Users/xenodennis/Fun/python101/projects/claude_code/creative_agent/frontend/node_modules/.bin/vitest run src/pages/LoginPage/LoginPage.validation.test.ts src/api/client.test.ts src/api/services/authService.test.ts src/api/services/authService.supabase.test.ts`

Fixes #673
Parent Epic: #436