### PR TITLE
feat(my-agent): age-adapted header CTA copy helper for Talk to Buddy

### DIFF
--- a/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
+++ b/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   captionsDefaultForAge,
+  headerCTACopy,
   isEndButtonEnabled,
   isPanelVisible,
   nextPendingGate,
@@ -280,5 +281,44 @@ describe("resolveCaptionsVisibility (#608)", () => {
     // a half-wired parent falls back to the per-age default.
     expect(resolveCaptionsVisibility(8, false)).toBe(true);
     expect(resolveCaptionsVisibility(4, false)).toBe(false);
+  });
+});
+
+describe("headerCTACopy (#638)", () => {
+  // Locks the per-age entry-surface copy to PRD §3.16.6:
+  //   | 3-5            | 6-8                  | 9-12            |
+  //   | emoji + "Talk!"| "Talk to {buddy}"    | mic + "Voice"   |
+  // Pure helper so the labels can't drift away from the table. One
+  // assertion per age band — the AC's "three tests, one per age".
+
+  it("3-5 → giant mic emoji + 'Talk!' (pre-readers get the emoji, no name)", () => {
+    expect(headerCTACopy("3-5", "Sparky")).toEqual({
+      label: "Talk!",
+      emoji: "🎤",
+    });
+  });
+
+  it("6-8 → 'Talk to {buddy_name}', no emoji", () => {
+    // The mid band reads fluently and is motivated by the personal
+    // relationship, so the buddy's name leads and there's no emoji.
+    expect(headerCTACopy("6-8", "Sparky")).toEqual({
+      label: "Talk to Sparky",
+      emoji: "",
+    });
+  });
+
+  it("9-12 → mic icon + 'Voice' (older kids get the terse, tool-like label)", () => {
+    expect(headerCTACopy("9-12", "Sparky")).toEqual({
+      label: "Voice",
+      emoji: "🎤",
+    });
+  });
+
+  it("interpolates the buddy name only for the 6-8 band", () => {
+    // The name is load-bearing only in the mid band's label; the other
+    // bands ignore it. A renamed buddy must not leak into 3-5 / 9-12.
+    expect(headerCTACopy("3-5", "Rex").label).toBe("Talk!");
+    expect(headerCTACopy("9-12", "Rex").label).toBe("Voice");
+    expect(headerCTACopy("6-8", "Rex").label).toBe("Talk to Rex");
   });
 });

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -42,6 +42,7 @@ import TalkToBuddyPanel, {
   type TalkToBuddyPanelVariant,
 } from "./TalkToBuddyPanel";
 import {
+  headerCTACopy,
   nextPendingGate,
   shouldShowEntryButton,
   shouldShowHeaderTalkPill,
@@ -307,6 +308,11 @@ export default function AgentChatPanel({
       isTalkOpen,
     );
 
+  // #638: age-adapt the header pill's visible label + emoji from the
+  // PRD §3.16.6 table. Falls back to the 6-8 band when the child's age
+  // group hasn't loaded — a readable, name-led default for any reader.
+  const headerCta = headerCTACopy(ageGroup ?? "6-8", agent.agent_name);
+
   const handleOpenTalk = () => {
     if (talkEntryReady) {
       setIsTalkOpen(true);
@@ -474,8 +480,10 @@ export default function AgentChatPanel({
               title={`Start talking with ${agent.agent_name}`}
               aria-label={`Start talking with ${agent.agent_name}`}
             >
-              <span aria-hidden="true">💬</span>
-              <span>Start Talking</span>
+              {headerCta.emoji && (
+                <span aria-hidden="true">{headerCta.emoji}</span>
+              )}
+              <span>{headerCta.label}</span>
             </button>
           )}
           {/* Consents-missing fallback: surface the entry as "Ask"

--- a/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
@@ -7,6 +7,7 @@
  */
 
 import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
+import type { AgeGroup } from "@/types/api";
 
 /**
  * User-facing status copy keyed by the voiceConversationStateMachine
@@ -199,4 +200,47 @@ export function resolveCaptionsVisibility(
 ): boolean {
   if (override === true) return true;
   return captionsDefaultForAge(age);
+}
+
+/**
+ * Age-adapted entry-surface copy for the header "Start Talking" pill
+ * (#638). Locks the labels to the PRD §3.16.6 age-adaptation table so
+ * the visible CTA can't drift away from the spec:
+ *
+ * | 3-5                | 6-8                  | 9-12              |
+ * | giant emoji + Talk!| "Talk to {buddy}"    | mic icon + Voice  |
+ *
+ * Design choices (per PRD):
+ *   - 3-5 (pre-readers): a single playful word + a big mic emoji. The
+ *     buddy name is deliberately omitted — a 4-year-old recognises the
+ *     emoji, not the persona's name.
+ *   - 6-8: the buddy NAME leads ("Talk to Sparky") because the personal
+ *     relationship is the motivator at this age; no emoji to keep it
+ *     reading like a sentence.
+ *   - 9-12: terse, tool-like "Voice" with a mic icon — older kids treat
+ *     it as a mode switch, not a character interaction.
+ *
+ * Reuses the canonical ``AgeGroup`` from ``@/types/api`` rather than a
+ * local copy so a future fourth band (there isn't one today) can't drift
+ * between modules. ``emoji`` is the empty string for 6-8 — the consuming
+ * JSX renders the emoji span only when non-empty.
+ */
+export interface HeaderCTACopy {
+  label: string;
+  emoji: string;
+}
+
+export function headerCTACopy(
+  ageGroup: AgeGroup,
+  buddyName: string,
+): HeaderCTACopy {
+  switch (ageGroup) {
+    case "3-5":
+      return { label: "Talk!", emoji: "🎤" };
+    case "9-12":
+      return { label: "Voice", emoji: "🎤" };
+    case "6-8":
+    default:
+      return { label: `Talk to ${buddyName}`, emoji: "" };
+  }
 }


### PR DESCRIPTION
## Summary

Resolves **#638**. Locks the per-age-group "Start Talking" header pill copy to the **PRD §3.16.6** age-adaptation table in a pure, unit-tested helper so the visible CTA can't drift away from the spec.

| 3-5 | 6-8 | 9-12 |
|-----|-----|------|
| 🎤 + "Talk!" | "Talk to {buddy_name}" | 🎤 + "Voice" |

- **3-5** (pre-readers): a playful word + a big mic emoji; the buddy name is omitted (a 4-year-old recognises the emoji, not the persona name).
- **6-8**: the buddy NAME leads ("Talk to Sparky") because the personal relationship is the motivator; no emoji so it reads like a sentence.
- **9-12**: terse, tool-like "Voice" with a mic icon — older kids treat it as a mode switch.

## Changes

- **`talkToBuddyHelpers.ts`** — new `headerCTACopy(ageGroup, buddyName): { label, emoji }`. Same pure-helper pattern as `TALK_PANEL_STATE_COPY` (#618). **Reuses the canonical `AgeGroup` from `@/types/api`** instead of the local type the issue sketched — avoids a duplicate band definition drifting between modules.
- **`AgentChatPanel.tsx`** — the #636 header pill now consumes the helper; the visible label/emoji are no longer JSX string literals. The emoji `<span>` renders only when non-empty (6-8 has none). Falls back to the 6-8 band when `ageGroup` hasn't loaded.
- **`talkToBuddyHelpers.test.ts`** — three per-age output locks + a name-interpolation test (the buddy name leaks only into the 6-8 label).

## Acceptance criteria

- [x] Helper returns the exact PRD §3.16.6 entry-surface copy per age group
- [x] Three tests (one per age) lock the output strings (+1 interpolation test)
- [x] Header pill in `AgentChatPanel` consumes the helper; no visible string literals in JSX
- [x] tsc clean

## Tests

`tsc --noEmit` clean · full frontend suite **430 passed (49 files)**.

## Note on coordination

Branched off the freshly-merged `origin/main` (includes #670). `AgentChatPanel.tsx` is also being edited by a parallel session (#668) — this change only touches the header-pill label/emoji lines, so any overlap should be a small, mechanical merge.

Fixes #638
Parent Epic: #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)