### PR TITLE
feat(my-agent): polish Talk to Buddy telemetry surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,14 @@ CHROMA_PATH=./data/vectors
 All AI-generated content MUST pass through `check_content_safety` MCP tool before delivery.
 Safety score threshold: >= 0.85. The `suggest_content_improvements` tool is used to fix failing content.
 
+<a id="_safety-best-practices"></a>
+#### Safety Best Practices
+
+- Streaming surfaces must fail closed before user-visible delivery. For Talk to Buddy, this means the child utterance is checked before it reaches the My Agent proxy, and the buddy reply is checked again before any TTS/audio frame is sent.
+- Do not persist raw child audio. Durable voice history is transcript-only and must use bounded modality fields such as `input_modality` and `output_modality`.
+- Telemetry must use bounded reason codes and numeric timing/count fields only. Never log child speech, buddy reply text, raw audio, or free-form prompt content.
+- Provider fallback must preserve the same safety gates. Switching between mock, hybrid, and OpenAI realtime providers must not bypass consent, quota, enabled-skill, or pre-TTS moderation checks.
+
 ### Age Adaptation
 Stories must be adapted to the child's age group (3-5, 6-8, 9-12). See `backend/src/prompts/age-adapter.md` for rules.
 

--- a/docs/architecture/talk-to-buddy.md
+++ b/docs/architecture/talk-to-buddy.md
@@ -1,0 +1,91 @@
+# Talk to Buddy Architecture
+
+Talk to Buddy is the realtime voice surface for My Agent. It adds speech input
+and speech output to the existing buddy chat without changing the underlying
+My Agent proxy, memory, safety, or launch-flow contracts.
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant FastAPI
+    participant Provider as RealtimeVoiceProvider
+    participant Safety as check_content_safety
+    participant Agent as My Agent proxy
+    participant Telemetry
+
+    Browser->>FastAPI: POST /api/v1/me/agent/voice/session
+    FastAPI->>FastAPI: verify child ownership, consent, quota, enabled skills
+    FastAPI-->>Browser: single-use voice token + transport
+    Browser->>FastAPI: WS /api/v1/me/agent/voice/stream
+    FastAPI->>Provider: start_session(...)
+    FastAPI->>Telemetry: voice_session_started
+    Browser->>FastAPI: audio_chunk / vad_end
+    FastAPI->>Provider: finalize_utterance()
+    Provider-->>FastAPI: transcript
+    FastAPI->>Safety: child utterance safety gate
+    FastAPI->>Agent: stream_my_agent_chat(...)
+    Agent-->>FastAPI: text deltas or launch_flow
+    FastAPI->>Safety: buddy reply pre-TTS gate
+    FastAPI->>Provider: synthesize_speech(...)
+    Provider-->>FastAPI: audio chunks
+    FastAPI-->>Browser: transcript + assistant_audio
+    FastAPI->>Telemetry: first_audio_ms / safety / launch_flow
+    Browser->>FastAPI: end
+    FastAPI->>Telemetry: voice_session_ended + interruption_count
+```
+
+## Provider Abstraction
+
+The broker depends on `RealtimeVoiceProvider` in
+`backend/src/services/realtime_voice_service.py`. Provider selection is process
+level and controlled by `REALTIME_VOICE_PROVIDER`:
+
+| Value | Provider | Notes |
+|---|---|---|
+| `mock` | `MockRealtimeVoiceProvider` | Deterministic local/test path. Always returns the same transcript. |
+| `hybrid` | `HybridRealtimeVoiceProvider` | Cascaded STT + Claude + TTS fallback. Degrades internally when optional provider keys are absent. |
+| `openai` | `OpenAIRealtimeProvider` | Primary realtime path when `OPENAI_API_KEY` exists. Falls back to hybrid if the key is missing. |
+| unset | `MockRealtimeVoiceProvider` | Safe dev default. |
+
+The browser uses the same session endpoint for every provider. The backend
+chooses `transport="webrtc"` only when the caller opts in and the selected
+provider can mint a browser-direct OpenAI realtime secret; otherwise the WS
+broker remains the universal transport.
+
+## Safety Pipeline
+
+Safety is fail-closed at three points:
+
+1. Token mint verifies child ownership, microphone consent, voice-conversation
+   consent, rolling quota, and enabled-skill eligibility before a session can
+   start.
+2. Every finalized child utterance runs through `check_content_safety` before it
+   reaches the My Agent proxy.
+3. Every buddy reply runs through the normal reply safety path before text is
+   converted to speech. If the safety MCP tool or review specialist fails, the
+   reply is replaced by the age-safe fallback.
+
+Raw audio bytes are transient. The browser streams chunks to the broker, the
+broker forwards them to the selected provider, and no route writes raw audio to
+disk. Durable history is transcript-only through `agent_chat_messages` with
+voice modality fields.
+
+## Telemetry Surface
+
+`backend/src/services/voice_telemetry.py` emits bounded structured events only.
+Do not put child speech, buddy text, raw audio, or free-form prompt content in
+these records.
+
+| Event | Purpose |
+|---|---|
+| `voice_session_started` | Engagement by age group, provider, and buddy persona. |
+| `voice_session_ended` | Duration and ended reason, including timeout, quota, disconnect, and normal end. |
+| `voice_session_safety_rejection` | Counts rejected utterance/reply turns by bounded category. |
+| `voice_session_launch_flow_emitted` | Measures voice-driven handoff into creation flows. |
+| `voice_session_first_audio_ms` | Time to first audible buddy response for p50/p95 latency. |
+| `voice_session_interruption_count` | Barge-in tuning signal, emitted once at session close. |
+
+The launch checklist for production provider rollout lives in
+`docs/guides/voice-launch-prerequisites.md`.

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -1355,6 +1355,8 @@ The existing tear-to-claim-star mechanic (Epic #371) is preserved:
 
 > Each child has a customized AI companion ("creative buddy") that serves as their personal creative assistant and as the public byline whenever they share work in Content Hub (§3.12). The buddy is the privacy primitive: real names, usernames, and emails are never shown publicly — only the buddy the child crafted.
 
+> Voice cross-reference: Talk to Buddy (§3.16) is the realtime spoken surface for this same buddy. It reuses the My Agent proxy, memory, safety, and launch-flow contracts defined in §3.11.7 rather than introducing a separate voice-only assistant.
+
 #### 3.11.1 Product Vision
 
 **Core purpose**: Give every child a stable, customized creative companion that grows with them. The buddy answers: *"Who's making this with me, and who do I show up as when I share?"*
@@ -1979,6 +1981,8 @@ Two parallel tracks:
 
 Two-way spoken conversation between the child and their My Agent buddy on `/my-agent`. Voice is a new I/O surface on top of the existing My Agent proxy (§3.11.7) — the proxy, memory wiring (§3.5), safety pipeline (§3.4), `launch_flow` handoffs, and Content Hub byline (§3.12) are all unchanged. Text-chat replies stay text-only in v1; voice is a separate surface, not a TTS overlay on text chat.
 
+Architecture reference: `docs/architecture/talk-to-buddy.md` documents the provider abstraction, fail-closed safety pipeline, transcript-only persistence invariant, and telemetry events.
+
 ### 3.16.1 Problem
 The buddy promise is companionship. Ages 3-5 cannot read the buddy's text replies, and ages 6-12 find typing slow on tablets. The existing one-shot `VoiceInputButton` (§3.15) lets a child speak a single prompt, but the buddy still answers in silence. That breaks the "creative buddy" pitch for the core pre-reader cohort and creates an unnatural rhythm for tablet users.
 
@@ -2007,7 +2011,7 @@ Both are parent-PIN-gated via `ParentApprovalPage`. The consent screen explicitl
 
 ### 3.16.5 Frontend Entry & Layout
 - **Entry surface (v2 — supersedes the FAB pattern from PR #633):** a prominent "Start Talking" pill in the **`AgentChatPanel` header**, gated by `shouldShowEntryButton` (capability + both consents + active child + not currently text-streaming + not already in voice mode).
-- **In-place layout (replaces the full-screen overlay):** tapping the header pill swaps the composer textarea/send region for an **inline voice bubble** — the `TalkToBuddyPanel` mounted with `variant="inline"`. The message list above stays scrollable and visible; voice transcripts merge into the same list via `useAgentChatStore.appendVoiceCaption`. Tapping **End** unmounts the bubble and re-mounts the composer with focus restored to the textarea.
+- **In-place layout (replaces the full-screen overlay):** tapping the header pill swaps the composer textarea/send region for an **inline voice bubble** — the `TalkToBuddyPanel` mounted with `variant="inline"`. The message list above stays scrollable and visible; finalized voice turns persist into the same chat history as text turns with voice modality fields. Tapping **End** unmounts the bubble and re-mounts the composer with focus restored to the textarea.
 - **Why this beats the overlay+FAB pattern**: a single conversation surface, no modality jump, kid never sees two input affordances at once, scroll history stays anchored.
 - **Why the entry stays inside `AgentChatPanel` (not global `PageContainer` chrome)**: only meaningful on `/my-agent` with a buddy + consents; cross-page header would re-litigate the "Ask"/"Talk" header-pill decision from commit `e31c2aa0`. The same rule applies — the entry surface lives where the action lives.
 - **Setup path unchanged**: when `talkEntryReady === false`, the header pill is hidden. The empty-state onboarding banner from PR #633 (when consents are missing) remains the parent-setup affordance.

--- a/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
+++ b/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
@@ -6,10 +6,13 @@ import {
   isPanelVisible,
   nextPendingGate,
   pickIndicator,
+  reducedMotionStatusPill,
   resolveCaptionsVisibility,
   shouldShowEntryButton,
   shouldShowHeaderTalkPill,
   TALK_PANEL_STATE_COPY,
+  talkPanelScreenReaderState,
+  voiceQuotaNoticeCopy,
 } from "@/pages/MyAgentPage/talkToBuddyHelpers";
 import type { VoiceConversationState } from "@/hooks/voiceConversationStateMachine";
 
@@ -143,6 +146,40 @@ describe("pickIndicator (#618)", () => {
     for (const state of staticStates) {
       expect(pickIndicator(state, false)).toBe("static");
     }
+  });
+});
+
+describe("Talk-to-Buddy accessibility and quota copy (#609)", () => {
+  it("announces transcript text when the child is being heard", () => {
+    expect(
+      talkPanelScreenReaderState("listening", "hi buddy", ""),
+    ).toContain("Heard: hi buddy");
+  });
+
+  it("announces buddy text ahead of partial transcript text", () => {
+    const copy = talkPanelScreenReaderState(
+      "speaking",
+      "hi buddy",
+      "Hello there",
+    );
+    expect(copy).toContain("Buddy says: Hello there");
+    expect(copy).not.toContain("Heard: hi buddy");
+  });
+
+  it("uses static reduced-motion labels only for active voice states", () => {
+    expect(reducedMotionStatusPill("listening")).toBe("Listening");
+    expect(reducedMotionStatusPill("thinking")).toBe("Thinking");
+    expect(reducedMotionStatusPill("speaking")).toBe("Speaking");
+    expect(reducedMotionStatusPill("idle")).toBeNull();
+  });
+
+  it("turns exhausted quota into typed-chat fallback copy", () => {
+    expect(voiceQuotaNoticeCopy(0).toLowerCase()).toContain("typing");
+    expect(voiceQuotaNoticeCopy(undefined).toLowerCase()).toContain("typing");
+  });
+
+  it("warns when less than one minute of voice time remains", () => {
+    expect(voiceQuotaNoticeCopy(45).toLowerCase()).toContain("almost done");
   });
 });
 

--- a/frontend/src/hooks/useVoiceConversation.ts
+++ b/frontend/src/hooks/useVoiceConversation.ts
@@ -810,13 +810,25 @@ export function useVoiceConversation(
           prefer_webrtc: preferWebRTC || undefined,
         });
       } catch (err) {
-        const status = (err as { response?: { status?: number } })?.response?.status;
+        const responseError = err as {
+          response?: {
+            status?: number;
+            data?: { detail?: { seconds_remaining?: number } };
+          };
+        };
+        const status = responseError.response?.status;
         const kind: VoiceErrorKind =
           status === 409 ? "auth"
           : status === 429 ? "quota"
           : status === 404 ? "auth"
           : "network";
-        onError?.(kind, err instanceof Error ? err.message : String(err));
+        const secondsRemaining =
+          responseError.response?.data?.detail?.seconds_remaining;
+        const detail =
+          kind === "quota"
+            ? `Voice quota exhausted. Remaining: ${secondsRemaining ?? 0}s`
+            : err instanceof Error ? err.message : String(err);
+        onError?.(kind, detail);
         send({ type: "streamError" });
         return;
       }

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -46,6 +46,7 @@ import {
   nextPendingGate,
   shouldShowEntryButton,
   shouldShowHeaderTalkPill,
+  voiceQuotaNoticeCopy,
   type PendingGate,
 } from "./talkToBuddyHelpers";
 import {
@@ -821,9 +822,27 @@ function TalkToBuddyContainer({
 }) {
   void ageGroup; // Future: thread per-age TTS preset overrides (Phase C, #608).
 
+  const [voiceNotice, setVoiceNotice] = useState<string | null>(null);
   const voice = useVoiceConversation({
     childId,
     persona,
+    onError: (kind, detail) => {
+      if (kind === "quota") {
+        const match = detail?.match(/Remaining:\s*(\d+)s/i);
+        const remaining = match ? Number(match[1]) : 0;
+        setVoiceNotice(voiceQuotaNoticeCopy(remaining));
+        return;
+      }
+      if (kind === "auth") {
+        setVoiceNotice("A grown-up needs to allow voice before you can talk.");
+        return;
+      }
+      if (kind === "safety") {
+        setVoiceNotice("Buddy paused that part. You can try a different idea.");
+        return;
+      }
+      setVoiceNotice("Voice chat had a problem. You can keep chatting by typing.");
+    },
   });
 
   const prefersReducedMotion =
@@ -857,10 +876,17 @@ function TalkToBuddyContainer({
       // kid sees the fallback sentence the buddy speaks. The signal is
       // sticky for the rest of the session — reset on next start().
       captionsVisibleOverride={voice.safetyBlockedSeen ? true : undefined}
-      onStart={() => voice.start(true)}
+      onStart={() => {
+        setVoiceNotice(null);
+        void voice.start(true);
+      }}
       onEnd={handleEnd}
-      onRetry={voice.retry}
+      onRetry={() => {
+        setVoiceNotice(null);
+        voice.retry();
+      }}
       onClose={onClose}
+      noticeText={voiceNotice}
       variant={variant}
     />
   );

--- a/frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/TalkToBuddyPanel.tsx
@@ -28,8 +28,10 @@ import { motion } from "framer-motion";
 import {
   isEndButtonEnabled,
   isPanelVisible,
+  reducedMotionStatusPill,
   resolveCaptionsVisibility,
   TALK_PANEL_STATE_COPY,
+  talkPanelScreenReaderState,
 } from "./talkToBuddyHelpers";
 import { pickOrbMode } from "./buddyOrbHelpers";
 import { BuddyOrb } from "./BuddyOrb";
@@ -70,6 +72,8 @@ export interface TalkToBuddyPanelProps {
   /** Optional close button for the panel itself (separate from End).
    *  Hidden in `inline` variant where the bubble unmounts on End. */
   onClose?: () => void;
+  /** Optional non-transcript notice from the voice hook (quota, auth, network). */
+  noticeText?: string | null;
   /** Layout. Default `overlay` preserves PR #620's behavior. */
   variant?: TalkToBuddyPanelVariant;
 }
@@ -99,11 +103,20 @@ export function TalkToBuddyPanel({
   onEnd,
   onRetry,
   onClose,
+  noticeText,
   variant = "overlay",
 }: TalkToBuddyPanelProps) {
   if (!isPanelVisible(state)) return null;
 
   const status = TALK_PANEL_STATE_COPY[state];
+  const screenReaderStatus = talkPanelScreenReaderState(
+    state,
+    partialTranscript,
+    assistantText,
+  );
+  const staticMotionLabel = prefersReducedMotion
+    ? reducedMotionStatusPill(state)
+    : null;
   const orbMode = pickOrbMode(state, prefersReducedMotion);
   const endEnabled = isEndButtonEnabled(state);
   const canStart = state === "idle" || state === "error";
@@ -213,6 +226,34 @@ export function TalkToBuddyPanel({
         >
           {status}
         </p>
+        <p role="status" aria-live="polite" className="sr-only">
+          {screenReaderStatus}
+        </p>
+
+        {staticMotionLabel && (
+          <div
+            className={
+              isInline
+                ? "mx-auto mb-2 w-fit rounded-full border border-violet-200 bg-white px-3 py-1 text-[11px] font-semibold text-violet-700"
+                : "mx-auto mb-3 w-fit rounded-full border border-violet-200 bg-white px-3 py-1 text-xs font-semibold text-violet-700"
+            }
+          >
+            {staticMotionLabel}
+          </div>
+        )}
+
+        {noticeText && (
+          <div
+            role="status"
+            className={
+              isInline
+                ? "mb-2 rounded-lg border border-amber-200 bg-amber-50 p-2 text-xs text-amber-900"
+                : "mb-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+            }
+          >
+            {noticeText}
+          </div>
+        )}
 
         {captionsVisible && partialTranscript && (
           <div
@@ -250,7 +291,7 @@ export function TalkToBuddyPanel({
           <motion.button
             type="button"
             onClick={onStart}
-            whileTap={{ scale: 0.97 }}
+            whileTap={prefersReducedMotion ? undefined : { scale: 0.97 }}
             className={startButtonClass}
           >
             {state === "error" ? "Try Again" : "Start Talking"}

--- a/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
@@ -28,6 +28,53 @@ export const TALK_PANEL_STATE_COPY: Record<VoiceConversationState, string> = {
     "Voice chat isn't available on this device. You can keep using typed chat.",
 };
 
+export const TALK_PANEL_SCREEN_READER_COPY: Record<VoiceConversationState, string> = {
+  idle: "Voice chat is idle.",
+  connecting: "Voice chat is connecting.",
+  listening: "Voice chat is listening.",
+  thinking: "Buddy is thinking.",
+  speaking: "Buddy is speaking.",
+  interrupted: "Buddy heard the interruption.",
+  ending: "Voice chat is ending.",
+  error: "Voice chat needs attention.",
+  unsupported: "Voice chat is not supported on this device.",
+};
+
+export function talkPanelScreenReaderState(
+  state: VoiceConversationState,
+  partialTranscript: string,
+  assistantText: string,
+): string {
+  const base = TALK_PANEL_SCREEN_READER_COPY[state];
+  const heard = partialTranscript.trim();
+  const reply = assistantText.trim();
+  if (reply) return `${base} Buddy says: ${reply}`;
+  if (heard) return `${base} Heard: ${heard}`;
+  return base;
+}
+
+export function reducedMotionStatusPill(
+  state: VoiceConversationState,
+): string | null {
+  if (state === "listening" || state === "interrupted") return "Listening";
+  if (state === "thinking") return "Thinking";
+  if (state === "speaking") return "Speaking";
+  return null;
+}
+
+export function voiceQuotaNoticeCopy(
+  secondsRemaining: number | null | undefined,
+): string {
+  const remaining = Math.max(0, Math.floor(secondsRemaining ?? 0));
+  if (remaining <= 0) {
+    return "Voice time is used up for today. You can keep chatting by typing.";
+  }
+  if (remaining <= 60) {
+    return "Voice time is almost done for today. You can keep chatting by typing when it ends.";
+  }
+  return `Voice time remaining today: ${Math.ceil(remaining / 60)} minutes.`;
+}
+
 /**
  * Capability + consent + child-profile preconditions for the Talk
  * button to appear on AgentChatPanel. All four must be true.


### PR DESCRIPTION
## Summary
- surface Talk-to-Buddy quota/auth/safety notices in the inline voice panel
- add screen-reader state copy and reduced-motion static status handling
- document Talk-to-Buddy provider selection, fail-closed safety gates, raw-audio invariant, and telemetry events
- cross-link PRD §3.11/§3.16 and add CLAUDE safety best practices anchor

## Tests
- npm run test -- --environment node src/__tests__/components/talkToBuddyHelpers.test.ts src/__tests__/components/TalkToBuddyPanel.test.ts
- npm run build

Fixes #609