### PR TITLE
fix(library): route GROUP_CONCAT through sql_compat for Postgres safety

### DIFF
--- a/backend/src/api/routes/library.py
+++ b/backend/src/api/routes/library.py
@@ -22,7 +22,7 @@ from ...services.database import (
 )
 from ...services.database.artifact_repository import StoryArtifactLinkRepository
 from ...services.database.connection import db_manager
-from ...services.database.sql_compat import date_format_sql
+from ...services.database.sql_compat import date_format_sql, group_concat_sql
 from ...services.user_service import UserData
 from ...utils.text import count_words
 from ..deps import get_current_user
@@ -627,8 +627,8 @@ async def get_rich_stats(
             {period_expr} AS period,
             COUNT(*) AS cnt,
             COALESCE(SUM(word_count), 0) AS total_words,
-            GROUP_CONCAT(themes, '||') AS all_themes,
-            GROUP_CONCAT(story_type, '||') AS all_types
+            {group_concat_sql("themes", "||", db_manager.dialect)} AS all_themes,
+            {group_concat_sql("story_type", "||", db_manager.dialect)} AS all_types
         FROM stories
         WHERE user_id = ?
           AND (safety_score IS NULL OR safety_score >= ?)

--- a/backend/src/services/database/sql_compat.py
+++ b/backend/src/services/database/sql_compat.py
@@ -121,6 +121,18 @@ def date_format_sql(column: str, fmt: str, dialect: str) -> str:
     return f"to_char({column}::timestamp, '{pg_fmt}')"
 
 
+def group_concat_sql(column: str, separator: str, dialect: str) -> str:
+    """
+    Generate SQL to concatenate grouped row values into one string.
+
+    SQLite:     GROUP_CONCAT(column, 'separator')
+    PostgreSQL: string_agg(column::text, 'separator')
+    """
+    if dialect == "sqlite":
+        return f"GROUP_CONCAT({column}, '{separator}')"
+    return f"string_agg({column}::text, '{separator}')"
+
+
 def ci_equals(column: str, dialect: str) -> str:
     """
     Generate a case-insensitive equality clause for a column.

--- a/backend/tests/unit/test_sql_compat.py
+++ b/backend/tests/unit/test_sql_compat.py
@@ -1,0 +1,30 @@
+"""Unit tests for SQL compatibility helpers (#681).
+
+Parent Epic: #49
+
+These helpers emit dialect-correct SQL for both SQLite (local dev) and
+PostgreSQL (production). The group_concat_sql helper exists because raw
+GROUP_CONCAT(...) is SQLite-only and 500s on Postgres.
+"""
+
+from src.services.database.sql_compat import group_concat_sql
+
+
+class TestGroupConcatSql:
+    """Both dialects must produce valid aggregate-concatenation SQL."""
+
+    def test_sqlite_uses_group_concat(self):
+        result = group_concat_sql("themes", "||", "sqlite")
+        assert result == "GROUP_CONCAT(themes, '||')"
+
+    def test_postgresql_uses_string_agg_with_text_cast(self):
+        result = group_concat_sql("themes", "||", "postgresql")
+        assert result == "string_agg(themes::text, '||')"
+
+    def test_sqlite_respects_column_and_separator(self):
+        result = group_concat_sql("story_type", ",", "sqlite")
+        assert result == "GROUP_CONCAT(story_type, ',')"
+
+    def test_postgresql_respects_column_and_separator(self):
+        result = group_concat_sql("story_type", ",", "postgresql")
+        assert result == "string_agg(story_type::text, ',')"


### PR DESCRIPTION
## Summary

The `/library/stats-rich` query used raw SQLite-only `GROUP_CONCAT(themes, '||')` and `GROUP_CONCAT(story_type, '||')`, which 500s on PostgreSQL. The file already routed dates through `sql_compat.date_format_sql` but bypassed compat for these aggregates.

This PR:
- Adds `group_concat_sql(column, separator, dialect)` to `backend/src/services/database/sql_compat.py`, mirroring the neighboring helpers. SQLite emits `GROUP_CONCAT(...)`; Postgres emits `string_agg(<col>::text, '...')`.
- Wires it into `backend/src/api/routes/library.py`, preserving the `AS all_themes` / `AS all_types` aliases.
- Adds `backend/tests/unit/test_sql_compat.py` asserting both dialect outputs.

## Test
`backend/venv/bin/python -m pytest tests/unit/test_sql_compat.py tests/api/test_library_stats.py -v` → 16 passed.

Fixes #681

Parent Epic: #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)