### PR TITLE
chore(repo): gitignore env backups, root node_modules, runtime dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Environment
 .env
 *.env
+# local/backup env variants: .env.local, .env.bak, etc.
+.env.*
+# keep tracked example/template env files
+!.env.example
 backend/.env
 venv/
 backend/venv/
@@ -37,7 +41,12 @@ data/sessions/
 data/uploads/
 data/audio/
 data/vectors/
+# runtime video job outputs
+data/video_jobs/
 backend/data/
+
+# Node (root-level deps; frontend/node_modules covered below)
+/node_modules/
 
 # Frontend artifacts
 frontend/node_modules/


### PR DESCRIPTION
## Summary

Tightens `.gitignore` so files that were already meant to be ignored but kept showing up as untracked are now actually covered.

Added patterns:
- `.env.*` — covers `.env.local`, `.env.bak`, and similar local/backup env variants (the old `*.env` did not match `.env.bak`/`.env.local`)
- `!.env.example` — negation so the currently-tracked `backend/.env.example` template stays tracked
- `/node_modules/` — root-level node_modules (only `frontend/node_modules/` was ignored before)
- `data/video_jobs/` — runtime video job output

Only `.gitignore` was edited. No files were deleted.

## Verification

`git check-ignore -v` confirms all four targets are now ignored:
- `backend/.env.bak` -> `.env.*`
- `frontend/.env.local` -> `.env.*`
- `node_modules/` -> `/node_modules/`
- `data/video_jobs/` -> `data/video_jobs/`

`backend/.env.example` is NOT ignored (negation verified), and piping the full `git ls-files` list through `git check-ignore --stdin` produced zero matches, confirming no currently-tracked file became ignored.

Fixes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)