### PR TITLE
fix(mcp): generate videos via Sora videos API instead of images.generate

### DIFF
--- a/backend/src/mcp_servers/video_generator_server.py
+++ b/backend/src/mcp_servers/video_generator_server.py
@@ -71,6 +71,24 @@ def get_image_mime_type(image_path: str) -> str:
     return mime_types.get(ext, "image/png")
 
 
+# Sora only renders fixed clip lengths; map any requested duration onto one.
+SORA_SUPPORTED_DURATIONS = (4, 8, 12)
+
+
+def nearest_supported_duration(duration_seconds: int) -> str:
+    """Snap a requested duration to the nearest Sora-supported clip length.
+
+    Sora's videos API only accepts 4, 8, or 12 second clips, so an arbitrary
+    request (e.g. the legacy default of 10) must be coerced or the call fails.
+    """
+    try:
+        requested = int(duration_seconds)
+    except (TypeError, ValueError):
+        requested = SORA_SUPPORTED_DURATIONS[0]
+    closest = min(SORA_SUPPORTED_DURATIONS, key=lambda s: abs(s - requested))
+    return str(closest)
+
+
 def save_job_status(job_id: str, job_data: Dict[str, Any]) -> None:
     """Save job status to file"""
     jobs_dir = get_video_jobs_path()
@@ -162,67 +180,68 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
             VIDEO_STYLE_PROMPTS["gentle_animation"]
         )
 
-        # Encode image
-        image_base64 = encode_image_to_base64(image_path)
-        mime_type = get_image_mime_type(image_path)
+        # Generate the animation with OpenAI Sora. The painting is supplied as a
+        # visual reference through the dedicated videos API.
+        #
+        # The previous implementation called client.images.generate(image=...),
+        # which raises "unexpected keyword argument 'image'": images.generate()
+        # accepts no image input and returns stills, not video. Sora is exposed
+        # via client.videos.* instead.
+        seconds = nearest_supported_duration(duration_seconds)
 
-        # Call OpenAI Sora API to generate video
-        # Note: Using OpenAI's video generation API (Sora)
-        response = client.images.generate(
-            model="sora",
-            prompt=style_prompt,
-            image=f"data:{mime_type};base64,{image_base64}",
-            n=1,
-            size="1024x1024",
-            response_format="url"
-        )
+        with open(image_path, "rb") as image_file:
+            video_job = client.videos.create_and_poll(
+                model="sora-2",
+                prompt=style_prompt,
+                input_reference=image_file,
+                seconds=seconds,
+                size="1280x720",
+            )
 
-        # Get generated video URL
-        if response.data and len(response.data) > 0:
-            video_url = response.data[0].url
+        if getattr(video_job, "status", None) != "completed":
+            failure = getattr(video_job, "error", None)
+            reason = getattr(failure, "message", None) or failure or "unknown error"
+            raise Exception(
+                f"Sora video job ended with status "
+                f"'{getattr(video_job, 'status', 'unknown')}': {reason}"
+            )
 
-            # Download video locally
-            video_dir = get_video_output_path()
-            video_filename = f"video_{job_id}.mp4"
-            video_path = Path(video_dir) / video_filename
+        # Download the rendered video locally.
+        video_dir = get_video_output_path()
+        video_filename = f"video_{job_id}.mp4"
+        video_path = Path(video_dir) / video_filename
+        client.videos.download_content(
+            video_job.id, variant="video"
+        ).write_to_file(str(video_path))
 
-            # Use httpx to download video
-            import httpx
-            async with httpx.AsyncClient() as http_client:
-                video_response = await http_client.get(video_url)
-                with open(video_path, "wb") as f:
-                    f.write(video_response.content)
+        # Save job status
+        job_data = {
+            "job_id": job_id,
+            "story_id": story_id,
+            "status": "completed",
+            "progress_percent": 100,
+            "video_path": str(video_path),
+            "video_filename": video_filename,
+            "style": style,
+            "duration_seconds": int(seconds),
+            "created_at": timestamp.isoformat(),
+            "completed_at": datetime.now().isoformat()
+        }
+        save_job_status(job_id, job_data)
 
-            # Save job status
-            job_data = {
-                "job_id": job_id,
-                "story_id": story_id,
-                "status": "completed",
-                "progress_percent": 100,
-                "video_path": str(video_path),
-                "video_filename": video_filename,
-                "style": style,
-                "duration_seconds": duration_seconds,
-                "created_at": timestamp.isoformat(),
-                "completed_at": datetime.now().isoformat()
-            }
-            save_job_status(job_id, job_data)
-
-            return {
-                "content": [{
-                    "type": "text",
-                    "text": json.dumps({
-                        "success": True,
-                        "job_id": job_id,
-                        "status": "completed",
-                        "video_path": str(video_path),
-                        "video_filename": video_filename,
-                        "video_url": f"/data/videos/{video_filename}"
-                    }, ensure_ascii=False, indent=2)
-                }]
-            }
-        else:
-            raise Exception("No video generated from API response")
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "success": True,
+                    "job_id": job_id,
+                    "status": "completed",
+                    "video_path": str(video_path),
+                    "video_filename": video_filename,
+                    "video_url": f"/data/videos/{video_filename}"
+                }, ensure_ascii=False, indent=2)
+            }]
+        }
 
     except Exception as e:
         error_message = str(e)

--- a/backend/tests/unit/test_video_generator_server.py
+++ b/backend/tests/unit/test_video_generator_server.py
@@ -1,0 +1,138 @@
+"""Unit tests for the Sora-backed video generation MCP tool.
+
+Regression guard for the bug where generate_painting_video called
+client.images.generate(image=...), which raises
+"Images.generate() got an unexpected keyword argument 'image'" — that
+endpoint accepts no image input and returns stills, not video.
+"""
+
+import json
+
+import pytest
+
+from backend.src.mcp_servers import video_generator_server as vgs
+
+
+class _FakeBinaryContent:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+        self.written_to = None
+
+    def write_to_file(self, path):
+        self.written_to = str(path)
+        with open(path, "wb") as f:
+            f.write(self._payload)
+
+
+class _FakeVideo:
+    def __init__(self, status="completed", error=None):
+        self.id = "vid_123"
+        self.status = status
+        self.error = error
+
+
+class _FakeVideos:
+    def __init__(self, video):
+        self._video = video
+        self.create_calls = []
+        self.download_calls = []
+
+    def create_and_poll(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return self._video
+
+    def download_content(self, video_id, variant="video"):
+        self.download_calls.append((video_id, variant))
+        return _FakeBinaryContent(b"fake-mp4-bytes")
+
+
+class _FakeImages:
+    def generate(self, **kwargs):  # pragma: no cover - must never be called
+        raise AssertionError("images.generate must not be used for video")
+
+
+class _FakeOpenAI:
+    last_instance = None
+
+    def __init__(self, api_key=None, video=None):
+        self.api_key = api_key
+        self.videos = _FakeVideos(video or _FakeVideo())
+        self.images = _FakeImages()
+        _FakeOpenAI.last_instance = self
+
+
+def _patch_openai(monkeypatch, video=None):
+    def factory(api_key=None):
+        return _FakeOpenAI(api_key=api_key, video=video)
+
+    monkeypatch.setattr(vgs, "OpenAI", factory)
+
+
+@pytest.mark.parametrize(
+    "requested,expected",
+    [(4, "4"), (8, "8"), (12, "12"), (10, "8"), (1, "4"), (100, "12")],
+)
+def test_nearest_supported_duration_snaps_to_sora_lengths(requested, expected):
+    assert vgs.nearest_supported_duration(requested) == expected
+
+
+@pytest.mark.asyncio
+async def test_generate_painting_video_uses_sora_videos_api(monkeypatch, tmp_path):
+    image_path = tmp_path / "drawing.png"
+    image_path.write_bytes(b"fake-png")
+    monkeypatch.setattr(vgs, "get_video_output_path", lambda: str(tmp_path))
+    monkeypatch.setattr(vgs, "save_job_status", lambda *_a, **_k: None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    _patch_openai(monkeypatch)
+
+    result = await vgs.generate_painting_video(
+        {
+            "image_path": str(image_path),
+            "style": "gentle_animation",
+            "duration_seconds": 10,
+            "story_id": "story-1",
+        }
+    )
+
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["success"] is True
+    assert payload["status"] == "completed"
+
+    client = _FakeOpenAI.last_instance
+    # The bug path (images.generate) must never run.
+    assert client.videos.create_calls, "expected videos.create_and_poll to be called"
+    call = client.videos.create_calls[0]
+    assert call["model"] == "sora-2"
+    assert call["seconds"] == "8"  # 10s request snapped to nearest Sora length
+    assert "input_reference" in call  # painting passed as a reference, not a kwarg
+    assert client.videos.download_calls == [("vid_123", "video")]
+
+    # Video bytes were written to disk at the advertised path.
+    written = tmp_path / payload["video_filename"]
+    assert written.exists() and written.read_bytes() == b"fake-mp4-bytes"
+
+
+@pytest.mark.asyncio
+async def test_generate_painting_video_fails_fast_on_incomplete_job(
+    monkeypatch, tmp_path
+):
+    image_path = tmp_path / "drawing.png"
+    image_path.write_bytes(b"fake-png")
+    monkeypatch.setattr(vgs, "get_video_output_path", lambda: str(tmp_path))
+    monkeypatch.setattr(vgs, "save_job_status", lambda *_a, **_k: None)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    _patch_openai(monkeypatch, video=_FakeVideo(status="failed", error="moderation"))
+
+    result = await vgs.generate_painting_video(
+        {
+            "image_path": str(image_path),
+            "style": "playful",
+            "duration_seconds": 8,
+            "story_id": "story-1",
+        }
+    )
+
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["success"] is False
+    assert payload["status"] == "failed"
+    assert "failed" in payload["error"]


### PR DESCRIPTION
## Summary

Video generation failed on every request with a 502 on `POST /api/v1/video/generate`. The console error was:

> `Video generation failed: Images.generate() got an unexpected keyword argument 'image'`

`generate_painting_video` called `client.images.generate(model="sora", image=...)`. That endpoint accepts no image input and `"sora"` is not an image model — Sora is exposed through the separate `client.videos.*` API, so this path could never have worked.

## Changes

- Call `client.videos.create_and_poll(model="sora-2", prompt=..., input_reference=<image file>, seconds=..., size="1280x720")` and download via `videos.download_content(id, variant="video").write_to_file(...)`.
- Add `nearest_supported_duration()` to snap requests onto Sora's only valid clip lengths (4/8/12s) — the legacy default of 10 would itself be rejected.
- Fail fast when the Sora job does not complete, feeding the existing `#182` error path.
- Add `backend/tests/unit/test_video_generator_server.py` — covers the Sora path (asserts `images.generate` is never used), duration snapping, file write, and incomplete-job handling.

## Testing

`backend/tests/unit/test_video_generator_server.py` + `backend/tests/api/test_video_routes.py` — 13/13 pass.

## Notes

- `kids_daily.py` also calls `images.generate` but correctly (text-to-image, no `image=` kwarg) — unaffected.
- Sora output still passes the same downstream content-safety gate before delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)