### PR TITLE
chore(tests): make chromadb a hard import in dedup contract (#685)

### DIFF
--- a/backend/tests/contracts/test_story_dedup_contract.py
+++ b/backend/tests/contracts/test_story_dedup_contract.py
@@ -9,6 +9,8 @@ Parent Epic: #42 | Issues: #161, #290
 
 import importlib
 import json
+
+import chromadb  # noqa: F401 — hard dep; fail loudly if missing (#685)
 import pytest
 
 
@@ -50,7 +52,6 @@ class TestStoreStoryEmbedding:
 
     @pytest.mark.asyncio
     async def test_stores_successfully(self, vs, tmp_path):
-        pytest.importorskip("chromadb")
         import os
         os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
 
@@ -69,7 +70,6 @@ class TestStoreStoryEmbedding:
 class TestSearchSimilarStories:
     @pytest.mark.asyncio
     async def test_returns_empty_for_unknown_child(self, vs, tmp_path):
-        pytest.importorskip("chromadb")
         import os
         os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
 
@@ -84,7 +84,6 @@ class TestSearchSimilarStories:
 
     @pytest.mark.asyncio
     async def test_finds_similar_story(self, vs, tmp_path):
-        pytest.importorskip("chromadb")
         import os
         os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
 
@@ -107,7 +106,6 @@ class TestSearchSimilarStories:
 
     @pytest.mark.asyncio
     async def test_response_shape(self, vs, tmp_path):
-        pytest.importorskip("chromadb")
         import os
         os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
 
@@ -128,7 +126,6 @@ class TestStoryDedupRoundTrip:
     @pytest.mark.asyncio
     async def test_near_duplicate_detected(self, vs, tmp_path):
         """Store a story, then search with nearly identical text; expect high similarity."""
-        pytest.importorskip("chromadb")
         import os
         os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
 
@@ -159,7 +156,6 @@ class TestStoryDedupRoundTrip:
     @pytest.mark.asyncio
     async def test_different_child_not_found(self, vs, tmp_path):
         """Stories from one child should not appear in another child's search."""
-        pytest.importorskip("chromadb")
         import os
         os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
 
@@ -184,7 +180,6 @@ class TestStoryDedupRoundTrip:
     @pytest.mark.asyncio
     async def test_upsert_updates_existing(self, vs, tmp_path):
         """Calling store with the same story_id should upsert, not duplicate."""
-        pytest.importorskip("chromadb")
         import os
         os.environ["CHROMA_PATH"] = str(tmp_path / "vectors")
 


### PR DESCRIPTION
Fixes #685

## Problem

`backend/tests/contracts/test_story_dedup_contract.py` guarded its tests with 7 in-method `pytest.importorskip("chromadb")` calls. But `chromadb>=1.4.1` is a **declared dependency** in `backend/requirements.txt` — it is not optional.

Treating a declared dependency as optional means a broken or missing chromadb causes the dedup contract to **silently SKIP** (the suite reports green with 0 assertions executed) instead of **failing loudly**. That defeats the purpose of a contract test: a regression in the vector-search dedup path could ship unnoticed.

## Fix

- Removed the 7 in-method `pytest.importorskip("chromadb")` guards.
- Added a single module-level `import chromadb  # noqa: F401 — hard dep; fail loudly if missing (#685)` near the top imports. The guards never used the returned module object, so a bare import is the correct binding.

Now a missing/broken chromadb errors the whole module at collection time (loud failure) rather than masquerading as passing tests.

## Verification

```
backend/tests/contracts/test_story_dedup_contract.py ......... 9 passed in 18.23s
```

All 9 tests **run and pass** — **0 skips** (previously these would skip if chromadb were absent).

## Follow-up (not implemented here)

There is currently **no CI workflow** in this repo, so this loud-failure guarantee is only enforced when someone runs pytest locally. A follow-up `Chore: add CI (pytest + vitest)` would run the contract suite on every PR and make this guarantee actually enforced. Filing/implementing that is out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)