### PR TITLE
fix(voice): warn when multi-worker configured with in-process token nonce (#684)

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -124,6 +124,12 @@ async def lifespan(app: FastAPI):
     if retention_enabled and os.getenv("ENVIRONMENT") != "test":
         await retention_scheduler.start()
 
+    # Guard the in-process voice-token replay nonce (#684): warn loudly if
+    # multiple workers/replicas are configured, since _USED_JTIS is per-process.
+    from .services.voice_ephemeral_token import assert_single_process_or_warn
+
+    assert_single_process_or_warn()
+
     # MCP server diagnostics
     from .mcp_servers import MCP_SERVER_STATUS
 

--- a/backend/src/services/voice_ephemeral_token.py
+++ b/backend/src/services/voice_ephemeral_token.py
@@ -40,8 +40,36 @@ TOKEN_PURPOSE: str = "voice_realtime"
 # out in ≤60s so the set can never grow past TOKEN_TTL_SECONDS × mint
 # rate. Bytes-wise this is O(KB) even at 100 req/s.
 #
-# TODO(scale): replace with Redis when we add a second uvicorn worker.
+# TODO(scale): in-process nonce set is only correct with exactly one
+# process/replica — see assert_single_process_or_warn() + #684. Future
+# fix = DB-backed nonce on the voice_sessions row (or Redis) so the
+# replay guard holds across multiple uvicorn workers.
 _USED_JTIS: Dict[str, float] = {}
+
+
+def assert_single_process_or_warn() -> None:
+    """Warn loudly if multiple workers are configured while the nonce
+    store is in-process. The in-memory _USED_JTIS replay guard is only
+    correct with exactly one process/replica. See #684 for the
+    DB-backed nonce migration path."""
+    for var in ("WEB_CONCURRENCY", "UVICORN_WORKERS"):
+        raw = os.getenv(var)
+        if not raw:
+            continue
+        try:
+            workers = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if workers > 1:
+            logger.warning(
+                "%s=%s configured but the voice token replay guard "
+                "(_USED_JTIS) is an in-process nonce store — single-use "
+                "voice tokens are NOT safe across multiple workers/replicas. "
+                "See #684: migrate to a DB-backed nonce on the voice_sessions "
+                "row before scaling out.",
+                var,
+                workers,
+            )
 
 
 def _signing_secret() -> str:

--- a/backend/tests/unit/test_voice_token_multiworker_guard.py
+++ b/backend/tests/unit/test_voice_token_multiworker_guard.py
@@ -1,0 +1,58 @@
+"""Unit tests for the multi-worker guard on the voice-token nonce (#684).
+
+Parent Epic: #605
+
+The single-use voice token replay guard (``_USED_JTIS``) is an in-process
+dict. It is only correct with exactly one process/replica. Prod runs a single
+uvicorn worker today (no ``--workers``), so it is safe NOW. This guard warns
+loudly at startup if anyone configures ``WEB_CONCURRENCY``/``UVICORN_WORKERS``
+> 1 so the safety assumption can never be violated silently. The full fix
+(DB-backed nonce on the voice_sessions row) is the documented future path.
+"""
+
+import logging
+
+from src.services.voice_ephemeral_token import assert_single_process_or_warn
+
+
+class TestAssertSingleProcessOrWarn:
+    """Startup guard: single worker is silent; multi-worker warns."""
+
+    def test_no_warning_when_concurrency_unset(self, caplog, monkeypatch):
+        monkeypatch.delenv("WEB_CONCURRENCY", raising=False)
+        monkeypatch.delenv("UVICORN_WORKERS", raising=False)
+        with caplog.at_level(logging.WARNING):
+            assert_single_process_or_warn()
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_no_warning_when_concurrency_is_one(self, caplog, monkeypatch):
+        monkeypatch.setenv("WEB_CONCURRENCY", "1")
+        monkeypatch.delenv("UVICORN_WORKERS", raising=False)
+        with caplog.at_level(logging.WARNING):
+            assert_single_process_or_warn()
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+    def test_warns_when_web_concurrency_gt_one(self, caplog, monkeypatch):
+        monkeypatch.setenv("WEB_CONCURRENCY", "2")
+        monkeypatch.delenv("UVICORN_WORKERS", raising=False)
+        with caplog.at_level(logging.WARNING):
+            assert_single_process_or_warn()
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "expected a warning when WEB_CONCURRENCY=2"
+        assert "#684" in warnings[0].getMessage()
+
+    def test_warns_when_uvicorn_workers_gt_one(self, caplog, monkeypatch):
+        monkeypatch.delenv("WEB_CONCURRENCY", raising=False)
+        monkeypatch.setenv("UVICORN_WORKERS", "4")
+        with caplog.at_level(logging.WARNING):
+            assert_single_process_or_warn()
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warnings, "expected a warning when UVICORN_WORKERS=4"
+        assert "#684" in warnings[0].getMessage()
+
+    def test_no_warning_on_unparseable_value(self, caplog, monkeypatch):
+        monkeypatch.setenv("WEB_CONCURRENCY", "auto")
+        monkeypatch.delenv("UVICORN_WORKERS", raising=False)
+        with caplog.at_level(logging.WARNING):
+            assert_single_process_or_warn()
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]


### PR DESCRIPTION
Fixes #684

## Summary

The single-use voice token replay guard in `backend/src/services/voice_ephemeral_token.py` keeps consumed nonces in an in-process dict (`_USED_JTIS`). That guard is only correct with **exactly one process/replica**. Production runs a single uvicorn worker today (`railway.toml`/`Procfile` start `uvicorn src.main:app` with **no** `--workers`), so it is safe **now** — but if anyone adds workers/replicas, the replay protection would silently weaken.

This is the small, safe guard from the #684 spike so that assumption can't be violated silently.

## Changes

- Added `assert_single_process_or_warn()` in `voice_ephemeral_token.py`. It reads `WEB_CONCURRENCY` and `UVICORN_WORKERS`; if either parses to an int > 1 it logs a loud `logger.warning` naming #684. It **warns, does not raise**, so a misconfigured deploy still boots.
- Called it once at app startup in `backend/src/main.py` (FastAPI `lifespan`, next to the scheduler startup).
- Updated the `TODO(scale)` comment to point at `assert_single_process_or_warn()` + #684.
- Added unit tests in `backend/tests/unit/test_voice_token_multiworker_guard.py` covering: unset / `=1` (silent), `WEB_CONCURRENCY=2` and `UVICORN_WORKERS=4` (warns, message contains `#684`), and an unparseable value (silent).

## Future path (documented, not done here)

Full fix = a **DB-backed nonce on the existing `voice_sessions` row** (or Redis), so the single-use replay guard holds across multiple workers/replicas. Out of scope for this guard.

## Tests

`python -m pytest tests/unit/test_voice_token_multiworker_guard.py tests/contracts/test_voice_ephemeral_token_contract.py tests/contracts/test_voice_token_expired_contract.py tests/contracts/test_voice_broker_contract.py -v` → **32 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)