### PR TITLE
fix(frontend): render avatar emojis as flat icons

### DIFF
--- a/frontend/src/__tests__/components/avatarIcons.test.tsx
+++ b/frontend/src/__tests__/components/avatarIcons.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  avatarIconForId,
+  isAnimalAvatarId,
+  normalizeAvatarId,
+} from "@/lib/avatarIcons";
+
+describe("avatar icon mapping", () => {
+  it("normalizes legacy raw animal emoji values", () => {
+    expect(normalizeAvatarId("🐶")).toBe("emoji:🐶");
+    expect(isAnimalAvatarId("🐶")).toBe(true);
+    expect(avatarIconForId("🐶")).toBe(avatarIconForId("emoji:🐶"));
+  });
+
+  it("keeps generated child fallbacks stable and animal-shaped", () => {
+    const first = avatarIconForId("child-a");
+    const second = avatarIconForId("child-a");
+    const another = avatarIconForId("child-b");
+
+    expect(first).toBe(second);
+    expect(first).toBeDefined();
+    expect(another).toBeDefined();
+  });
+
+  it("does not classify external media urls as animal avatars", () => {
+    expect(isAnimalAvatarId("/uploads/avatar.png")).toBe(false);
+    expect(isAnimalAvatarId("https://example.test/avatar.png")).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
+++ b/frontend/src/__tests__/components/talkToBuddyHelpers.test.ts
@@ -323,15 +323,15 @@ describe("resolveCaptionsVisibility (#608)", () => {
 
 describe("headerCTACopy (#638)", () => {
   // Locks the per-age entry-surface copy to PRD §3.16.6:
-  //   | 3-5            | 6-8                  | 9-12            |
-  //   | emoji + "Talk!"| "Talk to {buddy}"    | mic + "Voice"   |
+  //   | 3-5    | 6-8                  | 9-12    |
+  //   | "Talk!"| "Talk to {buddy}"    | "Voice" |
   // Pure helper so the labels can't drift away from the table. One
   // assertion per age band — the AC's "three tests, one per age".
 
-  it("3-5 → giant mic emoji + 'Talk!' (pre-readers get the emoji, no name)", () => {
+  it("3-5 → 'Talk!' without emoji", () => {
     expect(headerCTACopy("3-5", "Sparky")).toEqual({
       label: "Talk!",
-      emoji: "🎤",
+      emoji: "",
     });
   });
 
@@ -347,7 +347,7 @@ describe("headerCTACopy (#638)", () => {
   it("9-12 → mic icon + 'Voice' (older kids get the terse, tool-like label)", () => {
     expect(headerCTACopy("9-12", "Sparky")).toEqual({
       label: "Voice",
-      emoji: "🎤",
+      emoji: "",
     });
   });
 

--- a/frontend/src/components/common/AvatarDisplay/index.tsx
+++ b/frontend/src/components/common/AvatarDisplay/index.tsx
@@ -1,4 +1,6 @@
 import { resolveMediaUrl } from '@/utils/mediaUrl'
+import { UserRound } from 'lucide-react'
+import { AnimalAvatarIcon, isAnimalAvatarId } from '@/lib/avatarIcons'
 
 const sizeMap = {
   sm: 'w-8 h-8 text-lg',
@@ -15,14 +17,14 @@ interface AvatarDisplayProps {
 function AvatarDisplay({ avatarUrl, size = 'md', className = '' }: AvatarDisplayProps) {
   const sizeClasses = sizeMap[size]
 
-  // Emoji avatar: stored as "emoji:<emoji>"
-  if (avatarUrl && avatarUrl.startsWith('emoji:')) {
-    const emoji = avatarUrl.slice('emoji:'.length)
+  // Animal avatar ids stay in storage for compatibility, while the UI renders
+  // the matching flat animal icon.
+  if (isAnimalAvatarId(avatarUrl)) {
     return (
       <div
-        className={`${sizeClasses} rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0 ${className}`}
+        className={`${sizeClasses} rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0 text-primary ${className}`}
       >
-        <span>{emoji}</span>
+        <AnimalAvatarIcon avatarId={avatarUrl} size={size === 'sm' ? 16 : size === 'lg' ? 28 : 22} />
       </div>
     )
   }
@@ -48,9 +50,9 @@ function AvatarDisplay({ avatarUrl, size = 'md', className = '' }: AvatarDisplay
   // Default fallback
   return (
     <div
-      className={`${sizeClasses} rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0 ${className}`}
+      className={`${sizeClasses} rounded-full bg-gradient-to-br from-primary/20 to-secondary/20 flex items-center justify-center flex-shrink-0 text-primary ${className}`}
     >
-      <span>👤</span>
+      <UserRound size={size === 'sm' ? 16 : size === 'lg' ? 28 : 22} aria-hidden="true" />
     </div>
   )
 }

--- a/frontend/src/components/common/SignInPrompt.tsx
+++ b/frontend/src/components/common/SignInPrompt.tsx
@@ -7,9 +7,11 @@
  */
 
 import { Link } from "react-router-dom";
+import { LogIn } from "lucide-react";
+import type { ReactNode } from "react";
 
 interface Props {
-  icon?: string;
+  icon?: ReactNode;
   title: string;
   description: string;
   /** Where to come back to after sign-in. Optional — defaults to current path. */
@@ -17,7 +19,7 @@ interface Props {
 }
 
 export default function SignInPrompt({
-  icon = "👋",
+  icon = <LogIn className="h-9 w-9" aria-hidden="true" />,
   title,
   description,
   returnPath,
@@ -27,7 +29,7 @@ export default function SignInPrompt({
   const href = `/login?return=${encodeURIComponent(ret)}`;
   return (
     <div className="mx-auto flex max-w-2xl flex-col items-center gap-3 rounded-lg border-2 border-dashed border-primary/20 bg-white px-6 py-10 text-center">
-      <span className="text-4xl" aria-hidden="true">
+      <span className="text-primary" aria-hidden="true">
         {icon}
       </span>
       <h2 className="text-xl font-semibold text-gray-900">{title}</h2>

--- a/frontend/src/components/layout/PageContainer/index.tsx
+++ b/frontend/src/components/layout/PageContainer/index.tsx
@@ -28,6 +28,7 @@ import { authService } from '@/api/services/authService'
 import { performFullLogout } from '@/utils/logout'
 import { NavRefProvider, useNavRef } from '@/contexts/NavRefContext'
 import { PUBLIC_NAV_ITEMS } from './publicNav'
+import { AnimalAvatarIcon } from '@/lib/avatarIcons'
 
 const CHILD_SELECTION_PATHS = new Set([
   '/upload',
@@ -618,8 +619,11 @@ function ActiveChildPicker({
             onClick={() => onSelect(child.child_id)}
           >
             <div className="flex items-center gap-3">
-              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-2xl">
-                {avatarLabel(child)}
+              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+                <AnimalAvatarIcon
+                  avatarId={child.avatar ?? child.child_id}
+                  size={22}
+                />
               </span>
               <div className="min-w-0">
                 <h2 className="truncate text-base font-bold text-gray-800">
@@ -690,19 +694,12 @@ function ActiveChildSwitcher({
         )}
         {profiles.map((child) => (
           <option key={child.child_id} value={child.child_id}>
-            {avatarLabel(child)} {child.name}
+            {child.name}
           </option>
         ))}
       </select>
     </label>
   )
-}
-
-function avatarLabel(child: { avatar?: string | null }) {
-  if (child.avatar?.startsWith('emoji:')) {
-    return child.avatar.replace('emoji:', '')
-  }
-  return 'Child'
 }
 
 function NavLink({

--- a/frontend/src/lib/avatarIcons.tsx
+++ b/frontend/src/lib/avatarIcons.tsx
@@ -1,0 +1,107 @@
+import {
+  Beef,
+  Bird,
+  Bug,
+  Cat,
+  Crown,
+  Dog,
+  Fish,
+  Flame,
+  LucideIcon,
+  PawPrint,
+  PiggyBank,
+  Rabbit,
+  Rat,
+  Shell,
+  Sparkles,
+  Squirrel,
+  Turtle,
+} from "lucide-react";
+
+import { ANIMAL_EMOJIS } from "@/lib/avatars";
+
+const ANIMAL_ICON_BY_AVATAR_ID: Record<string, LucideIcon> = {
+  "emoji:🐶": Dog,
+  "emoji:🐱": Cat,
+  "emoji:🐼": PawPrint,
+  "emoji:🐨": PawPrint,
+  "emoji:🦊": Squirrel,
+  "emoji:🐰": Rabbit,
+  "emoji:🐸": Bug,
+  "emoji:🦁": Crown,
+  "emoji:🐯": Cat,
+  "emoji:🐮": Beef,
+  "emoji:🐷": PiggyBank,
+  "emoji:🐵": Rat,
+  "emoji:🐔": Bird,
+  "emoji:🐧": Bird,
+  "emoji:🦄": Sparkles,
+  "emoji:🐲": Flame,
+  "emoji:🐢": Turtle,
+  "emoji:🦋": Bug,
+  "emoji:🐬": Fish,
+  "emoji:🐙": Shell,
+};
+
+const ANIMAL_EMOJI_SET = new Set<string>(ANIMAL_EMOJIS);
+const FALLBACK_ANIMAL_ICONS: LucideIcon[] = [
+  Dog,
+  Cat,
+  Rabbit,
+  Bird,
+  Fish,
+  Turtle,
+  Squirrel,
+  Bug,
+  PawPrint,
+];
+
+export function normalizeAvatarId(
+  avatarId: string | null | undefined,
+): string | null {
+  if (!avatarId) return null;
+
+  const trimmed = avatarId.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith("emoji:")) return trimmed;
+  if (ANIMAL_EMOJI_SET.has(trimmed)) return `emoji:${trimmed}`;
+
+  return trimmed;
+}
+
+function fallbackIconForId(avatarId: string): LucideIcon {
+  let hash = 0;
+  for (const char of avatarId) {
+    hash = (hash * 31 + char.codePointAt(0)!) % FALLBACK_ANIMAL_ICONS.length;
+  }
+
+  return FALLBACK_ANIMAL_ICONS[hash];
+}
+
+export function avatarIconForId(avatarId: string | null | undefined): LucideIcon {
+  const normalized = normalizeAvatarId(avatarId);
+  if (!normalized) return PawPrint;
+
+  return ANIMAL_ICON_BY_AVATAR_ID[normalized] ?? fallbackIconForId(normalized);
+}
+
+export function isAnimalAvatarId(
+  avatarId: string | null | undefined,
+): boolean {
+  const normalized = normalizeAvatarId(avatarId);
+  return Boolean(normalized && ANIMAL_ICON_BY_AVATAR_ID[normalized]);
+}
+
+export function AnimalAvatarIcon({
+  avatarId,
+  size = 22,
+  className,
+}: {
+  avatarId: string | null | undefined;
+  size?: number;
+  className?: string;
+}) {
+  const Icon = avatarIconForId(avatarId);
+  return <Icon size={size} className={className} aria-hidden="true" />;
+}

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -25,6 +25,8 @@ import {
   ExternalLink,
   ImagePlus,
   Loader2,
+  MessageCircle,
+  Mic,
   Send,
   Settings,
   Sparkles,
@@ -68,6 +70,7 @@ import {
   chipPrefillForCharacter,
   pickRecurringCharacter,
 } from "./recurringCharacter";
+import { AnimalAvatarIcon } from "@/lib/avatarIcons";
 
 interface Props {
   agent: Agent;
@@ -99,12 +102,6 @@ const STARTER_PROMPTS: string[] = [
 const TALK_TO_BUDDY_ENABLED =
   (import.meta as { env?: { VITE_TALK_TO_BUDDY_ENABLED?: string } }).env
     ?.VITE_TALK_TO_BUDDY_ENABLED === "true";
-
-function avatarGlyph(agent: Agent): string {
-  return agent.agent_avatar_id.startsWith("emoji:")
-    ? agent.agent_avatar_id.slice("emoji:".length)
-    : "✦";
-}
 
 function launchLabel(flow: SSELaunchFlowData): string {
   switch (flow.flow_type) {
@@ -231,7 +228,6 @@ export default function AgentChatPanel({
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [messages.length, tail]);
 
-  const buddyGlyph = useMemo(() => avatarGlyph(agent), [agent]);
   const canSend = Boolean(draft.trim()) && !isStreaming && Boolean(childId);
   const imageInputId = `agent-chat-image-${agent.agent_id}`;
   const currentChild = useChildStore((s) => s.currentChild);
@@ -451,10 +447,10 @@ export default function AgentChatPanel({
       <header className="flex items-center justify-between gap-3 border-b border-gray-100 bg-gradient-to-r from-violet-50 to-pink-50 px-5 py-3.5">
         <div className="flex items-center gap-3">
           <div
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-2xl shadow-sm ring-1 ring-violet-100"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-violet-600 shadow-sm ring-1 ring-violet-100"
             aria-hidden="true"
           >
-            {buddyGlyph}
+            <AnimalAvatarIcon avatarId={agent.agent_avatar_id} size={22} />
           </div>
           <div className="min-w-0">
             <h2 className="truncate text-base font-semibold text-gray-900">
@@ -500,7 +496,7 @@ export default function AgentChatPanel({
               title="Ask a grown-up to turn on voice chat"
               aria-label="Ask a grown-up to turn on voice chat"
             >
-              <span aria-hidden="true">💬</span>
+              <MessageCircle size={14} aria-hidden="true" />
               <span>Ask</span>
             </button>
           )}
@@ -524,8 +520,8 @@ export default function AgentChatPanel({
       >
         {messages.length === 0 ? (
           <div className="mx-auto flex h-full max-w-md flex-col items-center justify-center gap-5 text-center">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white text-3xl shadow-md ring-2 ring-violet-100">
-              {buddyGlyph}
+            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-white text-violet-600 shadow-md ring-2 ring-violet-100">
+              <AnimalAvatarIcon avatarId={agent.agent_avatar_id} size={32} />
             </div>
             <div>
               <p className="text-base font-semibold text-gray-900">
@@ -562,9 +558,9 @@ export default function AgentChatPanel({
                 {message.role === "assistant" && (
                   <div
                     aria-hidden="true"
-                    className="mr-2 mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-base shadow-sm ring-1 ring-violet-100"
+                    className="mr-2 mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-white text-violet-600 shadow-sm ring-1 ring-violet-100"
                   >
-                    {buddyGlyph}
+                    <AnimalAvatarIcon avatarId={agent.agent_avatar_id} size={16} />
                   </div>
                 )}
                 <div
@@ -721,7 +717,7 @@ export default function AgentChatPanel({
                 className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:pointer-events-none disabled:bg-gray-100 disabled:text-gray-300"
                 title="Ask a grown-up to allow the microphone"
               >
-                <span aria-hidden="true">🎤</span>
+                <Mic size={18} aria-hidden="true" />
                 <span className="sr-only">Ask a grown-up to allow the microphone</span>
               </button>
             ))}

--- a/frontend/src/pages/MyAgentPage/AgentTitlePicker.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentTitlePicker.tsx
@@ -74,7 +74,7 @@ export default function AgentTitlePicker({
           </option>
         ))}
         {allowCustom && (
-          <option value={CUSTOM_SENTINEL}>✏️ Custom title</option>
+          <option value={CUSTOM_SENTINEL}>Custom title</option>
         )}
       </select>
       {mode === "custom" && allowCustom && (

--- a/frontend/src/pages/MyAgentPage/OnboardingModal.tsx
+++ b/frontend/src/pages/MyAgentPage/OnboardingModal.tsx
@@ -18,7 +18,9 @@
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { AxiosError } from "axios";
+import { Shuffle } from "lucide-react";
 import { ANIMAL_EMOJIS } from "@/lib/avatars";
+import { AnimalAvatarIcon } from "@/lib/avatarIcons";
 import { CURATED_TITLES, customTitleAllowed } from "@/lib/agentTitles";
 import { useUpsertAgent } from "@/hooks/useAgent";
 import { onboardingService } from "@/api/services/onboardingService";
@@ -219,10 +221,10 @@ export default function OnboardingModal({
           {currentStep === "avatar" && (
             <div className="flex flex-col gap-2">
               <span className="text-sm font-medium text-gray-700">
-                Pick an animal
+                Pick a buddy icon
               </span>
               <div role="radiogroup" className="grid grid-cols-5 gap-2">
-                {ANIMAL_EMOJIS.map((emoji) => {
+                {ANIMAL_EMOJIS.map((emoji, index) => {
                   const id = avatarIdFor(emoji);
                   const selected = avatarId === id;
                   return (
@@ -231,16 +233,16 @@ export default function OnboardingModal({
                       type="button"
                       role="radio"
                       aria-checked={selected}
-                      aria-label={`Choose ${emoji}`}
+                      aria-label={`Choose buddy icon ${index + 1}`}
                       onClick={() => setAvatarId(id)}
                       className={[
-                        "flex aspect-square items-center justify-center rounded-lg border-2 text-2xl transition-colors",
+                        "flex aspect-square items-center justify-center rounded-lg border-2 text-primary transition-colors",
                         selected
                           ? "border-primary bg-primary/10"
                           : "border-gray-200 hover:border-primary/35 hover:bg-primary/5",
                       ].join(" ")}
                     >
-                      {emoji}
+                      <AnimalAvatarIcon avatarId={id} size={22} />
                     </button>
                   );
                 })}
@@ -250,10 +252,10 @@ export default function OnboardingModal({
                   We'll call your buddy <strong>{name}</strong>. Tap{" "}
                   <button
                     type="button"
-                    className="text-primary-dark underline"
+                    className="inline-flex items-center gap-1 text-primary-dark underline"
                     onClick={() => setName(pickRandomName())}
                   >
-                    🔀 shuffle
+                    <Shuffle className="h-3 w-3" aria-hidden="true" /> shuffle
                   </button>{" "}
                   for a different name.
                 </p>
@@ -280,7 +282,7 @@ export default function OnboardingModal({
                   </option>
                 ))}
                 {customTitleAllowed(ageGroup) && (
-                  <option value="__custom__">✏️ Custom title</option>
+                  <option value="__custom__">Custom title</option>
                 )}
               </select>
               {customTitleAllowed(ageGroup) &&

--- a/frontend/src/pages/MyAgentPage/PersonaEditorSheet.tsx
+++ b/frontend/src/pages/MyAgentPage/PersonaEditorSheet.tsx
@@ -16,6 +16,7 @@ import { useEffect, useState } from "react";
 import { AxiosError } from "axios";
 import { X } from "lucide-react";
 import { ANIMAL_EMOJIS } from "@/lib/avatars";
+import { AnimalAvatarIcon } from "@/lib/avatarIcons";
 import { useUpsertAgent } from "@/hooks/useAgent";
 import type { Agent, AgentErrorDetail } from "@/types/agent";
 import type { AgeGroup } from "@/types/api";
@@ -214,14 +215,14 @@ export default function PersonaEditorSheet({
           {/* Avatar */}
           <div className="flex flex-col gap-2">
             <span className="text-sm font-medium text-gray-700">
-              Buddy animal
+              Buddy icon
             </span>
             <div
               role="radiogroup"
-              aria-label="Buddy animal"
+              aria-label="Buddy icon"
               className="grid grid-cols-5 gap-2"
             >
-              {ANIMAL_EMOJIS.map((emoji) => {
+              {ANIMAL_EMOJIS.map((emoji, index) => {
                 const id = avatarIdFor(emoji);
                 const selected = avatarId === id;
                 return (
@@ -230,17 +231,17 @@ export default function PersonaEditorSheet({
                     type="button"
                     role="radio"
                     aria-checked={selected}
-                    aria-label={`Choose ${emoji}`}
+                    aria-label={`Choose buddy icon ${index + 1}`}
                     disabled={upsert.isPending}
                     onClick={() => setAvatarId(id)}
                     className={[
-                      "flex aspect-square items-center justify-center rounded-xl border-2 text-2xl transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500",
+                      "flex aspect-square items-center justify-center rounded-xl border-2 text-violet-600 transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500",
                       selected
                         ? "border-violet-500 bg-violet-50"
                         : "border-gray-200 hover:border-gray-300",
                     ].join(" ")}
                   >
-                    {emoji}
+                    <AnimalAvatarIcon avatarId={id} size={22} />
                   </button>
                 );
               })}

--- a/frontend/src/pages/MyAgentPage/index.tsx
+++ b/frontend/src/pages/MyAgentPage/index.tsx
@@ -30,6 +30,7 @@ import OnboardingModal from "./OnboardingModal";
 import PersonaEditorSheet from "./PersonaEditorSheet";
 import { shouldAutoOpenOnboarding } from "./onboardingState";
 import SignInPrompt from "@/components/common/SignInPrompt";
+import { AnimalAvatarIcon } from "@/lib/avatarIcons";
 
 export default function MyAgentPage() {
   const currentChild = useChildStore((s) => s.currentChild);
@@ -128,7 +129,7 @@ export default function MyAgentPage() {
           </p>
         </header>
         <SignInPrompt
-          icon="🦊"
+          icon={<AnimalAvatarIcon avatarId="emoji:🦊" size={36} />}
           title="Sign in to meet your buddy"
           description="Once you sign in, we'll walk you through naming your creative buddy and picking its animal — takes under a minute."
         />
@@ -223,7 +224,9 @@ export default function MyAgentPage() {
           </p>
         </header>
         <div className="rounded-2xl border border-dashed border-violet-200 bg-violet-50/60 p-8 text-center">
-          <div className="mx-auto mb-3 text-5xl">🦊</div>
+          <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-white text-violet-600 shadow-sm ring-1 ring-violet-100">
+            <AnimalAvatarIcon avatarId="emoji:🦊" size={30} />
+          </div>
           <p className="text-sm text-gray-700">
             Your buddy isn't set up yet. Take a minute to introduce yourselves.
           </p>

--- a/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
+++ b/frontend/src/pages/MyAgentPage/talkToBuddyHelpers.ts
@@ -269,8 +269,8 @@ export function resolveCaptionsVisibility(
  *
  * Reuses the canonical ``AgeGroup`` from ``@/types/api`` rather than a
  * local copy so a future fourth band (there isn't one today) can't drift
- * between modules. ``emoji`` is the empty string for 6-8 — the consuming
- * JSX renders the emoji span only when non-empty.
+ * between modules. ``emoji`` remains in the return shape for backwards
+ * compatibility, but it is intentionally empty so the UI stays on flat icons.
  */
 export interface HeaderCTACopy {
   label: string;
@@ -283,9 +283,9 @@ export function headerCTACopy(
 ): HeaderCTACopy {
   switch (ageGroup) {
     case "3-5":
-      return { label: "Talk!", emoji: "🎤" };
+      return { label: "Talk!", emoji: "" };
     case "9-12":
-      return { label: "Voice", emoji: "🎤" };
+      return { label: "Voice", emoji: "" };
     case "6-8":
     default:
       return { label: `Talk to ${buddyName}`, emoji: "" };

--- a/frontend/src/pages/ProfilePage/CharacterGallery.tsx
+++ b/frontend/src/pages/ProfilePage/CharacterGallery.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { motion } from "framer-motion";
+import { Palette, Star, Users } from "lucide-react";
 import Card from "@/components/common/Card";
 import type { MemoryCharacter } from "@/types/api";
 
@@ -133,7 +134,7 @@ function CharacterGallery({
 
       {characters.length === 0 ? (
         <div className="text-center py-8">
-          <div className="text-4xl mb-3">🎨</div>
+          <Palette className="mx-auto mb-3 h-10 w-10 text-primary" aria-hidden="true" />
           <p className="text-gray-500 text-sm">
             Create your first story to meet your characters!
           </p>
@@ -141,8 +142,9 @@ function CharacterGallery({
       ) : (
         <div className="space-y-4">
           <div>
-            <p className="text-sm font-semibold text-gray-700 mb-2">
-              🌟 Main Characters ({resolvedMainCharacters.length})
+            <p className="mb-2 inline-flex items-center gap-1.5 text-sm font-semibold text-gray-700">
+              <Star className="h-4 w-4 text-amber-500" aria-hidden="true" />
+              Main Characters ({resolvedMainCharacters.length})
             </p>
             {resolvedMainCharacters.length > 0 ? (
               <div ref={scrollRef} className="character-carousel">
@@ -154,8 +156,9 @@ function CharacterGallery({
           </div>
 
           <div>
-            <p className="text-sm font-semibold text-gray-700 mb-2">
-              👥 Other Characters ({resolvedOtherCharacters.length})
+            <p className="mb-2 inline-flex items-center gap-1.5 text-sm font-semibold text-gray-700">
+              <Users className="h-4 w-4 text-gray-500" aria-hidden="true" />
+              Other Characters ({resolvedOtherCharacters.length})
             </p>
             {resolvedOtherCharacters.length > 0 ? (
               <div className="character-carousel">

--- a/frontend/src/pages/ProfilePage/ChildrenTab.tsx
+++ b/frontend/src/pages/ProfilePage/ChildrenTab.tsx
@@ -12,6 +12,8 @@ import Button from "@/components/common/Button";
 import Card from "@/components/common/Card";
 import useChildStore, { DEFAULT_INTERESTS } from "@/store/useChildStore";
 import type { AgeGroup, ChildProfile } from "@/types/api";
+import { AnimalAvatarIcon } from "@/lib/avatarIcons";
+import { ANIMAL_EMOJIS } from "@/lib/avatars";
 
 const AGE_OPTIONS: AgeGroup[] = ["3-5", "6-8", "9-12"];
 
@@ -26,8 +28,12 @@ const EMPTY_FORM: FormState = {
   name: "",
   age_group: "6-8",
   interestsText: "",
-  avatar: "",
+  avatar: avatarIdFor(ANIMAL_EMOJIS[0]),
 };
+
+function avatarIdFor(emoji: string): string {
+  return `emoji:${emoji}`;
+}
 
 interface ChildrenTabProps {
   isParent: boolean;
@@ -219,7 +225,10 @@ function ChildrenTab({ isParent }: ChildrenTabProps) {
                     }`}
                     onClick={() => switchActiveChild(child.child_id)}
                   >
-                    {avatarLabel(child)}
+                    <AnimalAvatarIcon
+                      avatarId={child.avatar ?? child.child_id}
+                      size={16}
+                    />
                     <span>{child.name}</span>
                     {isActive && (
                       <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
@@ -282,6 +291,40 @@ function ChildrenTab({ isParent }: ChildrenTabProps) {
                   ))}
                 </select>
               </label>
+            </div>
+
+            <div>
+              <span className="mb-2 block text-sm font-medium text-gray-600">
+                Avatar
+              </span>
+              <div
+                role="radiogroup"
+                aria-label="Child avatar"
+                className="grid grid-cols-5 gap-2 sm:grid-cols-10"
+              >
+                {ANIMAL_EMOJIS.map((emoji, index) => {
+                  const avatarId = avatarIdFor(emoji);
+                  const selected = form.avatar === avatarId;
+                  return (
+                    <button
+                      key={avatarId}
+                      type="button"
+                      role="radio"
+                      aria-checked={selected}
+                      aria-label={`Choose child avatar ${index + 1}`}
+                      onClick={() => setForm({ ...form, avatar: avatarId })}
+                      className={[
+                        "flex aspect-square items-center justify-center rounded-lg border-2 text-primary transition-colors",
+                        selected
+                          ? "border-primary bg-primary/10"
+                          : "border-gray-200 hover:border-primary/35 hover:bg-primary/5",
+                      ].join(" ")}
+                    >
+                      <AnimalAvatarIcon avatarId={avatarId} size={20} />
+                    </button>
+                  );
+                })}
+              </div>
             </div>
 
             <label className="block">
@@ -388,7 +431,12 @@ function ChildrenTab({ isParent }: ChildrenTabProps) {
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-2xl">{avatarLabel(child)}</span>
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+                        <AnimalAvatarIcon
+                          avatarId={child.avatar ?? child.child_id}
+                          size={20}
+                        />
+                      </span>
                       <h3 className="truncate text-lg font-bold text-gray-800">
                         {child.name}
                       </h3>
@@ -492,13 +540,6 @@ function StatusPill({
       {children}
     </span>
   );
-}
-
-function avatarLabel(child: ChildProfile): string {
-  if (child.avatar?.startsWith("emoji:")) {
-    return child.avatar.replace("emoji:", "");
-  }
-  return "🎨";
 }
 
 export default ChildrenTab;

--- a/frontend/src/pages/ProfilePage/PreferenceSummary.tsx
+++ b/frontend/src/pages/ProfilePage/PreferenceSummary.tsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import { Rainbow } from "lucide-react";
 import Card from "@/components/common/Card";
 import type { MemoryPreferenceCategory, PreferenceProfile } from "@/types/api";
 
@@ -123,7 +124,7 @@ function PreferenceSummary({
 
       {!hasData ? (
         <div className="text-center py-6">
-          <div className="text-4xl mb-3">🌈</div>
+          <Rainbow className="mx-auto mb-3 h-10 w-10 text-primary" aria-hidden="true" />
           <p className="text-gray-500 text-sm">
             Your favorite themes will appear here as you explore stories!
           </p>

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -2,6 +2,16 @@ import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useQuery } from "@tanstack/react-query";
+import {
+  Check,
+  Flame,
+  Gift,
+  Newspaper,
+  Palette,
+  PartyPopper,
+  Star,
+  Theater,
+} from "lucide-react";
 import Button from "@/components/common/Button";
 import Card from "@/components/common/Card";
 import TiltCard from "@/components/depth/TiltCard";
@@ -21,6 +31,7 @@ import ChildrenTab from "./ChildrenTab";
 import { useMemoryApi } from "@/hooks/useMemoryApi";
 import type { MemoryPreferenceCategory } from "@/types/api";
 import { ANIMAL_EMOJIS } from "@/lib/avatars";
+import { AnimalAvatarIcon, normalizeAvatarId } from "@/lib/avatarIcons";
 
 const PROFILE_TABS = [
   { id: "overview", label: "Overview" },
@@ -83,13 +94,13 @@ function StarBoard() {
     <Card className="overflow-hidden">
       <div className="bg-gradient-to-r from-amber-400 via-yellow-400 to-orange-400 px-5 py-4">
         <div className="flex items-center gap-3">
-          <div className="text-3xl">🫙</div>
+          <Star className="h-8 w-8 text-white" aria-hidden="true" />
           <div>
             <h2 className="text-base font-bold text-white flex items-center gap-2">
               My Star Collection
               {streak >= 2 && (
                 <span className="px-2 py-0.5 text-[10px] font-bold rounded-full bg-white/25 text-white backdrop-blur-sm border border-white/30">
-                  🔥 {streak} day streak
+                  <Flame className="h-3 w-3" aria-hidden="true" /> {streak} day streak
                 </span>
               )}
             </h2>
@@ -329,7 +340,7 @@ function ProfilePage() {
           onClick={() => navigate("/library?tab=art-stories")}
         >
           <div className="bg-gradient-to-br from-primary/10 to-primary/5 rounded-card p-5 text-center">
-            <div className="text-4xl mb-2">🎨</div>
+            <Palette className="mx-auto mb-2 h-9 w-9 text-primary" aria-hidden="true" />
             <div className="text-3xl font-bold text-gray-800">
               {statsLoading ? "..." : (stats?.art_story_count ?? 0)}
             </div>
@@ -343,7 +354,7 @@ function ProfilePage() {
           onClick={() => navigate("/library?tab=interactive")}
         >
           <div className="bg-gradient-to-br from-accent/20 to-accent/10 rounded-card p-5 text-center">
-            <div className="text-4xl mb-2">🎭</div>
+            <Theater className="mx-auto mb-2 h-9 w-9 text-emerald-600" aria-hidden="true" />
             <div className="text-3xl font-bold text-gray-800">
               {statsLoading ? "..." : (stats?.interactive_count ?? 0)}
             </div>
@@ -357,7 +368,7 @@ function ProfilePage() {
           onClick={() => navigate("/library?tab=kids-news")}
         >
           <div className="bg-gradient-to-br from-secondary/20 to-secondary/10 rounded-card p-5 text-center">
-            <div className="text-4xl mb-2">📰</div>
+            <Newspaper className="mx-auto mb-2 h-9 w-9 text-amber-600" aria-hidden="true" />
             <div className="text-3xl font-bold text-gray-800">
               {statsLoading ? "..." : (stats?.news_count ?? 0)}
             </div>
@@ -492,20 +503,22 @@ function ProfilePage() {
                     size="md"
                   />
                   <span className="text-sm text-gray-500">
-                    {editForm.avatar_url?.startsWith("emoji:")
-                      ? "Tap an animal to change"
-                      : "Pick your favorite animal!"}
+                    {normalizeAvatarId(editForm.avatar_url)?.startsWith("emoji:")
+                      ? "Tap an icon to change"
+                      : "Pick your profile icon"}
                   </span>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  {ANIMAL_EMOJIS.map((emoji) => {
+                  {ANIMAL_EMOJIS.map((emoji, index) => {
                     const emojiValue = `emoji:${emoji}`;
-                    const isSelected = editForm.avatar_url === emojiValue;
+                    const isSelected =
+                      normalizeAvatarId(editForm.avatar_url) === emojiValue;
                     return (
                       <motion.button
                         key={emoji}
                         type="button"
-                        className={`flex h-10 w-10 items-center justify-center rounded-lg text-xl transition-all ${
+                        aria-label={`Choose profile icon ${index + 1}`}
+                        className={`flex h-10 w-10 items-center justify-center rounded-lg text-primary transition-all ${
                           isSelected
                             ? "border-2 border-primary bg-primary/10 shadow-md"
                             : "border border-gray-200 hover:border-gray-300 hover:shadow-sm"
@@ -516,7 +529,7 @@ function ProfilePage() {
                         whileHover={{ scale: 1.15, y: -2 }}
                         whileTap={{ scale: 0.9 }}
                       >
-                        {emoji}
+                        <AnimalAvatarIcon avatarId={emojiValue} size={20} />
                       </motion.button>
                     );
                   })}
@@ -540,7 +553,7 @@ function ProfilePage() {
           {/* Header banner */}
           <div className="bg-gradient-to-r from-violet-500 via-purple-500 to-indigo-500 px-5 py-4">
             <div className="flex items-center gap-3">
-              <div className="text-3xl">🎁</div>
+              <Gift className="h-8 w-8 text-white" aria-hidden="true" />
               <div>
                 <h2 className="text-base font-bold text-white flex items-center gap-2">
                   Share the Fun!
@@ -584,7 +597,13 @@ function ProfilePage() {
                         : "bg-gradient-to-r from-violet-500 to-purple-500 text-white hover:from-violet-600 hover:to-purple-600 shadow-purple-200 shadow-md hover:shadow-lg"
                     }`}
                   >
-                    {linkCopied ? "Copied ✓" : "Copy Link"}
+                    {linkCopied ? (
+                      <span className="inline-flex items-center gap-1">
+                        Copied <Check className="h-3.5 w-3.5" aria-hidden="true" />
+                      </span>
+                    ) : (
+                      "Copy Link"
+                    )}
                   </button>
                 </div>
               </div>
@@ -612,7 +631,12 @@ function ProfilePage() {
                 </div>
                 <p className="text-xs text-gray-400 mt-2">
                   {referral.membership_tier === "plus"
-                    ? "🎉 You're a Plus member — enjoy 3x daily creations!"
+                    ? (
+                      <span className="inline-flex items-center gap-1">
+                        <PartyPopper className="h-3.5 w-3.5" aria-hidden="true" />
+                        You're a Plus member — enjoy 3x daily creations!
+                      </span>
+                    )
                     : `Invite ${referral.upgrade_threshold - referral.qualified_count} more friends to upgrade to Plus and get 3x daily uses`}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- add a shared animal flat-icon avatar mapper with raw emoji normalization
- replace parent, child, and buddy emoji avatar displays with flat icons
- keep missing child avatars on stable animal-icon fallbacks instead of generic icons

## Verification
- npx vitest run src/__tests__/components/avatarIcons.test.tsx --environment node
- npm run build
- git diff --check