### PR TITLE
chore(cost): use cheapest best-value model tier everywhere

### DIFF
--- a/backend/src/mcp_servers/image_style_server.py
+++ b/backend/src/mcp_servers/image_style_server.py
@@ -289,10 +289,17 @@ async def _transform_art_style_tool(args: Dict[str, Any]) -> Dict[str, Any]:
     try:
         prompt = ART_THEME_PROMPTS[theme]
 
-        # Call Replicate flux-kontext-pro model
+        # Best-value policy: ``flux-kontext-pro`` is already cheap (~$0.04/img),
+        # fast (hosted, no GPU cold start), and high quality — the right
+        # quality/speed/cost balance for a user-facing styled image. The
+        # cheaper open-weights ``dev`` tier saves ~$0.02 but is slower and
+        # lower fidelity, so it is opt-in via the IMAGE_STYLE_MODEL env var.
+        style_model = os.getenv(
+            "IMAGE_STYLE_MODEL", "black-forest-labs/flux-kontext-pro"
+        )
         with open(image_path, "rb") as img_file:
             output = replicate.run(
-                "black-forest-labs/flux-kontext-pro",
+                style_model,
                 input={
                     "prompt": prompt,
                     "input_image": img_file,

--- a/backend/src/mcp_servers/video_generator_server.py
+++ b/backend/src/mcp_servers/video_generator_server.py
@@ -1,7 +1,11 @@
 """
 Video Generation MCP Server
 
-Provides tools for generating animated videos from children's paintings using OpenAI Sora.
+Provides tools for generating animated videos from children's paintings.
+
+Cheapest-everywhere policy: video uses a low-cost Replicate image-to-video
+model (default ``wan-video/wan-2.2-i2v-fast``) instead of OpenAI Sora. The
+model is overridable via the ``VIDEO_MODEL`` env var with no code change.
 """
 
 import os
@@ -14,9 +18,14 @@ import uuid
 from datetime import datetime, timedelta
 
 try:
-    from openai import OpenAI
+    import replicate as _replicate
 except Exception:  # pragma: no cover - import fallback for test env
-    OpenAI = None
+    _replicate = None
+
+try:
+    import httpx as _httpx
+except Exception:  # pragma: no cover - import fallback for test env
+    _httpx = None
 
 try:
     from claude_agent_sdk import tool, create_sdk_mcp_server
@@ -36,6 +45,29 @@ VIDEO_STYLE_PROMPTS = {
     "playful": "Create a playful animation from this children's painting. Add bouncy, fun movements to the characters and elements. Keep the whimsical, child-drawn quality while making elements dance and move joyfully.",
     "storybook": "Transform this children's painting into a storybook-style animation. Add gentle page-turning effects and bring elements to life as if the drawing is coming alive from a magical book."
 }
+
+
+# Cheapest-everywhere policy: a low-cost, maintained, prompt-capable Replicate
+# image-to-video model. Overridable via env without a redeploy of code.
+DEFAULT_VIDEO_MODEL = "wan-video/wan-2.2-i2v-fast"
+
+
+def get_video_model() -> str:
+    return os.getenv("VIDEO_MODEL", DEFAULT_VIDEO_MODEL)
+
+
+def get_video_resolution() -> str:
+    # 480p is the cheaper tier; bump to 720p via env only if needed.
+    return os.getenv("VIDEO_RESOLUTION", "480p")
+
+
+def get_video_render_timeout() -> float:
+    """Max seconds to wait for a render. i2v jobs routinely take 1-2+ min
+    (plus cold start), well beyond replicate.run()'s ~60s default wait."""
+    try:
+        return float(os.getenv("VIDEO_RENDER_TIMEOUT_S", "300"))
+    except (TypeError, ValueError):
+        return 300.0
 
 
 def get_video_output_path():
@@ -71,22 +103,18 @@ def get_image_mime_type(image_path: str) -> str:
     return mime_types.get(ext, "image/png")
 
 
-# Sora only renders fixed clip lengths; map any requested duration onto one.
-SORA_SUPPORTED_DURATIONS = (4, 8, 12)
+def normalize_duration_seconds(duration_seconds) -> int:
+    """Coerce a requested clip length to a small, cost-friendly integer.
 
-
-def nearest_supported_duration(duration_seconds: int) -> str:
-    """Snap a requested duration to the nearest Sora-supported clip length.
-
-    Sora's videos API only accepts 4, 8, or 12 second clips, so an arbitrary
-    request (e.g. the legacy default of 10) must be coerced or the call fails.
+    The Replicate i2v model renders a short clip from its own frame defaults;
+    we only record the requested duration in the job metadata. Clamp to a
+    cheap 4-8s window so a stray large request can't drive up cost.
     """
     try:
         requested = int(duration_seconds)
     except (TypeError, ValueError):
-        requested = SORA_SUPPORTED_DURATIONS[0]
-    closest = min(SORA_SUPPORTED_DURATIONS, key=lambda s: abs(s - requested))
-    return str(closest)
+        requested = 5
+    return max(4, min(8, requested))
 
 
 def save_job_status(job_id: str, job_data: Dict[str, Any]) -> None:
@@ -153,66 +181,81 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
             }]
         }
 
-    # Check OpenAI API Key
-    api_key = os.getenv("OPENAI_API_KEY")
+    # Check Replicate availability + token (cheapest-everywhere video provider).
+    if _replicate is None or _httpx is None:
+        return {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "success": False,
+                    "error": "replicate/httpx SDK not installed",
+                    "job_id": None
+                }, ensure_ascii=False)
+            }]
+        }
+    api_key = os.getenv("REPLICATE_API_TOKEN")
     if not api_key:
         return {
             "content": [{
                 "type": "text",
                 "text": json.dumps({
                     "success": False,
-                    "error": "OPENAI_API_KEY environment variable not configured",
+                    "error": "REPLICATE_API_TOKEN environment variable not configured",
                     "job_id": None
                 }, ensure_ascii=False)
             }]
         }
 
     try:
-        client = OpenAI(api_key=api_key)
-
         # Generate job ID
         job_id = str(uuid.uuid4())
         timestamp = datetime.now()
 
-        # Get style prompt
+        # Get style prompt + cost-clamped clip length
         style_prompt = VIDEO_STYLE_PROMPTS.get(
             style,
             VIDEO_STYLE_PROMPTS["gentle_animation"]
         )
+        clip_seconds = normalize_duration_seconds(duration_seconds)
+        model = get_video_model()
 
-        # Generate the animation with OpenAI Sora. The painting is supplied as a
-        # visual reference through the dedicated videos API.
-        #
-        # The previous implementation called client.images.generate(image=...),
-        # which raises "unexpected keyword argument 'image'": images.generate()
-        # accepts no image input and returns stills, not video. Sora is exposed
-        # via client.videos.* instead.
-        seconds = nearest_supported_duration(duration_seconds)
-
+        # Generate the animation via a Replicate image-to-video model. The
+        # painting is the conditioning frame and the per-style prompt drives
+        # the motion. ``resolution``/``go_fast`` keep the render on the cheap
+        # tier (valid for the default WAN model). A generous client timeout is
+        # required: i2v renders routinely exceed run()'s ~60s default wait and
+        # would otherwise raise "read operation timed out".
+        client = _replicate.Client(
+            api_token=api_key,
+            timeout=_httpx.Timeout(get_video_render_timeout(), connect=15.0),
+        )
         with open(image_path, "rb") as image_file:
-            video_job = client.videos.create_and_poll(
-                model="sora-2",
-                prompt=style_prompt,
-                input_reference=image_file,
-                seconds=seconds,
-                size="1280x720",
+            output = client.run(
+                model,
+                input={
+                    "prompt": style_prompt,
+                    "image": image_file,
+                    "resolution": get_video_resolution(),
+                    "go_fast": True,
+                },
+                use_file_output=False,
             )
 
-        if getattr(video_job, "status", None) != "completed":
-            failure = getattr(video_job, "error", None)
-            reason = getattr(failure, "message", None) or failure or "unknown error"
-            raise Exception(
-                f"Sora video job ended with status "
-                f"'{getattr(video_job, 'status', 'unknown')}': {reason}"
-            )
+        # Replicate returns a single video URL (str / FileOutput) or a list.
+        video_ref = output[0] if isinstance(output, (list, tuple)) else output
+        if video_ref is None:
+            raise Exception(f"{model} returned no video output")
 
         # Download the rendered video locally.
         video_dir = get_video_output_path()
         video_filename = f"video_{job_id}.mp4"
         video_path = Path(video_dir) / video_filename
-        client.videos.download_content(
-            video_job.id, variant="video"
-        ).write_to_file(str(video_path))
+        if hasattr(video_ref, "read"):
+            data = video_ref.read()
+        else:
+            data = _httpx.get(str(video_ref), timeout=180).content
+        with open(video_path, "wb") as f:
+            f.write(data)
 
         # Save job status
         job_data = {
@@ -223,7 +266,8 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
             "video_path": str(video_path),
             "video_filename": video_filename,
             "style": style,
-            "duration_seconds": int(seconds),
+            "duration_seconds": clip_seconds,
+            "model": model,
             "created_at": timestamp.isoformat(),
             "completed_at": datetime.now().isoformat()
         }

--- a/backend/src/services/realtime_voice_service.py
+++ b/backend/src/services/realtime_voice_service.py
@@ -832,7 +832,16 @@ class OpenAIRealtimeProvider:
         The constructor's ``self.model`` is ignored — selection is
         decided at session start so a long-lived provider instance
         can serve sessions for many children with different tiers.
+
+        Cheapest-everywhere cost policy: premium realtime is disabled by
+        default — every session uses the ``gpt-realtime-mini`` tier
+        regardless of the per-child opt-in flags. To re-enable the
+        dual-opt-in escalation to ``gpt-realtime-2`` later, set the env
+        var ``VOICE_ALLOW_PREMIUM_REALTIME=1`` (no redeploy of code
+        needed; the escalation logic below is preserved).
         """
+        if os.getenv("VOICE_ALLOW_PREMIUM_REALTIME", "0") != "1":
+            return OPENAI_REALTIME_MODEL_DEFAULT
         if voice_premium_voice and voice_premium_voice_consent:
             return OPENAI_REALTIME_MODEL_ESCALATED
         return OPENAI_REALTIME_MODEL_DEFAULT

--- a/backend/tests/contracts/test_voice_cost_telemetry_contract.py
+++ b/backend/tests/contracts/test_voice_cost_telemetry_contract.py
@@ -107,8 +107,25 @@ class TestTierSelection:
         assert handle.provider_state["model"] == "gpt-realtime-mini"
 
     @pytest.mark.asyncio
+    async def test_premium_disabled_by_default_stays_mini(self, monkeypatch):
+        # Cheapest-everywhere cost policy: without VOICE_ALLOW_PREMIUM_REALTIME=1,
+        # even a dual opt-in profile stays on the mini tier.
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("VOICE_ALLOW_PREMIUM_REALTIME", raising=False)
+        provider = rtvs.OpenAIRealtimeProvider()
+        handle = await provider.start_session(
+            user_id="u", child_id="c", target_age=7,
+            voice_premium_voice=True,
+            voice_premium_voice_consent=True,
+        )
+        assert handle.provider_state["model"] == "gpt-realtime-mini"
+
+    @pytest.mark.asyncio
     async def test_escalation_requires_both_flags_true(self, monkeypatch):
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        # Premium escalation is opt-in via env (cheapest-everywhere default is
+        # OFF). Enable it here to exercise the dual-flag escalation policy.
+        monkeypatch.setenv("VOICE_ALLOW_PREMIUM_REALTIME", "1")
         provider = rtvs.OpenAIRealtimeProvider()
 
         # Only opt-in flag set → still mini (fail closed).
@@ -127,7 +144,7 @@ class TestTierSelection:
         )
         assert h2.provider_state["model"] == "gpt-realtime-mini"
 
-        # Both flags set → escalate.
+        # Both flags set AND premium allowed → escalate.
         h3 = await provider.start_session(
             user_id="u", child_id="c", target_age=7,
             voice_premium_voice=True,

--- a/backend/tests/test_batch_235_182_150.py
+++ b/backend/tests/test_batch_235_182_150.py
@@ -51,20 +51,22 @@ class TestVideoFailFast:
 
     @pytest.mark.asyncio
     async def test_generate_painting_video_fails_with_status_failed(self, tmp_path):
-        """When Sora API fails, job status must be 'failed', not 'pending'."""
+        """When the video provider fails, job status must be 'failed', not 'pending'."""
+        from src.mcp_servers import video_generator_server as vgs
         from src.mcp_servers.video_generator_server import generate_painting_video, load_job_status
 
         # Create a dummy image
         img = tmp_path / "test.png"
         img.write_bytes(b"\x89PNG" + b"\x00" * 100)
 
-        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
-            with patch("src.mcp_servers.video_generator_server.OpenAI") as mock_openai:
-                # Simulate Sora API failure
-                mock_client = MagicMock()
-                mock_client.images.generate.side_effect = RuntimeError("Sora model not available")
-                mock_openai.return_value = mock_client
+        # Simulate Replicate i2v failure → must fail fast.
+        fake_replicate = MagicMock()
+        fake_replicate.Client.return_value.run.side_effect = RuntimeError(
+            "video model not available"
+        )
 
+        with patch.dict("os.environ", {"REPLICATE_API_TOKEN": "r8_test"}):
+            with patch.object(vgs, "_replicate", fake_replicate):
                 result = await generate_painting_video({
                     "image_path": str(img),
                     "style": "gentle_animation",

--- a/backend/tests/unit/test_video_generator_server.py
+++ b/backend/tests/unit/test_video_generator_server.py
@@ -1,9 +1,9 @@
-"""Unit tests for the Sora-backed video generation MCP tool.
+"""Unit tests for the Replicate-backed video generation MCP tool.
 
-Regression guard for the bug where generate_painting_video called
-client.images.generate(image=...), which raises
-"Images.generate() got an unexpected keyword argument 'image'" — that
-endpoint accepts no image input and returns stills, not video.
+Cheapest-everywhere (best-value) policy: video uses a low-cost, speed-optimized
+Replicate image-to-video model (default ``wan-video/wan-2.2-i2v-fast`` @ 480p)
+instead of the expensive, slow OpenAI Sora. These tests lock the provider call
+shape, the env override, and the fail-fast error path.
 """
 
 import json
@@ -13,77 +13,72 @@ import pytest
 from backend.src.mcp_servers import video_generator_server as vgs
 
 
-class _FakeBinaryContent:
+class _FakeFileOutput:
+    """Mimics replicate's FileOutput return value (has ``.read()``)."""
+
     def __init__(self, payload: bytes):
         self._payload = payload
-        self.written_to = None
 
-    def write_to_file(self, path):
-        self.written_to = str(path)
-        with open(path, "wb") as f:
-            f.write(self._payload)
+    def read(self) -> bytes:
+        return self._payload
 
 
-class _FakeVideo:
-    def __init__(self, status="completed", error=None):
-        self.id = "vid_123"
-        self.status = status
-        self.error = error
+class _FakeReplicate:
+    """Stand-in for the replicate module: ``.Client(...).run(...)``."""
+
+    def __init__(self, output=None, raises=None):
+        self._output = output
+        self._raises = raises
+        self.run_calls = []
+
+    def Client(self, api_token=None, timeout=None):
+        outer = self
+
+        class _Client:
+            def run(self, model, input=None, use_file_output=None):
+                outer.run_calls.append({"model": model, "input": input})
+                if outer._raises:
+                    raise outer._raises
+                return outer._output
+
+        return _Client()
 
 
-class _FakeVideos:
-    def __init__(self, video):
-        self._video = video
-        self.create_calls = []
-        self.download_calls = []
+class _FakeHttpx:
+    """Minimal httpx stand-in for the URL-output download branch."""
 
-    def create_and_poll(self, **kwargs):
-        self.create_calls.append(kwargs)
-        return self._video
+    class _Resp:
+        content = b"url-mp4-bytes"
 
-    def download_content(self, video_id, variant="video"):
-        self.download_calls.append((video_id, variant))
-        return _FakeBinaryContent(b"fake-mp4-bytes")
+    @staticmethod
+    def get(*_a, **_k):
+        return _FakeHttpx._Resp()
 
-
-class _FakeImages:
-    def generate(self, **kwargs):  # pragma: no cover - must never be called
-        raise AssertionError("images.generate must not be used for video")
-
-
-class _FakeOpenAI:
-    last_instance = None
-
-    def __init__(self, api_key=None, video=None):
-        self.api_key = api_key
-        self.videos = _FakeVideos(video or _FakeVideo())
-        self.images = _FakeImages()
-        _FakeOpenAI.last_instance = self
-
-
-def _patch_openai(monkeypatch, video=None):
-    def factory(api_key=None):
-        return _FakeOpenAI(api_key=api_key, video=video)
-
-    monkeypatch.setattr(vgs, "OpenAI", factory)
+    @staticmethod
+    def Timeout(*_a, **_k):
+        return None
 
 
 @pytest.mark.parametrize(
     "requested,expected",
-    [(4, "4"), (8, "8"), (12, "12"), (10, "8"), (1, "4"), (100, "12")],
+    [(4, 4), (8, 8), (10, 8), (1, 4), (100, 8), ("6", 6), (None, 5)],
 )
-def test_nearest_supported_duration_snaps_to_sora_lengths(requested, expected):
-    assert vgs.nearest_supported_duration(requested) == expected
+def test_normalize_duration_clamps_to_cost_window(requested, expected):
+    assert vgs.normalize_duration_seconds(requested) == expected
 
 
 @pytest.mark.asyncio
-async def test_generate_painting_video_uses_sora_videos_api(monkeypatch, tmp_path):
+async def test_generate_painting_video_uses_replicate_i2v(monkeypatch, tmp_path):
     image_path = tmp_path / "drawing.png"
     image_path.write_bytes(b"fake-png")
     monkeypatch.setattr(vgs, "get_video_output_path", lambda: str(tmp_path))
     monkeypatch.setattr(vgs, "save_job_status", lambda *_a, **_k: None)
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    _patch_openai(monkeypatch)
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "r8_test")
+    monkeypatch.delenv("VIDEO_MODEL", raising=False)
+    monkeypatch.delenv("VIDEO_RESOLUTION", raising=False)
+
+    fake = _FakeReplicate(output=_FakeFileOutput(b"fake-mp4-bytes"))
+    monkeypatch.setattr(vgs, "_replicate", fake)
 
     result = await vgs.generate_painting_video(
         {
@@ -98,14 +93,13 @@ async def test_generate_painting_video_uses_sora_videos_api(monkeypatch, tmp_pat
     assert payload["success"] is True
     assert payload["status"] == "completed"
 
-    client = _FakeOpenAI.last_instance
-    # The bug path (images.generate) must never run.
-    assert client.videos.create_calls, "expected videos.create_and_poll to be called"
-    call = client.videos.create_calls[0]
-    assert call["model"] == "sora-2"
-    assert call["seconds"] == "8"  # 10s request snapped to nearest Sora length
-    assert "input_reference" in call  # painting passed as a reference, not a kwarg
-    assert client.videos.download_calls == [("vid_123", "video")]
+    assert fake.run_calls, "expected replicate.run to be called"
+    call = fake.run_calls[0]
+    assert call["model"] == "wan-video/wan-2.2-i2v-fast"  # cheapest default
+    # Painting is the conditioning frame; the per-style prompt drives motion.
+    assert "image" in call["input"]
+    assert call["input"]["prompt"]  # non-empty style prompt
+    assert call["input"]["resolution"] == "480p"  # cheap tier by default
 
     # Video bytes were written to disk at the advertised path.
     written = tmp_path / payload["video_filename"]
@@ -113,15 +107,50 @@ async def test_generate_painting_video_uses_sora_videos_api(monkeypatch, tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_generate_painting_video_fails_fast_on_incomplete_job(
+async def test_video_model_and_resolution_are_env_overridable(monkeypatch, tmp_path):
+    image_path = tmp_path / "drawing.png"
+    image_path.write_bytes(b"fake-png")
+    monkeypatch.setattr(vgs, "get_video_output_path", lambda: str(tmp_path))
+    monkeypatch.setattr(vgs, "save_job_status", lambda *_a, **_k: None)
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "r8_test")
+    monkeypatch.setenv("VIDEO_MODEL", "some/other-model")
+    monkeypatch.setenv("VIDEO_RESOLUTION", "720p")
+
+    fake = _FakeReplicate(output="https://replicate.delivery/out.mp4")
+    monkeypatch.setattr(vgs, "_replicate", fake)
+    monkeypatch.setattr(vgs, "_httpx", _FakeHttpx)
+
+    result = await vgs.generate_painting_video(
+        {
+            "image_path": str(image_path),
+            "style": "playful",
+            "duration_seconds": 6,
+            "story_id": "s2",
+        }
+    )
+
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["success"] is True
+    call = fake.run_calls[0]
+    assert call["model"] == "some/other-model"
+    assert call["input"]["resolution"] == "720p"
+    # URL output goes through the httpx download branch.
+    written = tmp_path / payload["video_filename"]
+    assert written.read_bytes() == b"url-mp4-bytes"
+
+
+@pytest.mark.asyncio
+async def test_generate_painting_video_fails_fast_on_provider_error(
     monkeypatch, tmp_path
 ):
     image_path = tmp_path / "drawing.png"
     image_path.write_bytes(b"fake-png")
     monkeypatch.setattr(vgs, "get_video_output_path", lambda: str(tmp_path))
     monkeypatch.setattr(vgs, "save_job_status", lambda *_a, **_k: None)
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    _patch_openai(monkeypatch, video=_FakeVideo(status="failed", error="moderation"))
+    monkeypatch.setenv("REPLICATE_API_TOKEN", "r8_test")
+
+    fake = _FakeReplicate(raises=Exception("moderation rejected"))
+    monkeypatch.setattr(vgs, "_replicate", fake)
 
     result = await vgs.generate_painting_video(
         {
@@ -136,3 +165,26 @@ async def test_generate_painting_video_fails_fast_on_incomplete_job(
     assert payload["success"] is False
     assert payload["status"] == "failed"
     assert "failed" in payload["error"]
+
+
+@pytest.mark.asyncio
+async def test_generate_painting_video_requires_replicate_token(monkeypatch, tmp_path):
+    image_path = tmp_path / "drawing.png"
+    image_path.write_bytes(b"fake-png")
+    monkeypatch.delenv("REPLICATE_API_TOKEN", raising=False)
+    # SDKs present but no token → clear, non-crashing error.
+    monkeypatch.setattr(vgs, "_replicate", _FakeReplicate(output=_FakeFileOutput(b"x")))
+    monkeypatch.setattr(vgs, "_httpx", _FakeHttpx)
+
+    result = await vgs.generate_painting_video(
+        {
+            "image_path": str(image_path),
+            "style": "playful",
+            "duration_seconds": 8,
+            "story_id": "s",
+        }
+    )
+
+    payload = json.loads(result["content"][0]["text"])
+    assert payload["success"] is False
+    assert "REPLICATE_API_TOKEN" in payload["error"]


### PR DESCRIPTION
Cost-control sweep so every AI call runs on the cheapest tier that still delivers good quality + acceptable speed (best value, not rock-bottom). Deployed to Railway prod and verified (health green, real WAN render succeeded).

- **video**: OpenAI Sora-2 → Replicate `wan-video/wan-2.2-i2v-fast` @ 480p (faster + far cheaper). Env-overridable: `VIDEO_MODEL` / `VIDEO_RESOLUTION` / `VIDEO_RENDER_TIMEOUT_S`. Verified with a real render.
- **realtime voice**: pinned to `gpt-realtime-mini`; pricier `gpt-realtime-2` escalation now opt-in via `VOICE_ALLOW_PREMIUM_REALTIME` (default off).
- **image style**: keep `flux-kontext-pro` (best value); cheaper `dev` tier opt-in via `IMAGE_STYLE_MODEL`.
- **Claude**: already on cheapest `claude-haiku-4-5` everywhere (no change).

Tests updated for the new providers; all touched suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)