### PR TITLE
perf(kids-daily): parallelize episode audio + illustration generation

### DIFF
--- a/backend/src/api/routes/kids_daily.py
+++ b/backend/src/api/routes/kids_daily.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -244,8 +245,7 @@ async def _generate_illustrations(
                             os.getenv("MORNING_SHOW_IMAGE_MODEL", "gpt-image-1-mini"))
     api_key = (os.getenv("OPENAI_API_KEY") or "").strip()
 
-    illustrations: List[EpisodeIllustration] = []
-    for idx in range(count):
+    async def _gen_one(idx: int) -> EpisodeIllustration:
         subtitle = f"{topic.title()} scene {idx + 1}"
         animation_type = animation_types[idx % len(animation_types)]
         description = f"{topic.title()} illustration #{idx + 1}"
@@ -256,7 +256,10 @@ async def _generate_illustrations(
                 item_url = None
                 item_b64 = None
                 if openai_client is not None:
-                    response = openai_client.images.generate(
+                    # Run the blocking OpenAI image call off the event loop so
+                    # scenes render concurrently and other requests aren't stalled.
+                    response = await asyncio.to_thread(
+                        openai_client.images.generate,
                         model=image_model,
                         prompt=_scene_prompt(kid_title, topic, age_group, idx),
                         size="1024x1024",
@@ -307,16 +310,18 @@ async def _generate_illustrations(
 
         safe_description = await _safe_illustration_description(description, age_group)
 
-        illustrations.append(
-            EpisodeIllustration(
-                url=generated_url,
-                description=safe_description,
-                display_order=idx,
-                animation_type=animation_type,
-            )
+        return EpisodeIllustration(
+            url=generated_url,
+            description=safe_description,
+            display_order=idx,
+            animation_type=animation_type,
         )
 
-    return illustrations
+    # Generate all scenes concurrently. gather preserves input order so
+    # display_order stays correct; per-scene errors fall back to a
+    # placeholder inside _gen_one, so gather itself won't raise.
+    illustrations = await asyncio.gather(*[_gen_one(idx) for idx in range(count)])
+    return list(illustrations)
 
 
 # ===========================================================================
@@ -528,14 +533,18 @@ async def _build_episode(
         }
 
     dialogue_script = DialogueScript(**generated["dialogue_script"])
-    audio_urls = await generate_multi_speaker_audio(dialogue_script, request.age_group.value)
-
     episode_id = str(uuid.uuid4())
-    illustrations = await _generate_illustrations(
-        episode_id=episode_id,
-        kid_title=generated.get("kid_title", "Kids Daily"),
-        topic=request.category.value,
-        age_group=request.age_group.value,
+
+    # Audio (per-line TTS) and illustration generation are independent, so run
+    # them concurrently instead of back-to-back to cut episode latency.
+    audio_urls, illustrations = await asyncio.gather(
+        generate_multi_speaker_audio(dialogue_script, request.age_group.value),
+        _generate_illustrations(
+            episode_id=episode_id,
+            kid_title=generated.get("kid_title", "Kids Daily"),
+            topic=request.category.value,
+            age_group=request.age_group.value,
+        ),
     )
 
     key_concepts = _as_key_concepts(generated.get("key_concepts", []))

--- a/backend/src/services/tts_service.py
+++ b/backend/src/services/tts_service.py
@@ -566,17 +566,25 @@ async def generate_multi_speaker_audio(dialogue_script: Any, age_group: str) -> 
                 role = str(line.get("role", "guest"))
                 role_to_batch.setdefault(role, []).append({"segment_id": index, "text": line.get("text", "")})
 
-            for role, segments in role_to_batch.items():
-                if not segments:
-                    continue
+            async def _role_batch(role: str, segments: List[Dict[str, Any]]):
                 voice_cfg = voices.get(role, {"voice": "alloy", "speed": 1.0})
-                raw = await generate_audio_batch(
+                return await generate_audio_batch(
                     {
                         "story_segments": segments,
                         "voice": voice_cfg["voice"],
                         "speed": voice_cfg["speed"],
                     }
                 )
+
+            # Generate each role's batch concurrently instead of role-by-role.
+            active_roles = [(r, s) for r, s in role_to_batch.items() if s]
+            raws = await asyncio.gather(
+                *[_role_batch(r, s) for r, s in active_roles],
+                return_exceptions=True,
+            )
+            for raw in raws:
+                if isinstance(raw, Exception):
+                    continue
                 content = raw.get("content", []) if isinstance(raw, dict) else []
                 if not content:
                     continue
@@ -591,26 +599,36 @@ async def generate_multi_speaker_audio(dialogue_script: Any, age_group: str) -> 
         # Fall through to per-line generation
         pass
 
-    # Fill missing lines with direct TTS generation (or deterministic placeholders).
+    # Fill any lines the batch path missed with direct TTS — concurrently.
+    missing: List[tuple] = []
     for index, line in enumerate(lines):
         key = str(index)
         if key in audio_urls:
             continue
-
-        role = str(line.get("role", "guest"))
-        voice_cfg = voices.get(role, {"voice": "alloy", "speed": 1.0})
         text = str(line.get("text", "")).strip()
-
         if not text:
             continue
+        role = str(line.get("role", "guest"))
+        voice_cfg = voices.get(role, {"voice": "alloy", "speed": 1.0})
+        missing.append((key, text, voice_cfg))
 
-        generated = await generate_story_audio_file(
-            text=text,
-            voice=str(voice_cfg["voice"]),
-            speed=float(voice_cfg["speed"]),
+    if missing:
+        async def _one_line(text: str, voice_cfg: Dict[str, Any]):
+            return await generate_story_audio_file(
+                text=text,
+                voice=str(voice_cfg["voice"]),
+                speed=float(voice_cfg["speed"]),
+            )
+
+        gens = await asyncio.gather(
+            *[_one_line(t, vc) for _, t, vc in missing],
+            return_exceptions=True,
         )
-        url = _audio_url_from_path(generated.get("audio_path"))
-        if url:
-            audio_urls[key] = url
+        for (key, _text, _vc), gen in zip(missing, gens):
+            if isinstance(gen, Exception) or not isinstance(gen, dict):
+                continue
+            url = _audio_url_from_path(gen.get("audio_path"))
+            if url:
+                audio_urls[key] = url
 
     return audio_urls


### PR DESCRIPTION
`generate-now` dropped from **>180s (client timeout) to ~43s** by removing sequential AI work in the episode pipeline. Verified with a live run (8 dialogue lines, all audio generated concurrently + illustration overlapped).

- `_build_episode`: run multi-speaker audio + illustration generation concurrently (`asyncio.gather`) — they're independent.
- `generate_multi_speaker_audio`: per-role TTS batches + per-line fallback now run concurrently.
- `_generate_illustrations`: per-scene `asyncio.gather`; blocking OpenAI image call moved to `asyncio.to_thread` (no longer stalls the event loop).

Safe: Postgres access is pool-based (acquire-per-query), so added concurrency is fine. `gather` is order-stable (display_order preserved); per-item errors still fall back to placeholders. Test suite neutral (0 new failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)