### PR TITLE
feat(voice-clone): reject too-short/long samples with a friendly error

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ anthropic>=0.18.1,<1
 openai>=1.12.0,<2
 replicate>=1.0.7
 elevenlabs>=1.0.0
+mutagen>=1.47.0  # portable audio duration probing (voice-clone validation)
 
 # Vector Database (Local)
 chromadb>=1.4.1

--- a/backend/src/api/routes/voice.py
+++ b/backend/src/api/routes/voice.py
@@ -18,6 +18,7 @@ from ...services.voice_service import (
     list_cloned_voices,
     delete_cloned_voice,
     validate_voice_file,
+    validate_voice_duration,
 )
 from ...paths import UPLOAD_DIR
 
@@ -78,6 +79,13 @@ async def clone_voice_endpoint(
     voice_dir.mkdir(parents=True, exist_ok=True)
     temp_path = voice_dir / filename
     temp_path.write_bytes(file_data)
+
+    # Reject too-short/-long samples upfront with a friendly message instead of
+    # surfacing minimax's opaque provider error (needs 10s-5min of audio).
+    duration_error = validate_voice_duration(str(temp_path))
+    if duration_error:
+        temp_path.unlink(missing_ok=True)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=duration_error)
 
     try:
         result = await clone_voice(

--- a/backend/src/services/voice_service.py
+++ b/backend/src/services/voice_service.py
@@ -9,6 +9,7 @@ Parent Epic: #45
 import hashlib
 import logging
 import os
+import subprocess
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -39,6 +40,60 @@ def validate_voice_file(file_path: str, file_size: int) -> Optional[str]:
         return f"File too large ({file_size / (1024*1024):.1f} MB). Maximum: {max_mb:.0f} MB"
     if file_size == 0:
         return "File is empty"
+    return None
+
+
+def get_audio_duration_seconds(file_path: str) -> Optional[float]:
+    """Best-effort audio duration. Tries mutagen (pure-python, available in
+    every environment incl. the slim prod image) first, then ffprobe. Returns
+    None when neither can determine it, so callers never hard-block on a probe
+    failure — the provider stays the final gate."""
+    # 1. mutagen — portable, no system binary required.
+    try:
+        from mutagen import File as _MutagenFile
+        info = getattr(_MutagenFile(file_path), "info", None)
+        length = getattr(info, "length", None)
+        if length and length > 0:
+            return float(length)
+    except Exception:
+        pass
+    # 2. ffprobe fallback — present in local dev, may be absent in prod.
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                file_path,
+            ],
+            capture_output=True, text=True, timeout=15,
+        )
+        out = (result.stdout or "").strip()
+        return float(out) if result.returncode == 0 and out else None
+    except Exception:
+        return None
+
+
+def validate_voice_duration(file_path: str) -> Optional[str]:
+    """Enforce minimax's 10s-5min clone window with a friendly message.
+
+    Best-effort: if the duration can't be measured (no ffprobe), returns None
+    and lets the provider remain the final gate — so we never block a valid
+    upload just because probing failed.
+    """
+    duration = get_audio_duration_seconds(file_path)
+    if duration is None:
+        return None
+    if duration < MIN_DURATION_SECONDS:
+        return (
+            f"Voice sample is too short ({duration:.0f}s). Please upload "
+            f"{MIN_DURATION_SECONDS}-{MAX_DURATION_SECONDS}s of clear speech."
+        )
+    if duration > MAX_DURATION_SECONDS:
+        return (
+            f"Voice sample is too long ({duration:.0f}s). Maximum "
+            f"{MAX_DURATION_SECONDS // 60} minutes."
+        )
     return None
 
 

--- a/backend/tests/test_batch_235_182_150.py
+++ b/backend/tests/test_batch_235_182_150.py
@@ -158,6 +158,29 @@ class TestVoiceCloneValidation:
         assert error is not None
         assert "empty" in error
 
+    def test_reject_too_short_duration(self):
+        from src.services import voice_service as vs
+        with patch.object(vs, "get_audio_duration_seconds", return_value=5.0):
+            error = vs.validate_voice_duration("sample.mp3")
+        assert error is not None and "too short" in error
+
+    def test_reject_too_long_duration(self):
+        from src.services import voice_service as vs
+        with patch.object(vs, "get_audio_duration_seconds", return_value=400.0):
+            error = vs.validate_voice_duration("sample.mp3")
+        assert error is not None and "too long" in error
+
+    def test_accept_valid_duration(self):
+        from src.services import voice_service as vs
+        with patch.object(vs, "get_audio_duration_seconds", return_value=30.0):
+            assert vs.validate_voice_duration("sample.mp3") is None
+
+    def test_indeterminate_duration_allows_upload(self):
+        # ffprobe unavailable / unprobeable → don't block; provider is final gate.
+        from src.services import voice_service as vs
+        with patch.object(vs, "get_audio_duration_seconds", return_value=None):
+            assert vs.validate_voice_duration("sample.mp3") is None
+
 
 class TestVoiceCloneService:
     """Voice cloning service must call Replicate and persist result."""


### PR DESCRIPTION
minimax voice-cloning requires **10s–5min** audio; out-of-window samples failed with an opaque provider `502` ("invalid file ext"). Now we enforce the documented window upfront and return a clear `400`.

Verified: a 5.9s clip → `400 "Voice sample is too short (6s). Please upload 10-300s of clear speech."` (was a `502` before).

- `voice_service`: `get_audio_duration_seconds` (mutagen-first → ffprobe fallback → None) + `validate_voice_duration` enforcing the existing `MIN/MAX_DURATION_SECONDS` (10s–5min).
- voice route: probe the saved sample, `400` on out-of-range, clean up temp file.
- `requirements`: add `mutagen` (pure-python, portable — works in the slim prod image; no ffmpeg needed).

Best-effort & no regression: if duration can't be measured, the upload proceeds and the provider stays the final gate. 4 new unit tests; suite neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)