### PR TITLE
docs: cost-control model knobs + Replicate video provider + /health gotcha

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,27 @@ CLAUDE_AGENT_MODEL=claude-haiku-4-5
 SAFETY_CHECK_MODEL=claude-haiku-4-5
 VISION_ANALYSIS_MODEL=claude-haiku-4-5
 
+# ---------------------------------------------------------------------------
+# Model & cost controls (optional) — every AI call defaults to the cheapest
+# capable model. Override per feature without a code change; leave unset for
+# the cost-efficient defaults.
+# ---------------------------------------------------------------------------
+# Video: Replicate image-to-video (cheaper AND faster than OpenAI Sora).
+# Requires REPLICATE_API_TOKEN (also used for art-style + voice cloning).
+VIDEO_MODEL=wan-video/wan-2.2-i2v-fast
+VIDEO_RESOLUTION=480p              # 720p = sharper, higher cost/slower
+VIDEO_RENDER_TIMEOUT_S=300
+# Art-style transfer (Replicate). black-forest-labs/flux-kontext-dev is cheaper
+# but slower/lower-fidelity.
+IMAGE_STYLE_MODEL=black-forest-labs/flux-kontext-pro
+# Kids Daily / Morning Show illustrations (OpenAI).
+KIDS_DAILY_IMAGE_MODEL=gpt-image-1-mini
+# Talk-to-Buddy realtime model (OpenAI). VOICE_ALLOW_PREMIUM_REALTIME=1 permits
+# the pricier gpt-realtime-2 tier on dual opt-in; default keeps every session
+# on the cheaper mini tier.
+OPENAI_REALTIME_MODEL=gpt-realtime-mini
+VOICE_ALLOW_PREMIUM_REALTIME=0
+
 # OpenAI TTS + Whisper STT for Talk-to-Buddy hybrid voice
 OPENAI_API_KEY=your_openai_api_key_here
 

--- a/docs/guides/ops.md
+++ b/docs/guides/ops.md
@@ -125,10 +125,17 @@ railway variables delete KEY
 | `ANTHROPIC_API_KEY` | Claude API key | Set |
 | `OPENAI_API_KEY` | OpenAI TTS key | Set |
 | `DATABASE_URL` | PostgreSQL connection string (Supabase pooler) | Set |
-| `REPLICATE_API_TOKEN` | Replicate API token (voice cloning) | Set |
+| `REPLICATE_API_TOKEN` | Replicate token — **video, art-style transfer, voice cloning** | Set |
 | `TAVILY_API_KEY` | Web search for Daily Drop | Set |
 | `DAILY_DROP_ENABLED` | `0` = disabled, `1` = enabled | Set to `0` |
 | `ALLOWED_ORIGINS` | Comma-separated frontend URLs | Set |
+
+**Model & cost controls (optional):** every AI call defaults to the cheapest
+capable model. Override per feature without a code change via `VIDEO_MODEL`,
+`VIDEO_RESOLUTION`, `IMAGE_STYLE_MODEL`, `VOICE_ALLOW_PREMIUM_REALTIME`,
+`CLAUDE_AGENT_MODEL`, etc. — see
+[environment-variables.md](../learning/infrastructure/environment-variables.md)
+→ *Model & Cost Controls*. Video runs on Replicate WAN (not Sora).
 
 ### Health Check
 
@@ -136,7 +143,20 @@ railway variables delete KEY
 curl https://kids-creative-backend-production.up.railway.app/health
 ```
 
-Status will show `degraded` until `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` are set to real values.
+Status shows `degraded` only when `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` are
+**unset**. ⚠️ **Gotcha:** `/health` only checks that the keys are *present*,
+not that they *work*. A key that is set but **revoked or out of credits** (e.g.
+Anthropic billing) still reports `healthy` while every generation fails. If the
+site loads but all AI features error, test the key directly before debugging
+code:
+
+```bash
+curl -s https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" -H "anthropic-version: 2023-06-01" \
+  -H "content-type: application/json" \
+  -d '{"model":"claude-haiku-4-5","max_tokens":5,"messages":[{"role":"user","content":"hi"}]}'
+# "credit balance is too low" → top up at console.anthropic.com → Plans & Billing
+```
 
 ---
 

--- a/docs/learning/backend/mcp-servers/video-generator-server.md
+++ b/docs/learning/backend/mcp-servers/video-generator-server.md
@@ -6,26 +6,26 @@
 
 **Explorer**: This helper turns a story into a short video — like a cartoon made from the child's own drawing. It takes the story text and images and puts them together into a moving picture.
 
-**Maker**: This MCP server wraps video generation APIs to create "dynamic picture book" videos from story content. It's a Phase 3 feature — the server structure exists but the full pipeline (multi-frame generation, transitions, soundtrack overlay) is still being developed.
+**Maker**: This MCP server animates a child's drawing into a short clip using a **Replicate image-to-video model** (default `wan-video/wan-2.2-i2v-fast` @ 480p — overridable via the `VIDEO_MODEL` / `VIDEO_RESOLUTION` env vars). It exposes three tools: `generate_painting_video` (render), `check_video_status` (poll a job), and `combine_video_audio` (mux narration over the clip with ffmpeg).
 
 ## How It Works
 
-1. **Agent calls `generate_story_video`** with story text, scene descriptions, and style parameters
-2. **Server generates video frames** using AI image/video generation APIs
-3. **Frames are composited** into a video with transitions and optional audio narration
-4. **Video saved** to `data/video/` and path returned to the agent
+1. **Agent/route calls `generate_painting_video`** with the drawing's `image_path`, a `style`, and `duration_seconds`
+2. **Server renders the clip** — the painting is uploaded as the conditioning frame with a per-style motion prompt; a generous client timeout (`VIDEO_RENDER_TIMEOUT_S`, default 300s) covers slow renders
+3. **MP4 downloaded** to `data/videos/`, with a job record written to `data/video_jobs/`
+4. **Fail-fast (#182)** — if the render fails there is no phantom "pending" job; the tool returns `status: "failed"` immediately
 
 ## Key Concepts
 
 **Dynamic Picture Book**: A video format where illustrated scenes transition smoothly, with narration playing over them — like a digital flip book. The child's original drawing style influences the visual output.
 
-**Phase 3 Feature**: This server is part of the project's third development phase. The architecture is in place, but full production implementation depends on video generation API maturity and cost optimization.
+**Provider — cheapest-everywhere policy**: video runs on Replicate's fast WAN image-to-video model. It previously used OpenAI Sora, which was swapped out for a model that is both **cheaper and faster** (Sora was the most expensive, slowest path). The exact model and resolution are env-configurable, so quality can be dialed up per deployment without a code change.
 
 ## Connections
 
-- **Upstream**: Would be called by `image_to_story_agent.py` as an optional post-story enhancement
-- **Downstream**: Video generation APIs (provider TBD)
-- **Related**: `api/routes/video.py` provides the HTTP endpoint for video requests
+- **Upstream**: Called from `api/routes/video.py` (`POST /api/v1/video/generate`), which resolves the story's drawing and verifies ownership first
+- **Downstream**: Replicate image-to-video model (`VIDEO_MODEL`, default `wan-video/wan-2.2-i2v-fast`); `ffmpeg` for optional audio muxing. Requires `REPLICATE_API_TOKEN`
+- **Related**: `api/routes/video.py` provides the HTTP endpoint; see [environment-variables.md](../../infrastructure/environment-variables.md) → Model & Cost Controls
 
 ## Thinking Question
 

--- a/docs/learning/infrastructure/environment-variables.md
+++ b/docs/learning/infrastructure/environment-variables.md
@@ -48,6 +48,31 @@ Production (Railway + Vercel):
 
 **Important**: Frontend variables prefixed with `VITE_` are embedded in the JavaScript bundle at build time. They are visible to anyone who inspects the page source. Never put secret keys in `VITE_` variables.
 
+## Model & Cost Controls (Optional)
+
+Every AI call defaults to the **cheapest capable model** for that job. These
+optional variables override the model per feature **without a code change** —
+leave them unset for the cost-efficient defaults.
+
+| Variable | Default | What it controls |
+|----------|---------|------------------|
+| `CLAUDE_AGENT_MODEL` / `ANTHROPIC_MODEL` | `claude-haiku-4-5` | Claude model for story / My Agent / interactive / Kids Daily orchestration |
+| `SAFETY_CHECK_MODEL` | `claude-haiku-4-5` | Model for the content-safety MCP server |
+| `VISION_ANALYSIS_MODEL` | `claude-haiku-4-5` | Model for drawing / vision analysis |
+| `VIDEO_MODEL` | `wan-video/wan-2.2-i2v-fast` | Replicate image-to-video model (replaced OpenAI Sora — cheaper **and** faster) |
+| `VIDEO_RESOLUTION` | `480p` | Video render resolution; set `720p` for sharper output at higher cost |
+| `VIDEO_RENDER_TIMEOUT_S` | `300` | Max seconds to wait for a video render before failing |
+| `IMAGE_STYLE_MODEL` | `black-forest-labs/flux-kontext-pro` | Replicate art-style transfer model; `…-dev` is cheaper but slower/lower-fidelity |
+| `KIDS_DAILY_IMAGE_MODEL` / `MORNING_SHOW_IMAGE_MODEL` | `gpt-image-1-mini` | OpenAI image model for Kids Daily illustrations |
+| `OPENAI_REALTIME_MODEL` | `gpt-realtime-mini` | OpenAI realtime model for Talk-to-Buddy voice |
+| `VOICE_ALLOW_PREMIUM_REALTIME` | unset (off) | Set `1` to allow the pricier `gpt-realtime-2` tier on dual opt-in; default keeps **every** session on `mini` |
+| `REPLICATE_API_TOKEN` | — | **Required** for video, art-style transfer, and voice cloning (Replicate models) |
+
+**Cheapest-everywhere policy**: the defaults pick the cheapest tier that still
+delivers good quality and acceptable latency (e.g. video uses a fast 480p
+Replicate model instead of Sora). To raise quality for a single feature, set
+just that feature's variable — no redeploy of logic required.
+
 ## Key Concepts
 
 **Secret vs Public**: Secret variables (API keys, database passwords) must never appear in code or frontend bundles. Public variables (Supabase URL, anon key) are safe to embed because they only grant limited access controlled by Supabase's Row Level Security.


### PR DESCRIPTION
Docs-only — reflects the cheapest-best-value model work and this session's findings.

- **env-vars reference**: new *Model & Cost Controls* section (`VIDEO_MODEL`, `VIDEO_RESOLUTION`, `VIDEO_RENDER_TIMEOUT_S`, `IMAGE_STYLE_MODEL`, `VOICE_ALLOW_PREMIUM_REALTIME`, `CLAUDE_AGENT_MODEL`, …).
- **video-generator-server doc**: refreshed from "Sora / Phase 3 / provider TBD" to the real Replicate WAN image-to-video pipeline + correct tool names.
- **ops runbook**: `REPLICATE_API_TOKEN` now scoped to video/art-style/clone; cost-controls pointer; and the `/health` gotcha — a set-but-out-of-credits key still reports `healthy` while all generation fails (with a one-liner to test the key directly).
- **.env.example**: optional cost-control knobs with cheapest defaults.

No runtime impact (docs + template only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)