### PR TITLE
fix: 9 verified audit gaps (safety, library lifecycle, hub, interactive-story, voice)

### DIFF
--- a/backend/src/agents/image_to_story_agent.py
+++ b/backend/src/agents/image_to_story_agent.py
@@ -860,6 +860,31 @@ Return your response as JSON:
             styled_image_path = style_data.get("styled_image_path")
         except Exception:
             pass
+        # Step 5b: Re-validate the styled image for child safety (#710).
+        # The API routes already gate stylized images via validate_and_fallback;
+        # the agent-direct path (used by My Agent) bypassed that check, so the
+        # styled image could be returned without a vision safety pass. We
+        # fail closed here — discard the styled image and fall back to the
+        # original drawing if validation fails or errors.
+        if styled_image_path and Path(styled_image_path).exists():
+            try:
+                from ..mcp_servers.image_style_server import validate_and_fallback
+
+                styled_image_safety = await validate_and_fallback(
+                    styled_image_path=styled_image_path,
+                    original_image_path=str(image_path),
+                    child_age=child_age,
+                    theme=art_theme,
+                    session_id=child_id,
+                )
+                if not styled_image_safety.get("safety_passed"):
+                    styled_image_path = None
+            except Exception:
+                logger.warning(
+                    "Styled image safety validation failed (agent path), using original",
+                    exc_info=True,
+                )
+                styled_image_path = None
         yield {"type": "tool_result", "data": {"status": "completed"}}
 
     # Step 6: Audio generation (if enabled)

--- a/backend/src/agents/interactive_story_agent.py
+++ b/backend/src/agents/interactive_story_agent.py
@@ -53,6 +53,11 @@ from ..services.story_memory import get_story_memory_prompt
 from ..services.my_agent_context import build_my_agent_context
 from ..utils.model_config import get_claude_agent_model
 from ._safety import enforce_post_gen_safety
+from .image_to_story_agent import (
+    AGE_GROUP_WORD_RANGES,
+    repair_story_length,
+    validate_story_length,
+)
 
 
 async def _direct_generate(prompt: str, max_tokens: int = 4096) -> str:
@@ -171,6 +176,7 @@ class StoryChoiceOutput(BaseModel):
     choice_id: str
     text: str
     emoji: str
+    trait: Optional[str] = None
 
 
 class StorySegmentOutput(BaseModel):
@@ -257,6 +263,55 @@ UNLIMITED_SOFT_CAP = {
     "6-8": 30,
     "9-12": 50,
 }
+
+
+# Per-segment word ranges derived from AGE_CONFIG (#705).
+# Interactive segments use shorter, per-segment targets than full image-to-story
+# stories, so we register interactive-namespaced ranges and reuse the shared
+# ``repair_story_length`` guardrail (no extra LLM calls; over-long is trimmed
+# locally, too-short is flagged as degraded). The 3-5 "50-100" range is a
+# deliberate product choice tracked separately in #706 and stays unchanged.
+def _parse_word_range(word_count: str) -> tuple[int, int]:
+    """Parse an AGE_CONFIG ``word_count`` string like "50-100" into (min, max)."""
+    try:
+        low, high = (int(part.strip()) for part in str(word_count).split("-", 1))
+        return low, high
+    except (ValueError, TypeError):
+        return AGE_GROUP_WORD_RANGES["6-8"]
+
+
+# Register interactive per-segment ranges under namespaced keys so the shared
+# repair helper enforces interactive targets without affecting image-to-story.
+INTERACTIVE_RANGE_KEYS = {
+    age_group: f"interactive:{age_group}" for age_group in AGE_CONFIG
+}
+for _age_group, _cfg in AGE_CONFIG.items():
+    AGE_GROUP_WORD_RANGES[INTERACTIVE_RANGE_KEYS[_age_group]] = _parse_word_range(
+        _cfg["word_count"]
+    )
+
+
+def _repair_segment_length(segment_text: str, age_group: str) -> tuple[str, dict]:
+    """Trim/flag a segment against the interactive per-segment word range (#705).
+
+    Reuses the shared ``repair_story_length`` trim path for over-long segments
+    (purely local, no LLM call). Too-short segments are left untouched and flagged
+    as ``degraded_length`` rather than padded with generic filler, because an
+    interactive branch must read naturally and we never call the model to expand.
+    """
+    if not segment_text:
+        return segment_text, {"repaired": False}
+
+    range_key = INTERACTIVE_RANGE_KEYS.get(age_group, INTERACTIVE_RANGE_KEYS["6-8"])
+    info = validate_story_length(segment_text, range_key)
+    _min_words, max_words = AGE_GROUP_WORD_RANGES[range_key]
+
+    if info["word_count"] > max_words:
+        # Over-long: reuse the shared local trimmer.
+        return repair_story_length(segment_text, range_key)
+
+    # In-range or too-short: keep the text; surface degraded flag for telemetry.
+    return segment_text, {**info, "repaired": False}
 
 
 def get_total_segments(story_length_mode: str, age_group: str) -> int:
@@ -545,12 +600,12 @@ def _normalize_choices(
     segment_id: int,
     is_final_segment: bool,
     age_group: str,
-) -> List[Dict[str, str]]:
+) -> List[Dict[str, Any]]:
     """Guarantee non-ending segments always have 2-3 valid choices."""
     if is_final_segment:
         return []
 
-    normalized: List[Dict[str, str]] = []
+    normalized: List[Dict[str, Any]] = []
     seen_texts: set[str] = set()
     emoji_defaults = ["✨", "🧭", "🤝"]
 
@@ -568,7 +623,10 @@ def _normalize_choices(
                 str(choice.get("emoji", "")).strip()
                 or emoji_defaults[idx % len(emoji_defaults)]
             )
-            normalized.append({"choice_id": "", "text": text, "emoji": emoji})
+            trait = str(choice.get("trait", "")).strip() or None
+            normalized.append(
+                {"choice_id": "", "text": text, "emoji": emoji, "trait": trait}
+            )
 
     if len(normalized) < 2:
         for fb in _build_fallback_choices(segment_id, age_group):
@@ -576,7 +634,7 @@ def _normalize_choices(
                 continue
             seen_texts.add(fb["text"])
             normalized.append(
-                {"choice_id": "", "text": fb["text"], "emoji": fb["emoji"]}
+                {"choice_id": "", "text": fb["text"], "emoji": fb["emoji"], "trait": None}
             )
             if len(normalized) >= 2:
                 break
@@ -586,6 +644,31 @@ def _normalize_choices(
         choice["choice_id"] = f"choice_{segment_id}_{chr(97 + i)}"
 
     return normalized[:3]
+
+
+def _collect_selected_traits(
+    segments: List[Dict[str, Any]], choice_history: List[str]
+) -> List[str]:
+    """Aggregate unique traits from the choices the child actually selected.
+
+    Matches each selected ``choice_id`` against the choices stored on prior
+    segments and collects their ``trait`` (preserving order, de-duplicated).
+    """
+    traits: List[str] = []
+    seen: set[str] = set()
+    for choice_id in choice_history or []:
+        for segment in segments or []:
+            seg_choices = segment.get("choices", [])
+            if not isinstance(seg_choices, list):
+                continue
+            for choice in seg_choices:
+                if not isinstance(choice, dict) or choice.get("choice_id") != choice_id:
+                    continue
+                trait = str(choice.get("trait") or "").strip()
+                if trait and trait not in seen:
+                    seen.add(trait)
+                    traits.append(trait)
+    return traits
 
 
 def _build_choice_history_context(
@@ -1050,6 +1133,16 @@ async def generate_story_opening(
                 result_data = _create_default_opening(theme_str, interests, config)
                 result_data["safety_score"] = 0.95
                 result_data["degraded_reason"] = "safety_below_threshold_after_retry"
+
+    # Enforce per-age segment word range — trim over-long, flag too-short (#705).
+    # Local guardrail only; never issues an extra LLM call.
+    if result_data and "segment" in result_data:
+        opening_text = result_data["segment"].get("text", "")
+        if opening_text:
+            repaired_text, length_info = _repair_segment_length(opening_text, age_group)
+            result_data["segment"]["text"] = repaired_text
+            if length_info.get("degraded_length"):
+                result_data["degraded_length"] = True
 
     # Generate TTS audio if enabled
     if enable_audio and result_data and "segment" in result_data:
@@ -1733,6 +1826,16 @@ async def generate_next_segment(
                 result_data["safety_score"] = 0.95
                 result_data["degraded_reason"] = "safety_below_threshold_after_retry"
 
+    # Enforce per-age segment word range — trim over-long, flag too-short (#705).
+    # Local guardrail only; never issues an extra LLM call.
+    if result_data and "segment" in result_data:
+        segment_text = result_data["segment"].get("text", "")
+        if segment_text:
+            repaired_text, length_info = _repair_segment_length(segment_text, age_group)
+            result_data["segment"]["text"] = repaired_text
+            if length_info.get("degraded_length"):
+                result_data["degraded_length"] = True
+
     # Generate TTS audio if enabled
     if enable_audio and result_data and "segment" in result_data:
         story_text = result_data["segment"].get("text", "")
@@ -1783,12 +1886,21 @@ async def generate_next_segment(
         result_data["audio_path"] = audio_path
 
     # Add educational summary for endings
-    if is_final_segment and "educational_summary" not in result_data:
-        result_data["educational_summary"] = {
-            "themes": ["courage", "friendship"],
-            "concepts": ["decision-making", "exploration"],
-            "moral": "By bravely facing challenges and working with friends, you become stronger.",
-        }
+    if is_final_segment:
+        if "educational_summary" not in result_data:
+            result_data["educational_summary"] = {
+                "themes": ["courage", "friendship"],
+                "concepts": ["decision-making", "exploration"],
+                "moral": "By bravely facing challenges and working with friends, you become stronger.",
+            }
+        # Aggregate traits surfaced by the choices the child actually made (#707)
+        summary = result_data["educational_summary"]
+        if isinstance(summary, dict):
+            selected_traits = _collect_selected_traits(segments, choice_history)
+            if selected_traits:
+                summary["traits"] = selected_traits
+            else:
+                summary.setdefault("traits", [])
 
     return result_data
 

--- a/backend/src/agents/my_agent_proxy.py
+++ b/backend/src/agents/my_agent_proxy.py
@@ -73,8 +73,32 @@ def _json_tool_result(data: dict[str, Any]) -> dict[str, Any]:
 
 # Threshold matches the project-wide convention used in routes/agents.py
 # and PRD §3.4. Replies scoring below this are blocked and replaced with
-# a child-friendly fallback before delivery.
+# a child-friendly fallback before delivery. The youngest cohort (3-5)
+# uses a stricter bar because younger children are less able to contextualize
+# borderline content (#716).
 _REPLY_SAFETY_THRESHOLD = 0.85
+_REPLY_SAFETY_THRESHOLD_YOUNGEST = 0.90
+
+
+def _age_group_to_target_age(child_age_group: Optional[str]) -> int:
+    """Derive a representative numeric age from a child's age group.
+
+    The safety MCP wants a concrete ``target_age`` so it can calibrate how
+    strict to be; we map each cohort to its midpoint-ish age (#716).
+    """
+    group = (child_age_group or "").strip()
+    if group == "3-5":
+        return 4
+    if group == "9-12":
+        return 10
+    return 7  # "6-8" and any unexpected value default to the middle cohort
+
+
+def _reply_safety_threshold(child_age_group: Optional[str]) -> float:
+    """Stricter safety bar for the youngest cohort, standard otherwise (#716)."""
+    if (child_age_group or "").strip() == "3-5":
+        return _REPLY_SAFETY_THRESHOLD_YOUNGEST
+    return _REPLY_SAFETY_THRESHOLD
 
 # Warm, age-neutral fallback. Children are the audience — corporate
 # phrasing would feel jarring, but we also avoid implying the child did
@@ -84,7 +108,9 @@ _SAFETY_FALLBACK_MESSAGE = (
 )
 
 
-async def _check_reply_safety(text: str) -> tuple[Optional[float], Optional[str]]:
+async def _check_reply_safety(
+    text: str, child_age_group: Optional[str] = None
+) -> tuple[Optional[float], Optional[str]]:
     """Run the child-safety MCP against a buddy chat reply.
 
     Returns ``(score, None)`` on success or ``(None, reason)`` when the
@@ -92,6 +118,9 @@ async def _check_reply_safety(text: str) -> tuple[Optional[float], Optional[str]
     caller can fail closed without trusting a partial result. We never
     raise — the proxy is mid-stream and an exception here would orphan
     the SSE connection.
+
+    ``target_age`` is derived from the child's actual age group (#716) so
+    the safety bar tracks the real audience instead of a hardcoded 7.
 
     ``check_content_safety`` is decorated with the SDK's ``@tool``, which
     wraps it in a non-callable ``SdkMcpTool`` registration object; the
@@ -102,7 +131,7 @@ async def _check_reply_safety(text: str) -> tuple[Optional[float], Optional[str]
         result = await check_content_safety.handler({
             "content_text": text,
             "content_type": "story",
-            "target_age": 7,
+            "target_age": _age_group_to_target_age(child_age_group),
         })
     except Exception as exc:  # noqa: BLE001 — fail closed on any error
         logger.warning("My Agent reply safety MCP unavailable: %s", exc)
@@ -1096,7 +1125,7 @@ async def stream_my_agent_chat(
         role="user",
         text=message,
         input_modality=input_modality,
-        output_modality="text",
+        output_modality=output_modality,
     )
 
     yield _sse(
@@ -1347,7 +1376,8 @@ async def stream_my_agent_chat(
     # experience cost of a fallback message is far less than the cost
     # of delivering unsafe text. The original (blocked) text is logged
     # for telemetry but never re-emitted on the SSE stream.
-    safety_score, safety_error = await _check_reply_safety(final_text)
+    reply_safety_threshold = _reply_safety_threshold(child_age_group)
+    safety_score, safety_error = await _check_reply_safety(final_text, child_age_group)
     if safety_error is not None:
         logger.warning(
             "Replacing buddy reply with safe fallback (reason=%s, len=%d)",
@@ -1364,7 +1394,7 @@ async def stream_my_agent_chat(
         )
         final_text = _SAFETY_FALLBACK_MESSAGE
         result_metadata = {"response_type": "chat"}
-    elif safety_score is not None and safety_score < _REPLY_SAFETY_THRESHOLD:
+    elif safety_score is not None and safety_score < reply_safety_threshold:
         logger.warning(
             "Replacing buddy reply with safe fallback (score=%.2f, len=%d)",
             safety_score,
@@ -1375,7 +1405,7 @@ async def stream_my_agent_chat(
             {
                 "reason": "below_threshold",
                 "safety_score": safety_score,
-                "threshold": _REPLY_SAFETY_THRESHOLD,
+                "threshold": reply_safety_threshold,
                 "original_length": len(final_text),
             },
         )

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -172,6 +172,10 @@ class EducationalValue(BaseModel):
     themes: List[str] = Field(..., description="Themes (e.g., friendship, courage)")
     concepts: List[str] = Field(..., description="Concepts (e.g., colors, numbers)")
     moral: Optional[str] = Field(None, description="Moral lesson")
+    traits: List[str] = Field(
+        default_factory=list,
+        description="Character traits surfaced by the child's choices (e.g., courage, caution)",
+    )
 
 
 class CharacterMemory(BaseModel):

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -1342,6 +1342,7 @@ class HubPostResponse(BaseModel):
     """
     post_id: str
     group_id: str
+    agent_id: str
     agent_name: str
     agent_avatar_id: str
     agent_title: str
@@ -1349,6 +1350,8 @@ class HubPostResponse(BaseModel):
     source_id: str
     caption: Optional[str] = None
     created_at: str
+    reaction_counts: Dict[str, int] = Field(default_factory=dict)
+    viewer_reactions: List[str] = Field(default_factory=list)
 
 
 class HubPostCursor(BaseModel):

--- a/backend/src/api/routes/hub/posts.py
+++ b/backend/src/api/routes/hub/posts.py
@@ -37,7 +37,12 @@ from ...models import (
     ListHubPostsResponse,
 )
 from ....mcp_servers import check_content_safety
-from ....services.database import group_repo, hub_post_repo, session_repo
+from ....services.database import (
+    group_repo,
+    hub_post_repo,
+    hub_reaction_repo,
+    session_repo,
+)
 from ....services.achievement_service import FIRST_SHARED_POST, achievement_service
 from ....services.user_service import UserData
 
@@ -88,16 +93,26 @@ async def _run_caption_safety(text: str) -> float:
     return float(score)
 
 
-def _to_response(post) -> HubPostResponse:
+async def _to_response(post, viewer_user_id: str) -> HubPostResponse:
     """Project a HubPostData onto the COPPA-safe response shape.
 
     Critically: this picks ONLY the persona snapshot fields plus the
     post's own metadata — never any users-table column. The contract
     test in #450 asserts this projection is structurally sound.
+
+    Reaction aggregates (#717) and the byline ``agent_id`` (#718) come
+    from hub tables (``hub_post_reactions`` / ``hub_posts``), so they stay
+    within the COPPA-safe boundary. ``viewer_reactions`` is scoped to the
+    requesting user only.
     """
+    reaction_counts = await hub_reaction_repo.counts_for_post(post.post_id)
+    viewer_reactions = await hub_reaction_repo.reactions_by_user(
+        post.post_id, viewer_user_id
+    )
     return HubPostResponse(
         post_id=post.post_id,
         group_id=post.group_id,
+        agent_id=post.author_agent_id,
         agent_name=post.agent_name_snapshot,
         agent_avatar_id=post.agent_avatar_id_snapshot,
         agent_title=post.agent_title_snapshot,
@@ -105,6 +120,8 @@ def _to_response(post) -> HubPostResponse:
         source_id=post.source_id,
         caption=post.caption,
         created_at=post.created_at,
+        reaction_counts=reaction_counts,
+        viewer_reactions=viewer_reactions,
     )
 
 
@@ -278,7 +295,7 @@ async def create_post(
         user.user_id, child_id, FIRST_SHARED_POST
     )
 
-    return _to_response(post)
+    return await _to_response(post, user.user_id)
 
 
 # ---------------------------------------------------------------------------
@@ -321,7 +338,7 @@ async def list_posts(
         group_id, limit=limit, before=before
     )
     posts = await _hide_unresolvable_posts(raw_posts)
-    items = [_to_response(p) for p in posts]
+    items = [await _to_response(p, user.user_id) for p in posts]
     next_cursor: Optional[dict] = None
     if raw_posts and len(raw_posts) == limit:
         last = raw_posts[-1]

--- a/backend/src/api/routes/library.py
+++ b/backend/src/api/routes/library.py
@@ -46,6 +46,13 @@ from ..models import (
 # Content safety threshold — items below this score are hidden (#81)
 SAFETY_THRESHOLD = 0.85
 
+# Lifecycle states whose stories are visible in My Library + search.
+# Per PRD §3.6 / §3.7, only published or candidate content is surfaced;
+# intermediate (work-in-progress) and archived content must never appear.
+# Legacy stories with NO primary artifact link have no lifecycle state and
+# are treated as visible so we don't hide a user's existing library (#712/#713).
+VISIBLE_LIFECYCLE_STATES = {"published", "candidate"}
+
 router = APIRouter(prefix="/api/v1/library", tags=["Library"])
 
 
@@ -126,6 +133,42 @@ def _is_safe(item: LibraryItem) -> bool:
     if item.safety_score is None:
         return True  # No score = not yet checked, allow through
     return item.safety_score >= SAFETY_THRESHOLD
+
+
+async def _get_visible_story_ids(story_ids: List[str]) -> set:
+    """Resolve which story IDs are lifecycle-visible in the library (#712/#713).
+
+    A story is visible when its primary/canonical artifact is in a visible
+    lifecycle state (published or candidate). Legacy stories that have NO
+    primary artifact link have no lifecycle state at all, so we keep them
+    visible to avoid hiding a user's existing content. Stories whose primary
+    artifacts exist but are all intermediate/archived are hidden.
+
+    Returns the set of story_ids that should be shown. Batched to one query
+    set (chunked) to avoid N+1 lookups.
+    """
+    if not story_ids:
+        return set()
+
+    link_repo = StoryArtifactLinkRepository(db_manager)
+    try:
+        states_by_story = await link_repo.get_primary_lifecycle_states(story_ids)
+    except Exception:
+        # On lookup failure, fail open rather than hide the whole library —
+        # safety_score filtering still applies independently.
+        return set(story_ids)
+
+    visible: set = set()
+    for sid in story_ids:
+        states = states_by_story.get(sid)
+        if not states:
+            # Legacy / no primary artifact link → treat as visible.
+            visible.add(sid)
+        elif states & VISIBLE_LIFECYCLE_STATES:
+            # At least one primary artifact is published or candidate.
+            visible.add(sid)
+        # else: primary artifacts exist but are all intermediate/archived → hide
+    return visible
 
 
 def _session_to_library_item(session, is_favorited: bool = False) -> LibraryItem:
@@ -459,6 +502,11 @@ async def get_library(
         )
         fav_story_ids = fav_art_ids | fav_kids_daily_ids
 
+        # Resolve lifecycle visibility in one batched lookup (#712)
+        visible_story_ids = await _get_visible_story_ids(
+            [s["story_id"] for s in stories]
+        )
+
         for s in stories:
             thumb = await _resolve_thumbnail(s["story_id"])
             item = _story_to_library_item(
@@ -469,6 +517,9 @@ async def get_library(
                 continue
             # Apply safety filter (#81)
             if not _is_safe(item):
+                continue
+            # Apply lifecycle filter — only published/candidate are visible (#712)
+            if s["story_id"] not in visible_story_ids:
                 continue
             all_items.append(item)
 
@@ -814,6 +865,11 @@ async def search_library(
         )
         fav_ids = fav_art | fav_kids_daily
 
+        # Resolve lifecycle visibility in one batched lookup (#713)
+        visible_story_ids = await _get_visible_story_ids(
+            [s["story_id"] for s in stories]
+        )
+
         for s in stories:
             thumb = await _resolve_thumbnail(s["story_id"])
             item = _story_to_library_item(
@@ -824,6 +880,9 @@ async def search_library(
                 continue
             # Apply safety filter (#81)
             if not _is_safe(item):
+                continue
+            # Apply lifecycle filter — only published/candidate are visible (#713)
+            if s["story_id"] not in visible_story_ids:
                 continue
 
             text = s.get("story", {}).get("text", "")

--- a/backend/src/services/database/artifact_repository.py
+++ b/backend/src/services/database/artifact_repository.py
@@ -1001,6 +1001,46 @@ class StoryArtifactLinkRepository:
         artifact_repo = ArtifactRepository(self.db)
         return artifact_repo._row_to_artifact(result)
 
+    async def get_primary_lifecycle_states(
+        self, story_ids: List[str]
+    ) -> Dict[str, set]:
+        """
+        Batch-fetch the lifecycle states of each story's primary artifacts.
+
+        For each story_id, collects the lifecycle_state of every artifact that
+        is linked to it as a primary (canonical) artifact, across all roles.
+
+        Args:
+            story_ids: List of story IDs to look up.
+
+        Returns:
+            Dict mapping story_id -> set of lifecycle states for its primary
+            artifacts. Stories with NO primary artifact link are absent from
+            the dict (caller should treat absence as "legacy/unknown").
+        """
+        if not story_ids:
+            return {}
+
+        result: Dict[str, set] = {}
+        BATCH_SIZE = 500
+        for i in range(0, len(story_ids), BATCH_SIZE):
+            chunk = story_ids[i:i + BATCH_SIZE]
+            placeholders = ", ".join(["?"] * len(chunk))
+            rows = await self.db.fetchall(
+                f"""
+                SELECT l.story_id AS story_id, a.lifecycle_state AS lifecycle_state
+                FROM story_artifact_links l
+                JOIN artifacts a ON a.artifact_id = l.artifact_id
+                WHERE l.story_id IN ({placeholders}) AND l.is_primary = 1
+                """,
+                tuple(chunk),
+            )
+            for row in rows:
+                result.setdefault(row["story_id"], set()).add(
+                    row["lifecycle_state"]
+                )
+        return result
+
     async def list_by_story(self, story_id: str) -> List[StoryArtifactLink]:
         """
         List all artifacts linked to a story.

--- a/backend/tests/api/test_library_safety.py
+++ b/backend/tests/api/test_library_safety.py
@@ -14,10 +14,25 @@ import pytest
 import uuid
 from datetime import datetime
 
-from backend.src.api.routes.library import _is_safe, SAFETY_THRESHOLD
+from backend.src.api.routes.library import (
+    _is_safe,
+    _get_visible_story_ids,
+    SAFETY_THRESHOLD,
+    VISIBLE_LIFECYCLE_STATES,
+)
 from backend.src.api.models import LibraryItem, LibraryItemType
 from backend.src.services.database import story_repo, db_manager
 from backend.src.services.database.schema import init_schema
+from backend.src.services.database.artifact_repository import (
+    ArtifactRepository,
+    StoryArtifactLinkRepository,
+)
+from backend.src.services.models.artifact_models import (
+    ArtifactCreate,
+    ArtifactType,
+    StoryArtifactLinkCreate,
+    StoryArtifactRole,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -205,3 +220,145 @@ class TestLibrarySafetyFiltering:
             item_ids = [item["id"] for item in data["items"]]
 
             assert self.borderline_id in item_ids, "Borderline (0.85) story should appear"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle-state visibility filtering (#712 library, #713 search)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestLibraryLifecycleFiltering:
+    """Library + search must only surface published/candidate content.
+
+    Per PRD §3.6 / §3.7, intermediate (work-in-progress) and archived stories
+    must never appear in My Library or search. Legacy stories with no primary
+    artifact link have no lifecycle state and stay visible (we don't hide a
+    user's existing content).
+    """
+
+    @pytest.fixture(autouse=True)
+    async def setup_lifecycle_stories(self):
+        if not db_manager.is_connected:
+            await db_manager.connect()
+            await init_schema(db_manager)
+
+        self.arepo = ArtifactRepository(db_manager)
+        self.lrepo = StoryArtifactLinkRepository(db_manager)
+        now = datetime.now().isoformat()
+
+        async def make_story(tag: str) -> str:
+            sid = f"lc-{tag}-{uuid.uuid4().hex[:8]}"
+            await story_repo.create({
+                "story_id": sid,
+                "user_id": "test_user",
+                "child_id": "child_lc",
+                "age_group": "6-8",
+                "story": {
+                    "text": f"A lifecycle {tag} story about dragons.",
+                    "word_count": 6,
+                },
+                "educational_value": {"themes": ["adventure"]},
+                "characters": [],
+                "safety_score": 0.99,  # always safe — isolate lifecycle effect
+                "story_type": "image_to_story",
+                "created_at": now,
+            })
+            return sid
+
+        async def link_primary(story_id: str, state: str) -> None:
+            aid = await self.arepo.create(
+                ArtifactCreate(
+                    artifact_type=ArtifactType.TEXT,
+                    artifact_payload=uuid.uuid4().hex,
+                )
+            )
+            # Walk the valid lifecycle transitions to reach the target state.
+            if state == "candidate":
+                await self.arepo.update_lifecycle_state(aid, "candidate")
+            elif state == "published":
+                await self.arepo.update_lifecycle_state(aid, "candidate")
+                await self.arepo.update_lifecycle_state(aid, "published")
+            elif state == "archived":
+                await self.arepo.update_lifecycle_state(aid, "archived")
+            # "intermediate" is the default; no transition needed.
+            await self.lrepo.upsert(
+                StoryArtifactLinkCreate(
+                    story_id=story_id,
+                    artifact_id=aid,
+                    role=StoryArtifactRole.STORY_TEXT,
+                    is_primary=True,
+                )
+            )
+
+        self.published_id = await make_story("pub")
+        await link_primary(self.published_id, "published")
+        self.candidate_id = await make_story("cand")
+        await link_primary(self.candidate_id, "candidate")
+        self.intermediate_id = await make_story("inter")
+        await link_primary(self.intermediate_id, "intermediate")
+        self.archived_id = await make_story("arch")
+        await link_primary(self.archived_id, "archived")
+        self.legacy_id = await make_story("legacy")  # no artifact link
+
+        self.all_ids = [
+            self.published_id,
+            self.candidate_id,
+            self.intermediate_id,
+            self.archived_id,
+            self.legacy_id,
+        ]
+
+        yield
+
+        for sid in self.all_ids:
+            await db_manager.execute(
+                "DELETE FROM stories WHERE story_id = ?", (sid,)
+            )
+        await db_manager.commit()
+
+    async def test_visible_states_constant(self):
+        """Only published and candidate are visible states."""
+        assert VISIBLE_LIFECYCLE_STATES == {"published", "candidate"}
+
+    async def test_get_visible_story_ids_helper(self):
+        """The batch helper classifies each lifecycle state correctly."""
+        visible = await _get_visible_story_ids(self.all_ids)
+        assert self.published_id in visible
+        assert self.candidate_id in visible
+        assert self.intermediate_id not in visible
+        assert self.archived_id not in visible
+        assert self.legacy_id in visible, "Legacy (no link) must stay visible"
+
+    async def test_get_visible_story_ids_empty(self):
+        """Empty input returns an empty set (no query)."""
+        assert await _get_visible_story_ids([]) == set()
+
+    async def test_library_filters_by_lifecycle(self, test_client):
+        """GET /api/v1/library hides intermediate/archived, keeps the rest."""
+        async with test_client as client:
+            resp = await client.get("/api/v1/library", params={"limit": 100})
+            assert resp.status_code == 200
+            item_ids = [item["id"] for item in resp.json()["items"]]
+
+            assert self.published_id in item_ids
+            assert self.candidate_id in item_ids
+            assert self.legacy_id in item_ids
+            assert self.intermediate_id not in item_ids
+            assert self.archived_id not in item_ids
+
+    async def test_search_filters_by_lifecycle(self, test_client):
+        """GET /api/v1/library/search hides intermediate/archived stories."""
+        async with test_client as client:
+            resp = await client.get(
+                "/api/v1/library/search",
+                params={"q": "dragons", "limit": 100},
+            )
+            assert resp.status_code == 200
+            item_ids = [item["id"] for item in resp.json()["items"]]
+
+            assert self.published_id in item_ids
+            assert self.candidate_id in item_ids
+            assert self.legacy_id in item_ids
+            assert self.intermediate_id not in item_ids
+            assert self.archived_id not in item_ids


### PR DESCRIPTION
Fixes 9 **verification-confirmed** gaps from the cross-domain product audit (each candidate was independently re-checked against real code before being actioned). Implemented by 4 parallel worktree agents, integrated here. **Zero new test failures** vs `main` (same 25 pre-existing `:memory:`-harness failures; +5 new passing library tests).

### Child-safety
- **#716** Buddy-chat reply safety now uses the child's **actual age** (threshold 0.90 for ages 3-5, 0.85 otherwise) instead of a hardcoded age 7.
- **#710** Stylized images are **re-validated for safety on the agent-direct path** (fail-closed; no dev bypass).
- **#712 / #713** `/library` + `/library/search` now filter to **published/candidate** artifacts only (never intermediate/archived). Batched (no N+1); **fails open** so a transient DB error can't blank a child's library; legacy stories without artifact links stay visible.

### Feature completeness
- **#717** Hub posts now expose `reaction_counts` + `viewer_reactions`. **#718** byline now includes `agent_id`. (COPPA projection contract still holds.)
- **#705** Interactive-story segments are length-validated/repaired (reuses the image-to-story trimmer — **no new LLM calls**). **#707** per-choice `trait` captured + `traits` aggregated into the educational summary.
- **#719** Voice mode: user-message `output_modality` no longer hardcoded to `text`.

Closes #705, #707, #710, #712, #713, #716, #717, #718, #719.

**Deferred (filed, intentionally not auto-fixed):** #708/#709 (raise cost — product call), #706 (debatable word range), #711 (frontend), #714/#715 (product logic), #720/#721 (#648-scale launch prereqs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)