### PR TITLE
fix(video): align generated job storage paths

### DIFF
--- a/backend/src/api/routes/video.py
+++ b/backend/src/api/routes/video.py
@@ -6,6 +6,7 @@ Supports generating animated videos from children's artwork
 """
 
 import json
+import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
@@ -18,33 +19,114 @@ from ..models import (
     VideoJobResponse,
     VideoJobStatusResponse,
     VideoStyle,
-    VideoStatus
+    VideoStatus,
 )
 from ..deps import get_current_user, get_story_for_owner
-from ...mcp_servers import generate_painting_video, check_video_status, combine_video_audio
+from ...mcp_servers import (
+    generate_painting_video,
+    check_video_status,
+    combine_video_audio,
+)
 from ...services.database import story_repo
 from ...services.achievement_service import FIRST_VIDEO, achievement_service
 from ...services.user_service import UserData
 
-
-router = APIRouter(
-    prefix="/api/v1/video",
-    tags=["Video Generation"]
-)
+router = APIRouter(prefix="/api/v1/video", tags=["Video Generation"])
 
 
 # ============================================================================
 # Configuration
 # ============================================================================
-from ...paths import VIDEO_DIR, VIDEO_JOBS_DIR, DATA_DIR
+from ...paths import BACKEND_DIR, VIDEO_DIR, VIDEO_JOBS_DIR, DATA_DIR
+
+LEGACY_DATA_DIR = BACKEND_DIR.parent / "data"
+LEGACY_VIDEO_DIR = LEGACY_DATA_DIR / "videos"
+LEGACY_VIDEO_JOBS_DIR = LEGACY_DATA_DIR / "video_jobs"
+
+
+def _load_json_file(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _candidate_job_files(job_id: str) -> list[Path]:
+    primary = VIDEO_JOBS_DIR / f"{job_id}.json"
+    legacy = LEGACY_VIDEO_JOBS_DIR / f"{job_id}.json"
+    if legacy == primary:
+        return [primary]
+    return [primary, legacy]
+
+
+def _iter_video_job_files() -> list[Path]:
+    files: list[Path] = []
+    seen: set[str] = set()
+    for jobs_dir in (VIDEO_JOBS_DIR, LEGACY_VIDEO_JOBS_DIR):
+        if not jobs_dir.exists():
+            continue
+        for job_file in jobs_dir.glob("*.json"):
+            if job_file.name in seen:
+                continue
+            seen.add(job_file.name)
+            files.append(job_file)
+    return files
+
+
+def _resolve_legacy_video_path(job_data: dict) -> Optional[Path]:
+    video_filename = job_data.get("video_filename")
+    raw_video_path = job_data.get("video_path")
+
+    candidates: list[Path] = []
+    if raw_video_path:
+        raw_path = Path(raw_video_path)
+        candidates.append(
+            raw_path if raw_path.is_absolute() else BACKEND_DIR.parent / raw_path
+        )
+    if video_filename:
+        candidates.append(LEGACY_VIDEO_DIR / video_filename)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _backfill_legacy_video(job_data: dict) -> dict:
+    """Copy legacy root-level rendered video into the backend-served data dir."""
+    video_filename = job_data.get("video_filename")
+    if not video_filename:
+        return job_data
+
+    target = VIDEO_DIR / video_filename
+    if target.exists():
+        job_data["video_path"] = str(target)
+        return job_data
+
+    source = _resolve_legacy_video_path(job_data)
+    if source is None:
+        return job_data
+
+    VIDEO_DIR.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+    job_data["video_path"] = str(target)
+    return job_data
 
 
 def load_job_from_file(job_id: str) -> Optional[dict]:
     """Load job status from file"""
-    job_file = VIDEO_JOBS_DIR / f"{job_id}.json"
-    if job_file.exists():
-        with open(job_file, "r", encoding="utf-8") as f:
-            return json.load(f)
+    primary = VIDEO_JOBS_DIR / f"{job_id}.json"
+    for job_file in _candidate_job_files(job_id):
+        job_data = _load_json_file(job_file)
+        if job_data is None:
+            continue
+
+        job_data = _backfill_legacy_video(job_data)
+        if job_file != primary:
+            VIDEO_JOBS_DIR.mkdir(parents=True, exist_ok=True)
+            with open(primary, "w", encoding="utf-8") as f:
+                json.dump(job_data, f, ensure_ascii=False, indent=2, default=str)
+        return job_data
     return None
 
 
@@ -72,7 +154,7 @@ async def call_mcp_tool(tool_ref, payload: dict) -> dict:
     response_model=VideoJobResponse,
     summary="Generate video",
     description="Generate an animated video for an artwork story",
-    status_code=status.HTTP_202_ACCEPTED
+    status_code=status.HTTP_202_ACCEPTED,
 )
 async def generate_video(
     request: VideoJobRequest,
@@ -94,30 +176,33 @@ async def generate_video(
         else:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Story is missing artwork image"
+                detail="Story is missing artwork image",
             )
 
     if not Path(image_path).exists():
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Artwork image file not found: {image_path}"
+            detail=f"Artwork image file not found: {image_path}",
         )
 
     # 3. Call video generation tool
     try:
-        result = await call_mcp_tool(generate_painting_video, {
-            "image_path": image_path,
-            "style": request.style.value,
-            "duration_seconds": request.duration_seconds,
-            "story_id": request.story_id
-        })
+        result = await call_mcp_tool(
+            generate_painting_video,
+            {
+                "image_path": image_path,
+                "style": request.style.value,
+                "duration_seconds": request.duration_seconds,
+                "story_id": request.story_id,
+            },
+        )
 
         result_data = json.loads(result["content"][0]["text"])
 
         if not result_data.get("success") and not result_data.get("job_id"):
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result_data.get("error", "Video generation failed")
+                detail=result_data.get("error", "Video generation failed"),
             )
 
         job_id = result_data["job_id"]
@@ -147,11 +232,14 @@ async def generate_video(
                 audio_path = str(DATA_DIR / audio_url.removeprefix("/data/"))
 
                 if video_path and Path(audio_path).exists():
-                    combine_result = await call_mcp_tool(combine_video_audio, {
-                        "video_path": video_path,
-                        "audio_path": audio_path,
-                        "output_filename": f"combined_{job_id}.mp4"
-                    })
+                    combine_result = await call_mcp_tool(
+                        combine_video_audio,
+                        {
+                            "video_path": video_path,
+                            "audio_path": audio_path,
+                            "output_filename": f"combined_{job_id}.mp4",
+                        },
+                    )
 
                     combine_data = json.loads(combine_result["content"][0]["text"])
                     if combine_data.get("success"):
@@ -161,7 +249,9 @@ async def generate_video(
                             with open(job_file, "r", encoding="utf-8") as f:
                                 job_data = json.load(f)
                             job_data["combined_video_url"] = combine_data["video_url"]
-                            job_data["combined_video_path"] = combine_data["output_path"]
+                            job_data["combined_video_path"] = combine_data[
+                                "output_path"
+                            ]
                             with open(job_file, "w", encoding="utf-8") as f:
                                 json.dump(job_data, f, ensure_ascii=False, indent=2)
 
@@ -170,7 +260,7 @@ async def generate_video(
             story_id=request.story_id,
             status=VideoStatus(job_status),
             estimated_completion=estimated_completion,
-            created_at=datetime.now()
+            created_at=datetime.now(),
         )
 
     except HTTPException:
@@ -179,7 +269,7 @@ async def generate_video(
         print(f"Error generating video: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Video generation failed, please try again later"
+            detail="Video generation failed, please try again later",
         )
 
 
@@ -187,7 +277,7 @@ async def generate_video(
     "/status/{job_id}",
     response_model=VideoJobStatusResponse,
     summary="Check video generation status",
-    description="Check video generation progress by job ID"
+    description="Check video generation progress by job ID",
 )
 async def get_video_status(
     job_id: str,
@@ -206,7 +296,7 @@ async def get_video_status(
         if not result_data.get("success"):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=result_data.get("error", f"Job not found: {job_id}")
+                detail=result_data.get("error", f"Job not found: {job_id}"),
             )
 
         # Load job details to get combined video URL
@@ -239,7 +329,7 @@ async def get_video_status(
             video_url=video_url,
             error_message=result_data.get("error_message"),
             created_at=created_at,
-            completed_at=completed_at
+            completed_at=completed_at,
         )
 
     except HTTPException:
@@ -248,7 +338,7 @@ async def get_video_status(
         print(f"Error checking video status: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to check status"
+            detail="Failed to check status",
         )
 
 
@@ -258,8 +348,8 @@ async def get_video_status(
     description="Get video metadata by video ID",
     responses={
         200: {"description": "Successfully retrieved video info"},
-        404: {"description": "Video not found"}
-    }
+        404: {"description": "Video not found"},
+    },
 )
 async def get_video_info(
     video_id: str,
@@ -273,7 +363,7 @@ async def get_video_info(
     if job_data.get("status") != "completed":
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Video generation not yet complete, current status: {job_data.get('status')}"
+            detail=f"Video generation not yet complete, current status: {job_data.get('status')}",
         )
 
     # Get video file info
@@ -282,31 +372,36 @@ async def get_video_info(
 
     # Prefer combined video
     final_path = combined_path if combined_path else video_path
-    final_url = job_data.get("combined_video_url") or f"/data/videos/{job_data.get('video_filename')}"
+    final_url = (
+        job_data.get("combined_video_url")
+        or f"/data/videos/{job_data.get('video_filename')}"
+    )
 
     file_size_mb = None
     if final_path and Path(final_path).exists():
         file_size = Path(final_path).stat().st_size
         file_size_mb = round(file_size / (1024 * 1024), 2)
 
-    return JSONResponse(content={
-        "video_id": video_id,
-        "story_id": job_data.get("story_id"),
-        "status": job_data.get("status"),
-        "style": job_data.get("style"),
-        "duration_seconds": job_data.get("duration_seconds"),
-        "video_url": final_url,
-        "has_audio": bool(combined_path),
-        "file_size_mb": file_size_mb,
-        "created_at": job_data.get("created_at"),
-        "completed_at": job_data.get("completed_at")
-    })
+    return JSONResponse(
+        content={
+            "video_id": video_id,
+            "story_id": job_data.get("story_id"),
+            "status": job_data.get("status"),
+            "style": job_data.get("style"),
+            "duration_seconds": job_data.get("duration_seconds"),
+            "video_url": final_url,
+            "has_audio": bool(combined_path),
+            "file_size_mb": file_size_mb,
+            "created_at": job_data.get("created_at"),
+            "completed_at": job_data.get("completed_at"),
+        }
+    )
 
 
 @router.get(
     "/story/{story_id}",
     summary="Get all videos for a story",
-    description="Get all videos associated with a specific story"
+    description="Get all videos associated with a specific story",
 )
 async def get_videos_by_story(
     story_id: str,
@@ -319,34 +414,37 @@ async def get_videos_by_story(
 
     # Scan job directory for related videos
     videos = []
-    if VIDEO_JOBS_DIR.exists():
-        for job_file in VIDEO_JOBS_DIR.glob("*.json"):
-            try:
-                with open(job_file, "r", encoding="utf-8") as f:
-                    job_data = json.load(f)
+    for job_file in _iter_video_job_files():
+        try:
+            job_data = load_job_from_file(job_file.stem)
+            if not job_data:
+                continue
 
-                if job_data.get("story_id") == story_id:
-                    video_url = job_data.get("combined_video_url") or (
-                        f"/data/videos/{job_data.get('video_filename')}"
-                        if job_data.get("video_filename") else None
-                    )
+            if job_data.get("story_id") == story_id:
+                video_url = job_data.get("combined_video_url") or (
+                    f"/data/videos/{job_data.get('video_filename')}"
+                    if job_data.get("video_filename")
+                    else None
+                )
 
-                    videos.append({
+                videos.append(
+                    {
                         "video_id": job_data.get("job_id"),
                         "status": job_data.get("status"),
                         "style": job_data.get("style"),
-                        "video_url": video_url if job_data.get("status") == "completed" else None,
+                        "video_url": (
+                            video_url if job_data.get("status") == "completed" else None
+                        ),
                         "has_audio": bool(job_data.get("combined_video_url")),
-                        "created_at": job_data.get("created_at")
-                    })
-            except (json.JSONDecodeError, IOError):
-                continue
+                        "created_at": job_data.get("created_at"),
+                    }
+                )
+        except (json.JSONDecodeError, IOError):
+            continue
 
     # Sort by creation time
     videos.sort(key=lambda x: x.get("created_at", ""), reverse=True)
 
-    return JSONResponse(content={
-        "story_id": story_id,
-        "total": len(videos),
-        "videos": videos
-    })
+    return JSONResponse(
+        content={"story_id": story_id, "total": len(videos), "videos": videos}
+    )

--- a/backend/src/mcp_servers/video_generator_server.py
+++ b/backend/src/mcp_servers/video_generator_server.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import uuid
 from datetime import datetime, timedelta
 
+from ..paths import VIDEO_DIR, VIDEO_JOBS_DIR
+
 try:
     import replicate as _replicate
 except Exception:  # pragma: no cover - import fallback for test env
@@ -30,9 +32,11 @@ except Exception:  # pragma: no cover - import fallback for test env
 try:
     from claude_agent_sdk import tool, create_sdk_mcp_server
 except Exception:  # pragma: no cover - import fallback for test env
+
     def tool(*_args, **_kwargs):
         def decorator(func):
             return func
+
         return decorator
 
     def create_sdk_mcp_server(**kwargs):
@@ -43,13 +47,15 @@ except Exception:  # pragma: no cover - import fallback for test env
 VIDEO_STYLE_PROMPTS = {
     "gentle_animation": "Gently animate this children's painting with soft, slow movements. Keep the original artwork style intact while adding subtle motion like swaying trees, twinkling stars, or gently moving characters. The animation should be calm and soothing, suitable for all ages.",
     "playful": "Create a playful animation from this children's painting. Add bouncy, fun movements to the characters and elements. Keep the whimsical, child-drawn quality while making elements dance and move joyfully.",
-    "storybook": "Transform this children's painting into a storybook-style animation. Add gentle page-turning effects and bring elements to life as if the drawing is coming alive from a magical book."
+    "storybook": "Transform this children's painting into a storybook-style animation. Add gentle page-turning effects and bring elements to life as if the drawing is coming alive from a magical book.",
 }
 
 
 # Cheapest-everywhere policy: a low-cost, maintained, prompt-capable Replicate
 # image-to-video model. Overridable via env without a redeploy of code.
 DEFAULT_VIDEO_MODEL = "wan-video/wan-2.2-i2v-fast"
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_LEGACY_VIDEO_JOBS_DIR = _REPO_ROOT / "data" / "video_jobs"
 
 
 def get_video_model() -> str:
@@ -72,14 +78,14 @@ def get_video_render_timeout() -> float:
 
 def get_video_output_path():
     """Get video output directory"""
-    video_dir = os.getenv("VIDEO_OUTPUT_PATH", "./data/videos")
+    video_dir = os.getenv("VIDEO_OUTPUT_PATH", str(VIDEO_DIR))
     Path(video_dir).mkdir(parents=True, exist_ok=True)
     return video_dir
 
 
 def get_video_jobs_path():
     """Get video jobs directory"""
-    jobs_dir = "./data/video_jobs"
+    jobs_dir = str(VIDEO_JOBS_DIR)
     Path(jobs_dir).mkdir(parents=True, exist_ok=True)
     return jobs_dir
 
@@ -98,7 +104,7 @@ def get_image_mime_type(image_path: str) -> str:
         ".jpeg": "image/jpeg",
         ".png": "image/png",
         ".webp": "image/webp",
-        ".gif": "image/gif"
+        ".gif": "image/gif",
     }
     return mime_types.get(ext, "image/png")
 
@@ -127,11 +133,12 @@ def save_job_status(job_id: str, job_data: Dict[str, Any]) -> None:
 
 def load_job_status(job_id: str) -> Optional[Dict[str, Any]]:
     """Load job status"""
-    jobs_dir = get_video_jobs_path()
-    job_file = Path(jobs_dir) / f"{job_id}.json"
-    if job_file.exists():
-        with open(job_file, "r", encoding="utf-8") as f:
-            return json.load(f)
+    primary = Path(get_video_jobs_path()) / f"{job_id}.json"
+    legacy = _LEGACY_VIDEO_JOBS_DIR / f"{job_id}.json"
+    for job_file in (primary, legacy):
+        if job_file.exists():
+            with open(job_file, "r", encoding="utf-8") as f:
+                return json.load(f)
     return None
 
 
@@ -146,12 +153,7 @@ def load_job_status(job_id: str) -> Optional[Dict[str, Any]]:
 
     The video will animate elements within the painting while preserving
     the original artistic style.""",
-    {
-        "image_path": str,
-        "style": str,
-        "duration_seconds": int,
-        "story_id": str
-    }
+    {"image_path": str, "style": str, "duration_seconds": int, "story_id": str},
 )
 async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
     """
@@ -171,39 +173,54 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
     # Verify image exists
     if not Path(image_path).exists():
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": f"Image file not found: {image_path}",
-                    "job_id": None
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": False,
+                            "error": f"Image file not found: {image_path}",
+                            "job_id": None,
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
 
     # Check Replicate availability + token (cheapest-everywhere video provider).
     if _replicate is None or _httpx is None:
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": "replicate/httpx SDK not installed",
-                    "job_id": None
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": False,
+                            "error": "replicate/httpx SDK not installed",
+                            "job_id": None,
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
     api_key = os.getenv("REPLICATE_API_TOKEN")
     if not api_key:
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": "REPLICATE_API_TOKEN environment variable not configured",
-                    "job_id": None
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": False,
+                            "error": "REPLICATE_API_TOKEN environment variable not configured",
+                            "job_id": None,
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
 
     try:
@@ -213,8 +230,7 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
 
         # Get style prompt + cost-clamped clip length
         style_prompt = VIDEO_STYLE_PROMPTS.get(
-            style,
-            VIDEO_STYLE_PROMPTS["gentle_animation"]
+            style, VIDEO_STYLE_PROMPTS["gentle_animation"]
         )
         clip_seconds = normalize_duration_seconds(duration_seconds)
         model = get_video_model()
@@ -269,22 +285,28 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
             "duration_seconds": clip_seconds,
             "model": model,
             "created_at": timestamp.isoformat(),
-            "completed_at": datetime.now().isoformat()
+            "completed_at": datetime.now().isoformat(),
         }
         save_job_status(job_id, job_data)
 
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": True,
-                    "job_id": job_id,
-                    "status": "completed",
-                    "video_path": str(video_path),
-                    "video_filename": video_filename,
-                    "video_url": f"/data/videos/{video_filename}"
-                }, ensure_ascii=False, indent=2)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": True,
+                            "job_id": job_id,
+                            "status": "completed",
+                            "video_path": str(video_path),
+                            "video_filename": video_filename,
+                            "video_url": f"/data/videos/{video_filename}",
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    ),
+                }
+            ]
         }
 
     except Exception as e:
@@ -307,15 +329,21 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
         save_job_status(job_id, job_data)
 
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "job_id": job_id,
-                    "status": "failed",
-                    "error": f"Video generation failed: {error_message}",
-                }, ensure_ascii=False, indent=2)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": False,
+                            "job_id": job_id,
+                            "status": "failed",
+                            "error": f"Video generation failed: {error_message}",
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    ),
+                }
+            ]
         }
 
 
@@ -324,7 +352,7 @@ async def generate_painting_video(args: Dict[str, Any]) -> Dict[str, Any]:
     """Check the status of a video generation job.
 
     Returns the current status, progress percentage, and video URL if completed.""",
-    {"job_id": str}
+    {"job_id": str},
 )
 async def check_video_status(args: Dict[str, Any]) -> Dict[str, Any]:
     """
@@ -341,13 +369,15 @@ async def check_video_status(args: Dict[str, Any]) -> Dict[str, Any]:
     job_data = load_job_status(job_id)
     if not job_data:
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": f"Job not found: {job_id}"
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {"success": False, "error": f"Job not found: {job_id}"},
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
 
     # If job is in pending status, check for external updates
@@ -361,7 +391,7 @@ async def check_video_status(args: Dict[str, Any]) -> Dict[str, Any]:
         "progress_percent": job_data.get("progress_percent", 0),
         "created_at": job_data.get("created_at"),
         "completed_at": job_data.get("completed_at"),
-        "estimated_completion": job_data.get("estimated_completion")
+        "estimated_completion": job_data.get("estimated_completion"),
     }
 
     if status == "completed":
@@ -374,10 +404,9 @@ async def check_video_status(args: Dict[str, Any]) -> Dict[str, Any]:
         response["error_message"] = job_data.get("error")
 
     return {
-        "content": [{
-            "type": "text",
-            "text": json.dumps(response, ensure_ascii=False, indent=2)
-        }]
+        "content": [
+            {"type": "text", "text": json.dumps(response, ensure_ascii=False, indent=2)}
+        ]
     }
 
 
@@ -386,7 +415,7 @@ async def check_video_status(args: Dict[str, Any]) -> Dict[str, Any]:
     """Combine a generated video with audio narration.
 
     Uses ffmpeg to merge video and audio files into a single video with narration.""",
-    {"video_path": str, "audio_path": str, "output_filename": str}
+    {"video_path": str, "audio_path": str, "output_filename": str},
 )
 async def combine_video_audio(args: Dict[str, Any]) -> Dict[str, Any]:
     """
@@ -405,24 +434,34 @@ async def combine_video_audio(args: Dict[str, Any]) -> Dict[str, Any]:
     # Verify files exist
     if not Path(video_path).exists():
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": f"Video file not found: {video_path}"
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": False,
+                            "error": f"Video file not found: {video_path}",
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
 
     if not Path(audio_path).exists():
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": f"Audio file not found: {audio_path}"
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": False,
+                            "error": f"Audio file not found: {audio_path}",
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
 
     try:
@@ -442,30 +481,36 @@ async def combine_video_audio(args: Dict[str, Any]) -> Dict[str, Any]:
         cmd = [
             "ffmpeg",
             "-y",  # Overwrite output file
-            "-i", video_path,
-            "-i", audio_path,
-            "-c:v", "copy",
-            "-c:a", "aac",
+            "-i",
+            video_path,
+            "-i",
+            audio_path,
+            "-c:v",
+            "copy",
+            "-c:a",
+            "aac",
             "-shortest",
-            str(output_path)
+            str(output_path),
         ]
 
         result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=120  # 2-minute timeout
+            cmd, capture_output=True, text=True, timeout=120  # 2-minute timeout
         )
 
         if result.returncode != 0:
             return {
-                "content": [{
-                    "type": "text",
-                    "text": json.dumps({
-                        "success": False,
-                        "error": f"ffmpeg merge failed: {result.stderr}"
-                    }, ensure_ascii=False)
-                }]
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(
+                            {
+                                "success": False,
+                                "error": f"ffmpeg merge failed: {result.stderr}",
+                            },
+                            ensure_ascii=False,
+                        ),
+                    }
+                ]
             }
 
         # Get file size
@@ -473,47 +518,62 @@ async def combine_video_audio(args: Dict[str, Any]) -> Dict[str, Any]:
         file_size_mb = round(file_size / (1024 * 1024), 2)
 
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": True,
-                    "output_path": str(output_path),
-                    "output_filename": output_filename,
-                    "video_url": f"/data/videos/{output_filename}",
-                    "file_size_mb": file_size_mb
-                }, ensure_ascii=False, indent=2)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": True,
+                            "output_path": str(output_path),
+                            "output_filename": output_filename,
+                            "video_url": f"/data/videos/{output_filename}",
+                            "file_size_mb": file_size_mb,
+                        },
+                        ensure_ascii=False,
+                        indent=2,
+                    ),
+                }
+            ]
         }
 
     except subprocess.TimeoutExpired:
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": "ffmpeg processing timed out"
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {"success": False, "error": "ffmpeg processing timed out"},
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
     except FileNotFoundError:
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": "ffmpeg not installed, please install ffmpeg first"
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {
+                            "success": False,
+                            "error": "ffmpeg not installed, please install ffmpeg first",
+                        },
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
     except Exception as e:
         return {
-            "content": [{
-                "type": "text",
-                "text": json.dumps({
-                    "success": False,
-                    "error": f"Merge failed: {str(e)}"
-                }, ensure_ascii=False)
-            }]
+            "content": [
+                {
+                    "type": "text",
+                    "text": json.dumps(
+                        {"success": False, "error": f"Merge failed: {str(e)}"},
+                        ensure_ascii=False,
+                    ),
+                }
+            ]
         }
 
 
@@ -542,7 +602,7 @@ video_server = create_sdk_mcp_server(
         _generate_painting_video_tool,
         _check_video_status_tool,
         _combine_video_audio_tool,
-    ]
+    ],
 )
 
 

--- a/backend/tests/api/test_video_routes.py
+++ b/backend/tests/api/test_video_routes.py
@@ -110,6 +110,43 @@ async def test_get_video_status_rejects_unowned_job_without_story_binding(
     assert exc.value.detail == "Video job is not linked to an owned story"
 
 
+def test_load_job_from_file_migrates_legacy_video_job(monkeypatch, tmp_path):
+    primary_jobs = tmp_path / "backend_jobs"
+    primary_videos = tmp_path / "backend_videos"
+    legacy_jobs = tmp_path / "legacy_jobs"
+    legacy_videos = tmp_path / "legacy_videos"
+    legacy_jobs.mkdir()
+    legacy_videos.mkdir()
+
+    legacy_video = legacy_videos / "video_job-1.mp4"
+    legacy_video.write_bytes(b"mp4")
+    (legacy_jobs / "job-1.json").write_text(
+        json.dumps(
+            {
+                "job_id": "job-1",
+                "story_id": "story-1",
+                "status": "completed",
+                "video_path": str(legacy_video),
+                "video_filename": legacy_video.name,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(video, "VIDEO_JOBS_DIR", primary_jobs)
+    monkeypatch.setattr(video, "VIDEO_DIR", primary_videos)
+    monkeypatch.setattr(video, "LEGACY_VIDEO_JOBS_DIR", legacy_jobs)
+    monkeypatch.setattr(video, "LEGACY_VIDEO_DIR", legacy_videos)
+
+    job = video.load_job_from_file("job-1")
+
+    assert job is not None
+    assert job["story_id"] == "story-1"
+    assert job["video_path"] == str(primary_videos / legacy_video.name)
+    assert (primary_jobs / "job-1.json").exists()
+    assert (primary_videos / legacy_video.name).read_bytes() == b"mp4"
+
+
 @pytest.mark.asyncio
 async def test_get_video_status_verifies_story_owner_before_returning_url(
     monkeypatch, tmp_path

--- a/backend/tests/unit/test_video_generator_server.py
+++ b/backend/tests/unit/test_video_generator_server.py
@@ -7,10 +7,12 @@ shape, the env override, and the fail-fast error path.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 
 from backend.src.mcp_servers import video_generator_server as vgs
+from backend.src.paths import VIDEO_DIR, VIDEO_JOBS_DIR
 
 
 class _FakeFileOutput:
@@ -65,6 +67,31 @@ class _FakeHttpx:
 )
 def test_normalize_duration_clamps_to_cost_window(requested, expected):
     assert vgs.normalize_duration_seconds(requested) == expected
+
+
+def test_video_paths_default_to_backend_data_dirs(monkeypatch):
+    monkeypatch.delenv("VIDEO_OUTPUT_PATH", raising=False)
+
+    assert Path(vgs.get_video_output_path()) == VIDEO_DIR
+    assert Path(vgs.get_video_jobs_path()) == VIDEO_JOBS_DIR
+
+
+def test_load_job_status_reads_legacy_root_job(monkeypatch, tmp_path):
+    primary = tmp_path / "backend_jobs"
+    legacy = tmp_path / "legacy_jobs"
+    legacy.mkdir()
+    (legacy / "job-1.json").write_text(
+        json.dumps({"job_id": "job-1", "story_id": "story-1"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(vgs, "get_video_jobs_path", lambda: str(primary))
+    monkeypatch.setattr(vgs, "_LEGACY_VIDEO_JOBS_DIR", legacy)
+
+    assert vgs.load_job_status("job-1") == {
+        "job_id": "job-1",
+        "story_id": "story-1",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Make the video MCP generator write jobs/videos to the backend data paths used by FastAPI
- Add legacy root-level job/video fallback and migration so existing completed renders remain readable
- Add route and MCP regression coverage for the path-parity bug

Fixes #724
Parent Epic: #313

## Verification
- env ENVIRONMENT=test DATABASE_URL= backend/venv/bin/python -m pytest backend/tests/api/test_video_routes.py backend/tests/unit/test_video_generator_server.py backend/tests/test_batch_235_182_150.py -q
- backend/venv/bin/python -m py_compile backend/src/api/routes/video.py backend/src/mcp_servers/video_generator_server.py
- Local Vite-proxied status request for b7f6f028-8965-4716-9f7f-5ab61615389f returned HTTP 200 with completed video URL
