### PR TITLE
fix(frontend): restore flat-icon conversion for non-avatar surfaces

### DIFF
--- a/frontend/src/components/common/VoiceInputButton/index.tsx
+++ b/frontend/src/components/common/VoiceInputButton/index.tsx
@@ -16,6 +16,7 @@
 import { useCallback } from 'react'
 import { motion } from 'framer-motion'
 import { useVoiceInput, type AgeBand } from '@/hooks/useVoiceInput'
+import { Mic, Square } from 'lucide-react'
 
 export interface VoiceInputButtonProps {
   ageGroup: AgeBand
@@ -94,7 +95,7 @@ export function VoiceInputButton({
         aria-label={recording ? 'Stop recording' : 'Start voice input'}
         aria-pressed={recording}
       >
-        <span aria-hidden="true">{recording ? '⏹️' : '🎤'}</span>
+        {recording ? <Square size={20} fill="currentColor" /> : <Mic size={22} />}
       </motion.button>
 
       <span

--- a/frontend/src/components/common/VoicePicker/index.tsx
+++ b/frontend/src/components/common/VoicePicker/index.tsx
@@ -4,6 +4,17 @@ import { motion, AnimatePresence } from 'framer-motion'
 import type { AgeGroup } from '@/types/api'
 import apiClient from '@/api/client'
 import { storyService } from '@/api/services/storyService'
+import {
+  Bot,
+  BookOpen,
+  LoaderCircle,
+  Mic,
+  Play,
+  Radio,
+  Theater,
+  UserRound,
+  Volume2,
+} from 'lucide-react'
 
 export interface VoiceEntry {
   voice_id: string
@@ -32,26 +43,26 @@ const PROVIDER_COLORS: Record<string, string> = {
   elevenlabs: 'bg-amber-50 border-amber-200',
 }
 
-const VOICE_EMOJIS: Record<string, string> = {
+const VOICE_ICONS: Record<string, typeof Mic> = {
   // OpenAI
-  nova: '👩',
-  shimmer: '💃',
-  fable: '📖',
-  echo: '👨',
-  alloy: '🤖',
-  onyx: '🎭',
+  nova: UserRound,
+  shimmer: Radio,
+  fable: BookOpen,
+  echo: UserRound,
+  alloy: Bot,
+  onyx: Theater,
   // ElevenLabs (by display name keywords)
-  default: '🎙️',
+  default: Mic,
 }
 
-function getVoiceEmoji(voice: VoiceEntry): string {
+function getVoiceIcon(voice: VoiceEntry): typeof Mic {
   // Check by voice_id first (OpenAI voices)
-  if (voice.voice_id in VOICE_EMOJIS) return VOICE_EMOJIS[voice.voice_id]
+  if (voice.voice_id in VOICE_ICONS) return VOICE_ICONS[voice.voice_id]
   // Infer from description
   const desc = voice.description.toLowerCase()
-  if (desc.includes('female') || desc.includes('girl') || desc.includes('woman')) return '👩'
-  if (desc.includes('male') || desc.includes('man') || desc.includes('boy') || desc.includes('knight')) return '👨'
-  return VOICE_EMOJIS.default
+  if (desc.includes('female') || desc.includes('girl') || desc.includes('woman')) return UserRound
+  if (desc.includes('male') || desc.includes('man') || desc.includes('boy') || desc.includes('knight')) return UserRound
+  return VOICE_ICONS.default
 }
 
 // Max voices shown per age group for young children
@@ -190,9 +201,9 @@ function VoicePicker({ ageGroup, selectedVoice, onVoiceChange, className = '' }:
         <motion.span
           animate={{ rotate: 360 }}
           transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-          className="text-2xl"
+          className="text-primary"
         >
-          🎵
+          <LoaderCircle size={22} />
         </motion.span>
         <span className="ml-2 text-gray-500 text-sm">Loading voices...</span>
       </div>
@@ -219,6 +230,7 @@ function VoicePicker({ ageGroup, selectedVoice, onVoiceChange, className = '' }:
             const isSelected = selectedVoice === voice.voice_id
             const isPreviewing = previewingId === voice.voice_id
             const isLoadingPreview = previewLoading === voice.voice_id
+            const VoiceIcon = getVoiceIcon(voice)
 
             return (
               <motion.div
@@ -243,10 +255,12 @@ function VoicePicker({ ageGroup, selectedVoice, onVoiceChange, className = '' }:
               >
                 <div className="flex items-start gap-2">
                   <motion.span
-                    className={`text-xl ${ageGroup === '3-5' ? 'text-3xl' : ''}`}
+                    className={`flex items-center justify-center rounded-lg bg-gray-100 text-gray-600 ${
+                      ageGroup === '3-5' ? 'h-10 w-10' : 'h-8 w-8'
+                    }`}
                     animate={isSelected ? { scale: [1, 1.2, 1] } : {}}
                   >
-                    {getVoiceEmoji(voice)}
+                    <VoiceIcon size={ageGroup === '3-5' ? 22 : 18} />
                   </motion.span>
                   <div className="flex-1 min-w-0">
                     <div className={`font-medium truncate ${ageGroup === '3-5' ? 'text-base' : 'text-sm'}`}>
@@ -282,17 +296,17 @@ function VoicePicker({ ageGroup, selectedVoice, onVoiceChange, className = '' }:
                         animate={{ rotate: 360 }}
                         transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
                       >
-                        ⏳
+                        <LoaderCircle size={14} />
                       </motion.span>
                     ) : isPreviewing ? (
                       <motion.span
                         animate={{ scale: [1, 1.3, 1] }}
                         transition={{ duration: 0.5, repeat: Infinity }}
                       >
-                        🔊
+                        <Volume2 size={14} />
                       </motion.span>
                     ) : (
-                      '▶'
+                      <Play size={14} fill="currentColor" />
                     )}
                   </motion.button>
                 </div>

--- a/frontend/src/components/upload/ImageUploader/index.tsx
+++ b/frontend/src/components/upload/ImageUploader/index.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDropzone } from 'react-dropzone'
 import { motion, AnimatePresence } from 'framer-motion'
+import {
+  Camera,
+  Crosshair,
+  FolderUp,
+  Image,
+  Sparkles,
+  TriangleAlert,
+} from 'lucide-react'
 import CameraCapture from '@/components/upload/CameraCapture'
 import ParentConsentGate from '@/components/common/ParentConsentGate'
 import useChildStore from '@/store/useChildStore'
@@ -121,13 +129,13 @@ function ImageUploader({
               exit={{ opacity: 0, scale: 0.9 }}
               className="flex flex-col items-center gap-4"
             >
-              <motion.span
-                className="text-6xl"
+              <motion.div
+                className="flex h-16 w-16 items-center justify-center rounded-lg border border-primary/20 bg-primary/10 text-primary"
                 animate={{ y: [0, -10, 0] }}
                 transition={{ duration: 0.5, repeat: Infinity }}
               >
-                🎯
-              </motion.span>
+                <Crosshair className="h-8 w-8" strokeWidth={2.2} />
+              </motion.div>
               <p className="text-xl font-bold text-primary">Drop to upload</p>
             </motion.div>
           ) : isDragReject ? (
@@ -138,7 +146,9 @@ function ImageUploader({
               exit={{ opacity: 0 }}
               className="flex flex-col items-center gap-4"
             >
-              <span className="text-6xl">😅</span>
+              <span className="flex h-16 w-16 items-center justify-center rounded-lg border border-red-200 bg-red-100 text-red-500">
+                <TriangleAlert className="h-8 w-8" strokeWidth={2.2} />
+              </span>
               <p className="text-xl font-bold text-red-500">Unsupported file format</p>
               <p className="text-gray-500">Please upload PNG, JPG or GIF images</p>
             </motion.div>
@@ -151,19 +161,19 @@ function ImageUploader({
               className="flex flex-col items-center gap-4"
             >
               <div className="relative">
-                <motion.span
-                  className="text-6xl"
+                <motion.div
+                  className="flex h-16 w-16 items-center justify-center rounded-lg border border-primary/20 bg-primary/10 text-primary"
                   animate={{ rotate: [0, -5, 5, 0] }}
                   transition={{ duration: 2, repeat: Infinity }}
                 >
-                  🖼️
-                </motion.span>
+                  <Image className="h-8 w-8" strokeWidth={2.1} />
+                </motion.div>
                 <motion.span
-                  className="absolute -top-2 -right-2 text-2xl"
+                  className="absolute -top-2 -right-2 flex h-7 w-7 items-center justify-center rounded-lg border border-accent/40 bg-white text-primary shadow-sm"
                   animate={{ scale: [1, 1.2, 1] }}
                   transition={{ duration: 1, repeat: Infinity }}
                 >
-                  ✨
+                  <Sparkles className="h-4 w-4" strokeWidth={2.2} />
                 </motion.span>
               </div>
 
@@ -204,7 +214,10 @@ function ImageUploader({
             activeTab === 'camera' ? 'bg-white text-primary shadow' : 'text-gray-600'
           }`}
         >
-          📸 Take Photo
+          <span className="inline-flex items-center gap-1.5">
+            <Camera className="h-4 w-4" strokeWidth={2.2} />
+            Take Photo
+          </span>
         </button>
         <button
           type="button"
@@ -215,7 +228,10 @@ function ImageUploader({
             activeTab === 'file' ? 'bg-white text-primary shadow' : 'text-gray-600'
           }`}
         >
-          📂 Upload File
+          <span className="inline-flex items-center gap-1.5">
+            <FolderUp className="h-4 w-4" strokeWidth={2.2} />
+            Upload File
+          </span>
         </button>
       </div>
 

--- a/frontend/src/pages/InteractiveStoryPage/index.tsx
+++ b/frontend/src/pages/InteractiveStoryPage/index.tsx
@@ -31,22 +31,43 @@ import {
   getInteractiveStoryPageState,
   type InteractiveStoryPageState,
 } from "./pageState";
+import {
+  Baby,
+  BookOpen,
+  CheckCircle,
+  Clock,
+  Flag,
+  Globe2,
+  Home,
+  Infinity as InfinityIcon,
+  Library,
+  Palette,
+  Rocket,
+  RotateCcw,
+  Save,
+  Sparkles,
+  Sunrise,
+  Trophy,
+  UserRound,
+  UsersRound,
+  XCircle,
+} from "lucide-react";
 
-const AGE_GROUPS: { value: AgeGroup; label: string; emoji: string }[] = [
-  { value: "3-5", label: "3-5 yrs", emoji: "🧒" },
-  { value: "6-8", label: "6-8 yrs", emoji: "👦" },
-  { value: "9-12", label: "9-12 yrs", emoji: "🧑" },
+const AGE_GROUPS = [
+  { value: "3-5" as AgeGroup, label: "3-5 yrs", icon: Baby },
+  { value: "6-8" as AgeGroup, label: "6-8 yrs", icon: UserRound },
+  { value: "9-12" as AgeGroup, label: "9-12 yrs", icon: UsersRound },
 ];
 
 const STORY_LENGTHS: {
   value: StoryLengthMode;
   label: string;
   sublabel: string;
-  emoji: string;
+  icon: typeof BookOpen;
 }[] = [
-  { value: "short", label: "Quick Tale", sublabel: "5 choices", emoji: "📖" },
-  { value: "medium", label: "Short Story", sublabel: "10 choices", emoji: "📚" },
-  { value: "unlimited", label: "Endless Adventure", sublabel: "No limit", emoji: "🌟" },
+  { value: "short", label: "Quick Tale", sublabel: "5 choices", icon: BookOpen },
+  { value: "medium", label: "Short Story", sublabel: "10 choices", icon: Library },
+  { value: "unlimited", label: "Endless Adventure", sublabel: "No limit", icon: InfinityIcon },
 ];
 
 function InteractiveStoryPageContent() {
@@ -329,8 +350,6 @@ function InteractiveStoryPageContent() {
             )
           : null;
         const selectedChoiceText = matchedChoice?.text || selectedChoiceId;
-        const selectedChoiceEmoji = matchedChoice?.emoji || "✅";
-
         return (
           <div
             key={`${segment.segment_id}-${index}`}
@@ -355,8 +374,8 @@ function InteractiveStoryPageContent() {
                 <p className="text-xs font-semibold uppercase tracking-wide text-primary mb-1">
                   You Chose
                 </p>
-                <p className="text-sm text-gray-700">
-                  <span className="mr-1">{selectedChoiceEmoji}</span>
+                <p className="inline-flex items-center justify-center gap-1.5 text-sm text-gray-700">
+                  <CheckCircle size={14} />
                   {selectedChoiceText}
                 </p>
               </motion.div>
@@ -406,11 +425,11 @@ function InteractiveStoryPageContent() {
         animate={{ opacity: 1, y: 0 }}
       >
         <motion.span
-          className="text-5xl inline-block"
+          className="mx-auto inline-flex h-14 w-14 items-center justify-center rounded-lg bg-primary/10 text-primary"
           animate={{ rotate: [0, -5, 5, 0] }}
           transition={{ duration: 3, repeat: Infinity }}
         >
-          🎭
+          <BookOpen size={30} />
         </motion.span>
         <h1 className="text-2xl md:text-3xl font-bold text-gray-800 mt-2">
           Interactive Story
@@ -431,7 +450,7 @@ function InteractiveStoryPageContent() {
             </span>
             {arrivingChoice ? (
               <span className="text-gray-600 truncate max-w-[18rem]">
-                · arrived via {arrivingChoice.emoji} {arrivingChoice.text}
+                · arrived via {arrivingChoice.text}
               </span>
             ) : (
               <span className="text-gray-500">· beginning of story</span>
@@ -455,7 +474,7 @@ function InteractiveStoryPageContent() {
           animate={{ opacity: 1, scale: 1 }}
         >
           <div className="flex items-center gap-2">
-            <span>❌</span>
+            <XCircle size={18} />
             <span>{error}</span>
           </div>
         </motion.div>
@@ -475,74 +494,80 @@ function InteractiveStoryPageContent() {
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
             >
-              <span className="text-lg mr-1">🌅</span> {sessionExpiredMsg}
+              <Sunrise className="mr-1 inline" size={18} /> {sessionExpiredMsg}
             </motion.div>
           )}
 
           {/* Age Group Selection */}
           <Card>
             <h2 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
-              <span>👶</span>
+              <UserRound size={20} />
               Select Age Group
               <span className="text-red-500">*</span>
             </h2>
             <div className="grid grid-cols-3 gap-3">
-              {AGE_GROUPS.map((age) => (
-                <motion.button
-                  key={age.value}
-                  className={`
-                    p-4 rounded-xl border-2 text-center transition-colors
-                    ${
-                      selectedAge === age.value
-                        ? "border-primary bg-primary/10"
-                        : "border-gray-200 hover:border-primary/50"
-                    }
-                  `}
-                  onClick={() => setSelectedAge(age.value)}
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                >
-                  <span className="text-2xl block mb-1">{age.emoji}</span>
-                  <span className="text-sm font-medium">{age.label}</span>
-                </motion.button>
-              ))}
+              {AGE_GROUPS.map((age) => {
+                const Icon = age.icon
+                return (
+                  <motion.button
+                    key={age.value}
+                    className={`
+                      p-4 rounded-xl border-2 text-center transition-colors
+                      ${
+                        selectedAge === age.value
+                          ? "border-primary bg-primary/10"
+                          : "border-gray-200 hover:border-primary/50"
+                      }
+                    `}
+                    onClick={() => setSelectedAge(age.value)}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                  >
+                    <Icon className="mx-auto mb-1 text-gray-700" size={24} />
+                    <span className="text-sm font-medium">{age.label}</span>
+                  </motion.button>
+                )
+              })}
             </div>
           </Card>
 
           {/* Story Length Mode (#331) */}
           <Card>
             <h2 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
-              <span>⏱️</span>
+              <Clock size={20} />
               Story Length
             </h2>
             <div className="grid grid-cols-3 gap-3">
-              {STORY_LENGTHS.map((len) => (
-                <motion.button
-                  key={len.value}
-                  className={`
-                    p-4 rounded-xl border-2 text-center transition-colors
-                    ${
-                      selectedLength === len.value
-                        ? "border-primary bg-primary/10"
-                        : "border-gray-200 hover:border-primary/50"
-                    }
-                  `}
-                  onClick={() => setSelectedLength(len.value)}
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                >
-                  <span className="text-2xl block mb-1">{len.emoji}</span>
-                  <span className="text-sm font-medium block">{len.label}</span>
-                  <span className="text-xs text-gray-400">{len.sublabel}</span>
-                </motion.button>
-              ))}
+              {STORY_LENGTHS.map((len) => {
+                const Icon = len.icon
+                return (
+                  <motion.button
+                    key={len.value}
+                    className={`
+                      p-4 rounded-xl border-2 text-center transition-colors
+                      ${
+                        selectedLength === len.value
+                          ? "border-primary bg-primary/10"
+                          : "border-gray-200 hover:border-primary/50"
+                      }
+                    `}
+                    onClick={() => setSelectedLength(len.value)}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                  >
+                    <Icon className="mx-auto mb-1 text-gray-700" size={24} />
+                    <span className="text-sm font-medium block">{len.label}</span>
+                    <span className="text-xs text-gray-400">{len.sublabel}</span>
+                  </motion.button>
+                )
+              })}
             </div>
           </Card>
 
           {/* Interest Tags */}
           <Card>
             <h2 className="text-lg font-bold text-gray-800 mb-2 flex items-center gap-2">
-              <span>💫</span>
+              <Sparkles size={20} />
               Select Interests
               <span className="text-sm font-normal text-gray-500">(1-5)</span>
             </h2>
@@ -584,7 +609,7 @@ function InteractiveStoryPageContent() {
           {/* Theme Input */}
           <Card>
             <h2 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
-              <span>🎨</span>
+              <Palette size={20} />
               Story Theme
               <span className="text-sm font-normal text-gray-500">
                 (Optional)
@@ -630,7 +655,7 @@ function InteractiveStoryPageContent() {
               selectedInterests.length === 0 ||
               streaming.isStreaming
             }
-            leftIcon={<span>🚀</span>}
+            leftIcon={<Rocket size={18} />}
           >
             {streaming.isStreaming ? "Creating..." : "Start Story"}
           </Button>
@@ -713,7 +738,7 @@ function InteractiveStoryPageContent() {
                   size="md"
                   onClick={handleEndStory}
                   disabled={isLoading}
-                  leftIcon={<span>🏁</span>}
+                  leftIcon={<Flag size={18} />}
                 >
                   End My Story
                 </Button>
@@ -756,7 +781,7 @@ function InteractiveStoryPageContent() {
           {educationalSummary && (
             <Card>
               <h3 className="text-lg font-bold text-gray-800 mb-4 flex items-center gap-2">
-                <span>📚</span>
+                <Library size={20} />
                 What You Learned
               </h3>
               <EducationalTags value={educationalSummary} />
@@ -766,7 +791,7 @@ function InteractiveStoryPageContent() {
           {/* Journey summary */}
           <Card variant="colorful" colorScheme="accent">
             <div className="text-center">
-              <span className="text-4xl block mb-2">🏆</span>
+              <Trophy className="mx-auto mb-2 text-yellow-600" size={36} />
               <h3 className="text-lg font-bold text-gray-800 mb-1">
                 You completed this story!
               </h3>
@@ -785,7 +810,7 @@ function InteractiveStoryPageContent() {
               onClick={handleSaveStory}
               disabled={saveStatus === "saving" || saveStatus === "saved"}
               isLoading={saveStatus === "saving"}
-              leftIcon={<span>{saveStatus === "saved" ? "✅" : "💾"}</span>}
+              leftIcon={saveStatus === "saved" ? <CheckCircle size={18} /> : <Save size={18} />}
             >
               {saveStatus === "saved"
                 ? "Saved!"
@@ -798,7 +823,7 @@ function InteractiveStoryPageContent() {
               size="lg"
               className="flex-1"
               onClick={handleReset}
-              leftIcon={<span>🔄</span>}
+              leftIcon={<RotateCcw size={18} />}
             >
               Play Again
             </Button>
@@ -807,7 +832,7 @@ function InteractiveStoryPageContent() {
               size="lg"
               className="flex-1"
               onClick={() => navigate("/")}
-              leftIcon={<span>🏠</span>}
+              leftIcon={<Home size={18} />}
             >
               Back to Home
             </Button>
@@ -821,7 +846,10 @@ function InteractiveStoryPageContent() {
                 className="rounded-2xl bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 px-6 py-3 text-base font-bold text-white shadow-md hover:shadow-lg transition-all"
                 onClick={() => setShareOpen(true)}
               >
-                🌐 Share to Content Hub
+                <span className="inline-flex items-center gap-2">
+                  <Globe2 size={18} />
+                  Share to Content Hub
+                </span>
               </button>
             </div>
           )}

--- a/frontend/src/pages/KidsDailyEpisodePage/index.tsx
+++ b/frontend/src/pages/KidsDailyEpisodePage/index.tsx
@@ -9,11 +9,12 @@ import useChildStore from "@/store/useChildStore";
 import useAuthStore from "@/store/useAuthStore";
 import { resolveMediaUrl } from "@/utils/mediaUrl";
 import ShareToHubModal from "@/components/hub/ShareToHubModal";
+import { GraduationCap, Mic2, UserRound, Globe2 } from "lucide-react";
 
 const ROLE_META = {
-  curious_kid: { label: "Curious Kid", emoji: "🧒" },
-  fun_expert: { label: "Fun Expert", emoji: "🧑‍🏫" },
-  guest: { label: "Guest Anchor", emoji: "🦉" },
+  curious_kid: { label: "Curious Kid", icon: UserRound },
+  fun_expert: { label: "Fun Expert", icon: GraduationCap },
+  guest: { label: "Guest Anchor", icon: Mic2 },
 } as const;
 
 function morningShowAudioSrc(url?: string | null): string | null {
@@ -301,6 +302,7 @@ function KidsDailyEpisodePage() {
             <div className="flex flex-wrap items-center gap-3">
               {(["curious_kid", "fun_expert", "guest"] as const).map((role) => {
                 const active = currentLine?.role === role;
+                const RoleIcon = ROLE_META[role].icon;
                 return (
                   <motion.div
                     key={role}
@@ -311,8 +313,8 @@ function KidsDailyEpisodePage() {
                       repeat: active ? Infinity : 0,
                     }}
                   >
-                    <span className={`${avatarSize} mr-2`}>
-                      {ROLE_META[role].emoji}
+                    <span className={`${avatarSize} mr-2 inline-flex align-middle`}>
+                      <RoleIcon size={16} />
                     </span>
                     {ROLE_META[role].label}
                   </motion.div>
@@ -366,6 +368,7 @@ function KidsDailyEpisodePage() {
               <div className="space-y-2 max-h-72 overflow-y-auto pr-1">
                 {lines.map((line, index) => {
                   const active = index === currentLineIndex;
+                  const RoleIcon = ROLE_META[line.role].icon;
                   return (
                     <div
                       key={`${line.role}-${index}`}
@@ -375,8 +378,8 @@ function KidsDailyEpisodePage() {
                           : "border-gray-200 bg-white"
                       }`}
                     >
-                      <p className="font-semibold text-xs text-gray-500 mb-1">
-                        {ROLE_META[line.role].emoji}{" "}
+                      <p className="flex items-center gap-1.5 font-semibold text-xs text-gray-500 mb-1">
+                        <RoleIcon size={14} />
                         {ROLE_META[line.role].label}
                       </p>
                       <p className="text-gray-700">{line.text}</p>
@@ -402,7 +405,10 @@ function KidsDailyEpisodePage() {
                 className="mt-4 w-full rounded-2xl bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 px-5 py-3 text-base font-bold text-white shadow-md hover:shadow-lg transition-all"
                 onClick={() => setShareOpen(true)}
               >
-                🌐 Share to Content Hub
+                <span className="inline-flex items-center justify-center gap-2">
+                  <Globe2 size={18} />
+                  Share to Content Hub
+                </span>
               </button>
             )}
           </Card>

--- a/frontend/src/pages/KidsDailyPage/index.tsx
+++ b/frontend/src/pages/KidsDailyPage/index.tsx
@@ -1,6 +1,21 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
+import {
+  Atom,
+  Bot,
+  Clock3,
+  Compass,
+  Drama,
+  Globe2,
+  Leaf,
+  Newspaper,
+  PawPrint,
+  Play,
+  Rocket,
+  Trophy,
+  type LucideIcon,
+} from "lucide-react";
 import Card from "@/components/common/Card";
 import { storyService } from "@/api/services/storyService";
 import useAuthStore from "@/store/useAuthStore";
@@ -14,55 +29,55 @@ import QuotaExceededOverlay, {
 const ALL_TOPICS: Array<{
   topic: NewsCategory;
   label: string;
-  icon: string;
+  icon: LucideIcon;
   tagline: string;
 }> = [
   {
     topic: "space",
     label: "Space",
-    icon: "\ud83d\ude80",
+    icon: Rocket,
     tagline: "Rockets, planets & stars",
   },
   {
     topic: "animals",
     label: "Animals",
-    icon: "\ud83d\udc3c",
+    icon: PawPrint,
     tagline: "Cute, wild & amazing",
   },
   {
     topic: "technology",
     label: "Robots",
-    icon: "\ud83e\udd16",
+    icon: Bot,
     tagline: "Inventions & gadgets",
   },
   {
     topic: "science",
     label: "Science",
-    icon: "\ud83d\udd2c",
+    icon: Atom,
     tagline: "Experiments & discoveries",
   },
   {
     topic: "nature",
     label: "Nature",
-    icon: "\ud83c\udf3f",
+    icon: Leaf,
     tagline: "Oceans, forests & weather",
   },
   {
     topic: "culture",
     label: "Culture",
-    icon: "\ud83c\udfad",
+    icon: Drama,
     tagline: "Art, music & stories",
   },
   {
     topic: "sports",
     label: "Sports",
-    icon: "\u26bd",
+    icon: Trophy,
     tagline: "Goals, records & teamwork",
   },
   {
     topic: "general",
     label: "General",
-    icon: "\ud83d\udcf0",
+    icon: Newspaper,
     tagline: "A bit of everything",
   },
 ];
@@ -179,12 +194,12 @@ function BouncingDots() {
 
 /** Full-card overlay shown while generating a podcast */
 function GeneratingOverlay({
-  icon,
+  Icon,
   topic,
   message,
   onCancel,
 }: {
-  icon: string;
+  Icon: LucideIcon;
   topic: string;
   message?: string | null;
   onCancel: () => void;
@@ -207,11 +222,11 @@ function GeneratingOverlay({
     >
       {/* Spinning topic icon */}
       <motion.div
-        className="text-5xl mb-3"
+        className="mb-3 flex h-16 w-16 items-center justify-center rounded-2xl border border-white/30 bg-white/20"
         animate={{ rotate: 360 }}
         transition={{ duration: 2, repeat: Infinity, ease: "linear" }}
       >
-        {icon}
+        <Icon className="h-9 w-9" strokeWidth={2.25} />
       </motion.div>
 
       {/* Pulsing ring */}
@@ -424,10 +439,10 @@ function KidsDailyPage() {
           setError("Follow this news club first, then tap Listen Now.");
         } else if (status === 502) {
           setError(
-            "Our story-makers are taking a quick break — try again in a moment! 🌟",
+            "Our story-makers are taking a quick break — try again in a moment!",
           );
         } else {
-          setError("Something went wrong — let's give it another go in a sec! 🦊");
+          setError("Something went wrong — let's give it another go in a sec!");
         }
       } finally {
         abortRef.current = null;
@@ -462,11 +477,11 @@ function KidsDailyPage() {
         animate={{ opacity: 1, y: 0 }}
       >
         <motion.span
-          className="text-5xl inline-block"
+          className="inline-flex h-16 w-16 items-center justify-center rounded-3xl border border-secondary/25 bg-white shadow-kid-md text-primary"
           animate={{ scale: [1, 1.15, 1], rotate: [0, -5, 5, 0] }}
           transition={{ duration: 3, repeat: Infinity }}
         >
-          🌍
+          <Globe2 className="h-9 w-9" strokeWidth={2.1} />
         </motion.span>
         <h1 className="text-2xl md:text-3xl font-bold text-gray-800 mt-2">
           Pick Your News Club
@@ -475,7 +490,7 @@ function KidsDailyPage() {
           Choose a topic card, keep your favorites, and listen anytime
         </p>
         <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/80 border border-primary/20 shadow-sm">
-          <span className="text-sm">🌈</span>
+          <Compass className="h-4 w-4 text-primary" strokeWidth={2.25} />
           <span className="text-sm font-semibold text-gray-700">
             {ALL_TOPICS.length} story channels — pick any to listen
           </span>
@@ -513,6 +528,7 @@ function KidsDailyPage() {
             const isRateLimited = rateLimitRetry?.topic === item.topic;
             const isSubscribed = subscribedTopicList.has(item.topic);
             const isToggling = togglingTopic === item.topic;
+            const TopicIcon = item.icon;
 
             return (
               <motion.div
@@ -536,11 +552,11 @@ function KidsDailyPage() {
                         className={`w-14 h-14 rounded-3xl bg-gradient-to-br ${theme.iconBubble} flex items-center justify-center shadow-sm border border-white/60`}
                       >
                         <motion.div
-                          className="text-4xl"
+                          className="text-gray-800/85"
                           animate={{ scale: [1, 1.04, 1] }}
                           transition={{ duration: 4, repeat: Infinity }}
                         >
-                          {item.icon}
+                          <TopicIcon className="h-8 w-8" strokeWidth={2.1} />
                         </motion.div>
                       </div>
                     </div>
@@ -620,13 +636,16 @@ function KidsDailyPage() {
                               animate={{ rotate: [0, 180] }}
                               transition={{ duration: 1, repeat: Infinity }}
                             >
-                              ⏳
+                              <Clock3 className="h-4 w-4" strokeWidth={2.25} />
                             </motion.span>
                             Wait {rateLimitRetry!.seconds}s
                           </>
                         ) : (
                           <>
-                            <span>▶</span>
+                            <Play
+                              className="h-4 w-4 fill-current"
+                              strokeWidth={2.25}
+                            />
                             Listen Now
                           </>
                         )}
@@ -638,7 +657,7 @@ function KidsDailyPage() {
                   <AnimatePresence>
                     {isGenerating && (
                       <GeneratingOverlay
-                        icon={item.icon}
+                        Icon={TopicIcon}
                         topic={item.label}
                         message={generationMessage}
                         onCancel={handleCancelGeneration}
@@ -654,7 +673,7 @@ function KidsDailyPage() {
 
       <div className="text-center pb-4 text-xs text-gray-500">
         Following {subscribedCount} news club{subscribedCount === 1 ? "" : "s"}
-        . Pick any card and tap Listen — fresh stories every time. ✨
+        . Pick any card and tap Listen — fresh stories every time.
       </div>
     </div>
   );

--- a/frontend/src/pages/StoryPage/index.tsx
+++ b/frontend/src/pages/StoryPage/index.tsx
@@ -2,7 +2,15 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { motion } from "framer-motion";
-import { BookOpen, Film, Globe2, Library, Sparkles } from "lucide-react";
+import {
+  BookOpen,
+  Film,
+  Frown,
+  Globe2,
+  Library,
+  PartyPopper,
+  Sparkles,
+} from "lucide-react";
 import Button from "@/components/common/Button";
 import Loading from "@/components/common/Loading";
 import AgeAwareContent from "@/components/common/AgeAwareContent";
@@ -289,9 +297,9 @@ function StoryPage() {
         <motion.div
           initial={{ scale: 0 }}
           animate={{ scale: 1 }}
-          className="text-6xl mb-4"
+          className="mb-4 flex justify-center"
         >
-          😢
+          <Frown className="h-16 w-16 text-gray-400" strokeWidth={2} />
         </motion.div>
         <h2 className="text-xl font-bold text-gray-800 mb-2">
           {isForbidden ? "Story not available for this account" : "Story not found"}
@@ -353,11 +361,11 @@ function StoryPage() {
           transition={{ delay: 0.1 }}
         >
           <motion.span
-            className="text-2xl"
+            className="inline-flex text-primary"
             animate={{ scale: [1, 1.2, 1] }}
             transition={{ duration: 0.5 }}
           >
-            🎉
+            <PartyPopper className="h-6 w-6" />
           </motion.span>
           <div>
             <p className="font-bold text-gray-800">

--- a/frontend/src/pages/StoryPage/index.tsx
+++ b/frontend/src/pages/StoryPage/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { motion } from "framer-motion";
-import { BookOpen, Film } from "lucide-react";
+import { BookOpen, Film, Globe2, Library, Sparkles } from "lucide-react";
 import Button from "@/components/common/Button";
 import Loading from "@/components/common/Loading";
 import AgeAwareContent from "@/components/common/AgeAwareContent";
@@ -487,7 +487,7 @@ function StoryPage() {
           size="lg"
           className="flex-1"
           onClick={handleNewStory}
-          leftIcon={<span>✨</span>}
+          leftIcon={<Sparkles size={18} />}
         >
           Create New Story
         </Button>
@@ -496,7 +496,7 @@ function StoryPage() {
           size="lg"
           className="flex-1"
           onClick={() => navigate("/library")}
-          leftIcon={<span>📚</span>}
+          leftIcon={<Library size={18} />}
         >
           My Library
         </Button>
@@ -516,7 +516,10 @@ function StoryPage() {
             className="rounded-2xl bg-gradient-to-r from-rose-300 via-pink-300 to-rose-300 hover:from-rose-400 hover:via-pink-400 hover:to-rose-400 px-6 py-3 text-base font-bold text-white shadow-md hover:shadow-lg transition-all"
             onClick={() => setShareOpen(true)}
           >
-            🌐 Share to Content Hub
+            <span className="inline-flex items-center gap-2">
+              <Globe2 size={18} />
+              Share to Content Hub
+            </span>
           </button>
         )}
       </motion.div>

--- a/frontend/src/pages/UploadPage/index.tsx
+++ b/frontend/src/pages/UploadPage/index.tsx
@@ -6,7 +6,6 @@ import ImagePreview from '@/components/upload/ImagePreview'
 import { StreamingVisualizer } from '@/components/streaming/StreamingVisualizer'
 import { PerspectiveContainer } from '@/components/depth/PerspectiveContainer'
 import TiltCard from '@/components/depth/TiltCard'
-import { FloatingElement } from '@/components/depth/ParallaxContainer'
 import { useStreamVisualizationContext } from '@/providers/StreamVisualizationProvider'
 import useStoryStore from '@/store/useStoryStore'
 import useAuthStore from '@/store/useAuthStore'
@@ -18,22 +17,46 @@ import type { AnimationPhase } from '@/types/streaming'
 import LoginPrompt from '@/components/common/LoginPrompt'
 import VoicePicker from '@/components/common/VoicePicker'
 import SuggestedThemes from '@/components/common/SuggestedThemes'
+import {
+  Baby,
+  Cake,
+  Droplets,
+  Heart,
+  Image,
+  ImagePlus,
+  Lightbulb,
+  Mic,
+  Paintbrush,
+  Palette,
+  Pencil,
+  Sparkles,
+  Square,
+  UserRound,
+  UsersRound,
+  XCircle,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
 
-const AGE_GROUPS: { value: AgeGroup; label: string; emoji: string; description: string }[] = [
-  { value: '3-5', label: '3-5 yrs', emoji: '🧒', description: 'Simple & Fun' },
-  { value: '6-8', label: '6-8 yrs', emoji: '👦', description: 'Engaging' },
-  { value: '9-12', label: '9-12 yrs', emoji: '🧑', description: 'Rich Stories' },
+const AGE_GROUPS: {
+  value: AgeGroup
+  label: string
+  icon: LucideIcon
+  description: string
+}[] = [
+  { value: '3-5', label: '3-5 yrs', icon: Baby, description: 'Simple & Fun' },
+  { value: '6-8', label: '6-8 yrs', icon: UserRound, description: 'Engaging' },
+  { value: '9-12', label: '9-12 yrs', icon: UsersRound, description: 'Rich Stories' },
 ]
 
 const ART_THEMES = [
-  { value: 'none', label: 'Keep Original', emoji: '🖼️', description: 'Use your drawing as-is', swatch: 'linear-gradient(135deg, #e5e7eb, #d1d5db)' },
-  { value: 'cartoon', label: 'Cartoon', emoji: '🎨', description: 'Fun cartoon style', swatch: 'linear-gradient(135deg, #FFD700, #FF6B6B)' },
-  { value: 'oil_painting', label: 'Oil Painting', emoji: '🖌️', description: 'Classic oil painting', swatch: 'linear-gradient(135deg, #8B4513, #DAA520)' },
-  { value: 'watercolor', label: 'Watercolor', emoji: '💧', description: 'Soft watercolor', swatch: 'linear-gradient(135deg, #87CEEB, #98FB98)' },
-  { value: 'pixel_art', label: 'Pixel Art', emoji: '👾', description: 'Retro pixel style', swatch: 'linear-gradient(135deg, #00FF00, #0000FF)' },
-  { value: 'anime', label: 'Anime', emoji: '✨', description: 'Anime illustration', swatch: 'linear-gradient(135deg, #FF69B4, #9370DB)' },
-  { value: 'crayon', label: 'Crayon', emoji: '🖍️', description: 'Crayon drawing', swatch: 'linear-gradient(135deg, #FF4500, #FFD700)' },
-  { value: 'storybook', label: 'Storybook', emoji: '📖', description: 'Storybook illustration', swatch: 'linear-gradient(135deg, #DEB887, #8FBC8F)' },
+  { value: 'none', label: 'Keep Original', icon: Image, description: 'Use your drawing as-is', swatch: 'linear-gradient(135deg, #e5e7eb, #d1d5db)' },
+  { value: 'cartoon', label: 'Cartoon', icon: Palette, description: 'Fun cartoon style', swatch: 'linear-gradient(135deg, #FFD700, #FF6B6B)' },
+  { value: 'oil_painting', label: 'Oil Painting', icon: Paintbrush, description: 'Classic oil painting', swatch: 'linear-gradient(135deg, #8B4513, #DAA520)' },
+  { value: 'watercolor', label: 'Watercolor', icon: Droplets, description: 'Soft watercolor', swatch: 'linear-gradient(135deg, #87CEEB, #98FB98)' },
+  { value: 'pixel_art', label: 'Pixel Art', icon: Square, description: 'Retro pixel style', swatch: 'linear-gradient(135deg, #00FF00, #0000FF)' },
+  { value: 'anime', label: 'Anime', icon: Sparkles, description: 'Anime illustration', swatch: 'linear-gradient(135deg, #FF69B4, #9370DB)' },
+  { value: 'crayon', label: 'Crayon', icon: Pencil, description: 'Crayon drawing', swatch: 'linear-gradient(135deg, #FF4500, #FFD700)' },
+  { value: 'storybook', label: 'Storybook', icon: ImagePlus, description: 'Storybook illustration', swatch: 'linear-gradient(135deg, #DEB887, #8FBC8F)' },
 ] as const
 
 const YOUNG_CHILD_THEMES = new Set(['none', 'cartoon', 'crayon', 'watercolor', 'storybook'])
@@ -176,9 +199,9 @@ function UploadPage() {
         animate={{ opacity: 1, y: 0, rotateX: 0 }}
         transition={{ type: 'spring', stiffness: 100 }}
       >
-        <FloatingElement depth="near" float className="inline-block">
-          <span className="text-3xl">✏️</span>
-        </FloatingElement>
+        <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Pencil size={26} />
+        </div>
         <h1 className="text-2xl font-bold text-gray-800 mt-2">Create New Story</h1>
         <p className="text-gray-500 mt-2">Upload your artwork, begin the magical journey</p>
       </motion.div>
@@ -191,7 +214,7 @@ function UploadPage() {
       >
         <TiltCard maxTilt={6} glare dynamicShadow className="w-full">
           <div className="bg-white rounded-card p-6">
-            <StepHeader number={1} title="Upload Your Artwork" emoji="🖼️" />
+            <StepHeader number={1} title="Upload Your Artwork" icon={ImagePlus} />
             <AnimatePresence mode="wait">
               {imagePreviewUrl ? (
                 <motion.div
@@ -234,50 +257,57 @@ function UploadPage() {
       >
         <TiltCard maxTilt={4} glare={false} dynamicShadow className="w-full">
           <div className="bg-white rounded-card p-6">
-            <StepHeader number={2} title="Select Your Age" emoji="🎂" />
+            <StepHeader number={2} title="Select Your Age" icon={Cake} />
             <div className="grid grid-cols-3 gap-4">
-              {AGE_GROUPS.map((group, index) => (
-                <motion.button
-                  key={group.value}
-                  className={`age-select-card p-4 rounded-card border-2 transition-all preserve-3d ${
-                    selectedAgeGroup === group.value
-                      ? 'border-primary bg-primary/10 shadow-lg'
-                      : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
-                  }`}
-                  onClick={() => handleAgeGroupSelect(group.value)}
-                  whileHover={
-                    prefersReducedMotion
-                      ? {}
-                      : {
-                          scale: 1.05,
-                          rotateY: 5,
-                          z: 20,
+              {AGE_GROUPS.map((group, index) => {
+                const Icon = group.icon
+                return (
+                  <motion.button
+                    key={group.value}
+                    className={`age-select-card p-4 rounded-card border-2 transition-all preserve-3d ${
+                      selectedAgeGroup === group.value
+                        ? 'border-primary bg-primary/10 shadow-lg'
+                        : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
+                    }`}
+                    onClick={() => handleAgeGroupSelect(group.value)}
+                    whileHover={
+                      prefersReducedMotion
+                        ? {}
+                        : {
+                            scale: 1.05,
+                            rotateY: 5,
+                            z: 20,
+                          }
+                    }
+                    whileTap={{ scale: 0.95 }}
+                    initial={{ opacity: 0, y: 20, rotateX: 15 }}
+                    animate={{ opacity: 1, y: 0, rotateX: 0 }}
+                    transition={{ delay: 0.2 + index * 0.1 }}
+                  >
+                    <div className="text-center">
+                      <motion.div
+                        className={`mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-lg ${
+                          selectedAgeGroup === group.value
+                            ? 'bg-primary text-white'
+                            : 'bg-gray-100 text-gray-600'
+                        }`}
+                        animate={
+                          selectedAgeGroup === group.value
+                            ? { scale: [1, 1.1, 1], rotate: [0, 5, -5, 0] }
+                            : {}
                         }
-                  }
-                  whileTap={{ scale: 0.95 }}
-                  initial={{ opacity: 0, y: 20, rotateX: 15 }}
-                  animate={{ opacity: 1, y: 0, rotateX: 0 }}
-                  transition={{ delay: 0.2 + index * 0.1 }}
-                >
-                  <div className="text-center">
-                    <motion.span
-                      className="text-4xl block mb-2"
-                      animate={
-                        selectedAgeGroup === group.value
-                          ? { scale: [1, 1.1, 1], rotate: [0, 5, -5, 0] }
-                          : {}
-                      }
-                      transition={{ duration: 0.5 }}
-                    >
-                      {group.emoji}
-                    </motion.span>
-                    <span className="font-bold text-gray-800">{group.label}</span>
-                    <span className="block text-sm text-gray-500 mt-1">
-                      {group.description}
-                    </span>
-                  </div>
-                </motion.button>
-              ))}
+                        transition={{ duration: 0.5 }}
+                      >
+                        <Icon size={24} />
+                      </motion.div>
+                      <span className="font-bold text-gray-800">{group.label}</span>
+                      <span className="block text-sm text-gray-500 mt-1">
+                        {group.description}
+                      </span>
+                    </div>
+                  </motion.button>
+                )
+              })}
             </div>
           </div>
         </TiltCard>
@@ -291,7 +321,7 @@ function UploadPage() {
       >
         <TiltCard maxTilt={4} glare={false} dynamicShadow className="w-full">
           <div className="bg-white rounded-card p-6">
-            <StepHeader number={3} title="Choose Art Style" emoji="🎨" optional />
+            <StepHeader number={3} title="Choose Art Style" icon={Palette} optional />
             <p className="text-gray-500 text-sm mb-4">
               Transform your drawing into a different art style
             </p>
@@ -301,32 +331,35 @@ function UploadPage() {
                   if (!selectedAgeGroup || selectedAgeGroup !== '3-5') return true
                   return YOUNG_CHILD_THEMES.has(t.value)
                 })
-                .map((theme, index) => (
-                  <motion.button
-                    key={theme.value}
-                    className={`rounded-card border-2 transition-all text-center overflow-hidden ${
-                      selectedArtTheme === theme.value
-                        ? 'border-primary bg-primary/10 shadow-lg ring-2 ring-purple-500 scale-105'
-                        : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
-                    }`}
-                    onClick={() => setSelectedArtTheme(theme.value)}
-                    whileHover={prefersReducedMotion ? {} : { scale: 1.05 }}
-                    whileTap={{ scale: 0.95 }}
-                    initial={{ opacity: 0, scale: 0.9 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    transition={{ delay: 0.25 + index * 0.03 }}
-                  >
-                    <div
-                      className="w-full h-8 rounded-t-lg"
-                      style={{ background: theme.swatch }}
-                    />
-                    <div className="p-3 pt-2">
-                      <span className="text-2xl block mb-1">{theme.emoji}</span>
-                      <span className="font-medium text-gray-800 text-sm block">{theme.label}</span>
-                      <span className="text-xs text-gray-500">{theme.description}</span>
-                    </div>
-                  </motion.button>
-                ))}
+                .map((theme, index) => {
+                  const Icon = theme.icon
+                  return (
+                    <motion.button
+                      key={theme.value}
+                      className={`rounded-card border-2 transition-all text-center overflow-hidden ${
+                        selectedArtTheme === theme.value
+                          ? 'border-primary bg-primary/10 shadow-lg ring-2 ring-purple-500 scale-105'
+                          : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
+                      }`}
+                      onClick={() => setSelectedArtTheme(theme.value)}
+                      whileHover={prefersReducedMotion ? {} : { scale: 1.05 }}
+                      whileTap={{ scale: 0.95 }}
+                      initial={{ opacity: 0, scale: 0.9 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ delay: 0.25 + index * 0.03 }}
+                    >
+                      <div
+                        className="w-full h-8 rounded-t-lg"
+                        style={{ background: theme.swatch }}
+                      />
+                      <div className="p-3 pt-2">
+                        <Icon className="mx-auto mb-1 text-gray-700" size={22} />
+                        <span className="font-medium text-gray-800 text-sm block">{theme.label}</span>
+                        <span className="text-xs text-gray-500">{theme.description}</span>
+                      </div>
+                    </motion.button>
+                  )
+                })}
             </div>
           </div>
         </TiltCard>
@@ -343,7 +376,7 @@ function UploadPage() {
             <StepHeader
               number={4}
               title="What Do You Like?"
-              emoji="❤️"
+              icon={Heart}
               optional
             />
             <p className="text-gray-500 text-sm mb-4">
@@ -392,7 +425,7 @@ function UploadPage() {
       >
         <TiltCard maxTilt={4} glare={false} dynamicShadow className="w-full">
           <div className="bg-white rounded-card p-6">
-            <StepHeader number={5} title="Suggested Themes" emoji="💡" optional />
+            <StepHeader number={5} title="Suggested Themes" icon={Lightbulb} optional />
             <SuggestedThemes
               onSelect={(theme) => {
                 if (!selectedInterestsList.includes(theme) && selectedInterestsList.length < 5) {
@@ -417,7 +450,7 @@ function UploadPage() {
             <StepHeader
               number={6}
               title="Choose a Narrator"
-              emoji="🎙️"
+              icon={Mic}
               optional
             />
             <div className="space-y-4">
@@ -470,7 +503,7 @@ function UploadPage() {
             exit={{ opacity: 0, y: -10, scale: 0.95 }}
           >
             <div className="flex items-center gap-2">
-              <span>❌</span>
+              <XCircle size={18} />
               <span>{uploadError}</span>
             </div>
           </motion.div>
@@ -506,11 +539,11 @@ function UploadPage() {
             {isReady ? (
               <>
                 <motion.span
-                  className="text-xl"
+                  className="inline-flex"
                   animate={{ rotate: [0, 10, -10, 0], scale: [1, 1.1, 1] }}
                   transition={{ duration: 2, repeat: Infinity }}
                 >
-                  ✨
+                  <Sparkles size={20} />
                 </motion.span>
                 Generate My Story
               </>
@@ -527,12 +560,12 @@ function UploadPage() {
 function StepHeader({
   number,
   title,
-  emoji,
+  icon: Icon,
   optional = false,
 }: {
   number: number
   title: string
-  emoji: string
+  icon: LucideIcon
   optional?: boolean
 }) {
   return (
@@ -543,9 +576,9 @@ function StepHeader({
       >
         {number}
       </motion.span>
-      <FloatingElement depth="near" float={false}>
-        <span className="text-xl">{emoji}</span>
-      </FloatingElement>
+      <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-gray-600">
+        <Icon size={18} />
+      </span>
       <h2 className="text-lg font-bold text-gray-800">{title}</h2>
       {optional && (
         <span className="text-sm text-gray-400 ml-auto">Optional</span>


### PR DESCRIPTION
## What & why

You previously converted **all emoji → flat icons** across the app, but only the *avatar* slice survived (commit `d6777b57` / #693, via `lib/avatarIcons.tsx`). Every other surface had quietly reverted to raw emoji.

**Root cause (it was a stash + untracked-file loss, not a bad merge):** the broad conversion was stashed on 2026-06-14 during a "pre-land salvage" (`stash@{0}`). It depended on a brand-new `AnimalAvatar/` component that was still **untracked**, so `git stash` (no `-u`) never captured it — the edits that imported it were saved, the component itself vanished, and the broad change was never re-applied.

## What this PR does

Restores the lucide-icon swaps for the **non-avatar** surfaces, rebuilt on current `main`. The merged avatar system is left untouched.

- **Interactive Story** — age/length pickers, "You Chose" marker, section headers, completed-screen CTAs (incl. `Start Story` 🚀→`Rocket` and `End My Story` 🏁→`Flag`, which the original conversion missed)
- **Voice Picker** + **Voice Input button**
- **Image Uploader** — drop / reject / preview states + camera/file tabs
- **Upload Page** — step headers, age cards, art-theme cards, narrator, submit
- **Kids Daily** + **Kids Daily Episode** — topic icons, anchor role icons
- **Story Page** — action buttons

`InteractiveStoryPage` required a 3-way merge against main's `pageState` refactor; main's removal of the mic-consent block dropped the only `Mic` usage (cleaned up to satisfy `noUnusedLocals`).

## Excluded on purpose

- The recovered `AnimalAvatar` component / avatar re-wiring (avatars already render as flat icons on `main`).
- `ContentHubPage/GroupCard` and `LoginPage` stash edits — those were layout/validation tweaks, **not** emoji work.

## Verification

- `tsc -b` — clean
- `vitest run` — 52 files, **446 tests pass**
- `vite build` — succeeds

Related to #437, #44 (surfaces touched). Restores prior UI work; no behavior change beyond icon rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)