### PR TITLE
fix(frontend): keep generation running when the user navigates away (#727)

### DIFF
--- a/frontend/src/hooks/useGenerationNavigator.ts
+++ b/frontend/src/hooks/useGenerationNavigator.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { storyGenerationManager } from "@/services/storyGenerationManager";
 import { interactiveStoryGenerationManager } from "@/services/interactiveStoryGenerationManager";
+import { kidsDailyGenerationManager } from "@/services/kidsDailyGenerationManager";
 
 /**
  * Registers React Router's navigate function with the generation manager
@@ -14,6 +15,7 @@ export function useGenerationNavigator() {
   useEffect(() => {
     storyGenerationManager.registerNavigate(navigate);
     interactiveStoryGenerationManager.registerNavigate(navigate);
+    kidsDailyGenerationManager.registerNavigate(navigate);
   }, [navigate]);
 }
 

--- a/frontend/src/pages/KidsDailyPage/index.tsx
+++ b/frontend/src/pages/KidsDailyPage/index.tsx
@@ -1,5 +1,4 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Atom,
@@ -20,6 +19,8 @@ import Card from "@/components/common/Card";
 import { storyService } from "@/api/services/storyService";
 import useAuthStore from "@/store/useAuthStore";
 import useChildStore from "@/store/useChildStore";
+import useKidsDailyGenerationStore from "@/store/useKidsDailyGenerationStore";
+import { kidsDailyGenerationManager } from "@/services/kidsDailyGenerationManager";
 import type { NewsCategory } from "@/types/api";
 import LoginPrompt from "@/components/common/LoginPrompt";
 import QuotaExceededOverlay, {
@@ -275,17 +276,19 @@ function GeneratingOverlay({
 function KidsDailyPage() {
   const { isAuthenticated } = useAuthStore();
   const { currentChild, defaultChildId } = useChildStore();
-  const navigate = useNavigate();
 
   const childId = currentChild?.child_id || defaultChildId;
   const ageGroup = currentChild?.age_group || "6-8";
 
-  const [generatingTopic, setGeneratingTopic] = useState<NewsCategory | null>(
-    null,
+  // Generation progress lives in the store (#727) so it survives a
+  // navigation away/back; the manager owns the AbortController + the
+  // completion navigation so the episode still opens if the user left.
+  const generatingTopic = useKidsDailyGenerationStore((s) => s.generatingTopic);
+  const generationMessage = useKidsDailyGenerationStore(
+    (s) => s.generationMessage,
   );
-  const [generationMessage, setGenerationMessage] = useState<string | null>(
-    null,
-  );
+  const beginGenerationState = useKidsDailyGenerationStore((s) => s.begin);
+  const setGenerationMessage = useKidsDailyGenerationStore((s) => s.setMessage);
   const [subscribedTopics, setSubscribedTopics] = useState<Set<NewsCategory>>(
     () => new Set(),
   );
@@ -297,7 +300,6 @@ function KidsDailyPage() {
     seconds: number;
   } | null>(null);
   const retryTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
   const subscribedCount = subscribedTopics.size;
   const subscribedTopicList = useMemo(
     () => new Set(subscribedTopics),
@@ -373,11 +375,11 @@ function KidsDailyPage() {
     async (topic: NewsCategory) => {
       if (!childId || generatingTopic) return;
       setError(null);
-      setGeneratingTopic(topic);
-      setGenerationMessage("Joining the news club...");
+      beginGenerationState(topic, "Joining the news club...");
 
-      const controller = new AbortController();
-      abortRef.current = controller;
+      // Controller + completion navigation are owned by the manager so the
+      // run survives this page unmounting mid generation (#727).
+      const signal = kidsDailyGenerationManager.beginGeneration();
 
       try {
         await ensureSubscribed(topic);
@@ -396,16 +398,18 @@ function KidsDailyPage() {
               throw new Error(data.message || "Episode generation failed.");
             },
           },
-          controller.signal,
+          signal,
         );
 
         if (episodeId) {
-          navigate(`/kids-daily/${episodeId}`);
+          kidsDailyGenerationManager.navigateToEpisode(
+            `/kids-daily/${episodeId}`,
+          );
         } else {
           setError("The episode finished, but we could not open it yet.");
         }
       } catch (err: unknown) {
-        if (controller.signal.aborted) return; // user cancelled — do nothing
+        if (signal.aborted) return; // user cancelled — do nothing
 
         const status = (err as { response?: { status?: number } })?.response
           ?.status ?? (err as { status?: number })?.status;
@@ -445,19 +449,23 @@ function KidsDailyPage() {
           setError("Something went wrong — let's give it another go in a sec!");
         }
       } finally {
-        abortRef.current = null;
-        setGeneratingTopic(null);
-        setGenerationMessage(null);
+        // Clears progress only if this run still owns the controller, so a
+        // superseding run (or a cancel) isn't wiped out.
+        kidsDailyGenerationManager.finish(signal);
       }
     },
-    [childId, ageGroup, generatingTopic, ensureSubscribed, navigate],
+    [
+      childId,
+      ageGroup,
+      generatingTopic,
+      ensureSubscribed,
+      beginGenerationState,
+      setGenerationMessage,
+    ],
   );
 
   const handleCancelGeneration = useCallback(() => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    setGeneratingTopic(null);
-    setGenerationMessage(null);
+    kidsDailyGenerationManager.cancel();
   }, []);
 
   if (!isAuthenticated) {

--- a/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
+++ b/frontend/src/pages/MyAgentPage/AgentChatPanel.tsx
@@ -152,17 +152,22 @@ export default function AgentChatPanel({
   const appendStreamingDelta = useAgentChatStore((s) => s.appendStreamingDelta);
   const settleAssistant = useAgentChatStore((s) => s.settleAssistantMessage);
   const adoptServerSession = useAgentChatStore((s) => s.adoptServerSession);
-  const [isStreaming, setIsStreaming] = useState(false);
-  const [statusText, setStatusText] = useState<string | null>(null);
-  const [toolText, setToolText] = useState<string | null>(null);
-  const [errorText, setErrorText] = useState<string | null>(null);
+  // Streaming state lives in the store (#727) so an in-flight reply keeps
+  // running and reappears when the user navigates away and back.
+  const isStreaming = useAgentChatStore((s) => s.isStreaming);
+  const statusText = useAgentChatStore((s) => s.streamStatus);
+  const toolText = useAgentChatStore((s) => s.streamTool);
+  const errorText = useAgentChatStore((s) => s.streamError);
+  const beginStream = useAgentChatStore((s) => s.beginStream);
+  const setStreamStatus = useAgentChatStore((s) => s.setStreamStatus);
+  const setStreamTool = useAgentChatStore((s) => s.setStreamTool);
+  const setStreamError = useAgentChatStore((s) => s.setStreamError);
+  const adoptStreamSession = useAgentChatStore((s) => s.adoptStreamSession);
+  const endStream = useAgentChatStore((s) => s.endStream);
+  const cancelStreamAction = useAgentChatStore((s) => s.cancelStream);
+  const abortIfSessionChanged = useAgentChatStore((s) => s.abortIfSessionChanged);
   const [recurringCharacter, setRecurringCharacter] =
     useState<MemoryCharacter | null>(null);
-  const abortRef = useRef<AbortController | null>(null);
-  // The session id the in-flight stream belongs to. Lets us tell a
-  // user-initiated session switch (abort) apart from the proxy adopting
-  // a server-issued session mid-stream (do not abort).
-  const streamSessionRef = useRef<string | null>(null);
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -173,28 +178,18 @@ export default function AgentChatPanel({
     resetPendingFlow,
   } = useLaunchFlowNavigation();
 
-  useEffect(() => {
-    return () => abortRef.current?.abort();
-  }, []);
+  // NOTE: we deliberately do NOT abort on unmount (#727). Navigating to
+  // another page must let the buddy reply finish — the stream writes into
+  // the shared store, so the message is intact when the user returns.
 
   // Abort an in-flight stream when the user switches to a *different*
   // session than the stream belongs to, so partial deltas don't bleed
-  // into the newly selected session's history (#570). A mid-stream
-  // adopt of the server session keeps streamSessionRef in sync, so that
-  // case does not trip this guard.
+  // into the newly selected session's history (#570). A mid-stream adopt
+  // of the server session keeps the stream's owning session in sync (via
+  // adoptStreamSession), so that case does not trip this guard.
   useEffect(() => {
-    if (
-      abortRef.current &&
-      streamSessionRef.current !== null &&
-      sessionId !== streamSessionRef.current
-    ) {
-      abortRef.current.abort();
-      abortRef.current = null;
-      setIsStreaming(false);
-      setStatusText(null);
-      setToolText(null);
-    }
-  }, [sessionId]);
+    abortIfSessionChanged(sessionId);
+  }, [sessionId, abortIfSessionChanged]);
 
   // Fetch recurring characters for the active child to surface a
   // "Remember…" chip above the composer (#560). Cancelled on
@@ -378,12 +373,7 @@ export default function AgentChatPanel({
   };
 
   const cancelStream = () => {
-    abortRef.current?.abort();
-    abortRef.current = null;
-    streamSessionRef.current = null;
-    setIsStreaming(false);
-    setToolText(null);
-    setStatusText(`${agent.agent_name} stopped.`);
+    cancelStreamAction(`${agent.agent_name} stopped.`);
   };
 
   const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -391,19 +381,15 @@ export default function AgentChatPanel({
     const message = draft.trim();
     if (!message || isStreaming) return;
 
-    const controller = new AbortController();
     const attachedImage = image;
-    abortRef.current?.abort();
-    abortRef.current = controller;
+    // Arm a module-scoped controller in the store (survives unmount, #727)
+    // and capture its signal for this turn's lifecycle checks.
+    const signal = beginStream(sessionId);
     setDraft("");
     clearImage();
-    setErrorText(null);
-    setToolText(null);
-    setStatusText(`${agent.agent_name} is thinking...`);
+    setStreamStatus(`${agent.agent_name} is thinking...`);
     resetPendingFlow();
     appendUserMessage(message);
-    streamSessionRef.current = sessionId;
-    setIsStreaming(true);
 
     try {
       await agentService.streamAgentChat(
@@ -417,40 +403,38 @@ export default function AgentChatPanel({
         },
         {
           onSession: (data: SSESessionData) => {
-            streamSessionRef.current = data.session_id;
+            adoptStreamSession(data.session_id);
             adoptServerSession(data.session_id);
           },
-          onStatus: (data: SSEStatusData) => setStatusText(data.message),
+          onStatus: (data: SSEStatusData) => setStreamStatus(data.message),
           onThinking: (data: SSEThinkingData) => appendStreamingDelta(data.content),
-          onToolUse: (data: SSEToolUseData) => setToolText(data.message),
+          onToolUse: (data: SSEToolUseData) => setStreamTool(data.message),
           onToolResult: (data: SSEToolResultData) =>
-            setToolText(data.message ?? "Specialist finished."),
+            setStreamTool(data.message ?? "Specialist finished."),
           onLaunchFlow,
           onResult: (data) => settleAssistant(resultMessage(data)),
           onError: (data: SSEErrorData) => {
-            setErrorText(data.message);
+            setStreamError(data.message);
             settleAssistant(data.message);
           },
           onComplete: (data: SSEStatusData) => {
-            setStatusText(data.message);
+            setStreamStatus(data.message);
             settleAssistant("");
           },
         },
-        controller.signal,
+        signal,
       );
     } catch (err) {
-      if (!controller.signal.aborted) {
+      if (!signal.aborted) {
         const messageText =
           err instanceof Error
             ? err.message
             : "My Agent chat is temporarily unavailable.";
-        setErrorText(messageText);
+        setStreamError(messageText);
         settleAssistant(messageText);
       }
     } finally {
-      if (abortRef.current === controller) abortRef.current = null;
-      streamSessionRef.current = null;
-      setIsStreaming(false);
+      endStream(signal);
     }
   };
 

--- a/frontend/src/services/__tests__/kidsDailyGenerationManager.test.ts
+++ b/frontend/src/services/__tests__/kidsDailyGenerationManager.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { kidsDailyGenerationManager } from "../kidsDailyGenerationManager";
+import useKidsDailyGenerationStore from "@/store/useKidsDailyGenerationStore";
+
+afterEach(() => {
+  // Leave no controller / progress armed between cases.
+  kidsDailyGenerationManager.cancel();
+});
+
+describe("kidsDailyGenerationManager (#727)", () => {
+  it("beginGeneration arms a fresh signal and reports generating via the store", () => {
+    useKidsDailyGenerationStore.getState().begin("science", "Joining...");
+    const signal = kidsDailyGenerationManager.beginGeneration();
+    expect(signal.aborted).toBe(false);
+    expect(kidsDailyGenerationManager.isGenerating()).toBe(true);
+    expect(kidsDailyGenerationManager.isCurrent(signal)).toBe(true);
+  });
+
+  it("a second beginGeneration supersedes (aborts) the prior run", () => {
+    const first = kidsDailyGenerationManager.beginGeneration();
+    const second = kidsDailyGenerationManager.beginGeneration();
+    expect(first.aborted).toBe(true);
+    expect(second.aborted).toBe(false);
+    expect(kidsDailyGenerationManager.isCurrent(first)).toBe(false);
+    expect(kidsDailyGenerationManager.isCurrent(second)).toBe(true);
+  });
+
+  it("finish clears progress only for the owning signal", () => {
+    useKidsDailyGenerationStore.getState().begin("science", "Joining...");
+    const stale = kidsDailyGenerationManager.beginGeneration();
+    const fresh = kidsDailyGenerationManager.beginGeneration();
+    // A late finally from the superseded run must not wipe the fresh run.
+    kidsDailyGenerationManager.finish(stale);
+    expect(useKidsDailyGenerationStore.getState().generatingTopic).toBe(
+      "science",
+    );
+    kidsDailyGenerationManager.finish(fresh);
+    expect(useKidsDailyGenerationStore.getState().generatingTopic).toBeNull();
+  });
+
+  it("cancel aborts the active run and clears progress", () => {
+    useKidsDailyGenerationStore.getState().begin("animals", "Joining...");
+    const signal = kidsDailyGenerationManager.beginGeneration();
+    kidsDailyGenerationManager.cancel();
+    expect(signal.aborted).toBe(true);
+    expect(useKidsDailyGenerationStore.getState().generatingTopic).toBeNull();
+    expect(kidsDailyGenerationManager.isGenerating()).toBe(false);
+  });
+
+  it("queues completion navigation until a navigate fn registers", () => {
+    const navigate = vi.fn();
+    // No navigate registered yet → queued.
+    kidsDailyGenerationManager.navigateToEpisode("/kids-daily/ep_1");
+    expect(navigate).not.toHaveBeenCalled();
+    // Registering flushes the pending path exactly once.
+    kidsDailyGenerationManager.registerNavigate(navigate);
+    expect(navigate).toHaveBeenCalledWith("/kids-daily/ep_1");
+    // A subsequent completion navigates immediately.
+    kidsDailyGenerationManager.navigateToEpisode("/kids-daily/ep_2");
+    expect(navigate).toHaveBeenCalledWith("/kids-daily/ep_2");
+    expect(navigate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/services/kidsDailyGenerationManager.ts
+++ b/frontend/src/services/kidsDailyGenerationManager.ts
@@ -1,0 +1,71 @@
+/**
+ * Kids Daily generation manager (#727).
+ *
+ * Owns the AbortController and post-completion navigation at *module*
+ * scope so an on-demand episode keeps generating — and still opens when
+ * it finishes — even if the user navigates away from KidsDailyPage mid
+ * generation. Progress state lives in `useKidsDailyGenerationStore`.
+ *
+ * Mirrors `storyGenerationManager`: React Router's navigate is registered
+ * once (via `useGenerationNavigator`) and a completion that fires while no
+ * navigate is registered is queued in `pendingNavigation`.
+ */
+import useKidsDailyGenerationStore from "@/store/useKidsDailyGenerationStore";
+
+type NavigateFn = (path: string) => void
+
+let abortController: AbortController | null = null
+let navigateFn: NavigateFn | null = null
+let pendingNavigation: string | null = null
+
+export const kidsDailyGenerationManager = {
+  registerNavigate(fn: NavigateFn) {
+    navigateFn = fn
+    if (pendingNavigation) {
+      const path = pendingNavigation
+      pendingNavigation = null
+      fn(path)
+    }
+  },
+
+  isGenerating(): boolean {
+    return useKidsDailyGenerationStore.getState().generatingTopic !== null
+  },
+
+  /** Abort any prior run, arm a fresh controller, return its signal. */
+  beginGeneration(): AbortSignal {
+    abortController?.abort()
+    abortController = new AbortController()
+    return abortController.signal
+  },
+
+  /** Navigate now if possible, otherwise queue until navigate registers. */
+  navigateToEpisode(path: string) {
+    if (navigateFn) {
+      navigateFn(path)
+    } else {
+      pendingNavigation = path
+    }
+  },
+
+  /** True only if `signal` still owns the active run (not superseded). */
+  isCurrent(signal: AbortSignal): boolean {
+    return abortController?.signal === signal
+  },
+
+  /** Finish the run that owns `signal`; clears progress + controller. */
+  finish(signal: AbortSignal) {
+    if (abortController?.signal !== signal) return
+    abortController = null
+    useKidsDailyGenerationStore.getState().clear()
+  },
+
+  /** User pressed cancel — abort and reset progress. */
+  cancel() {
+    abortController?.abort()
+    abortController = null
+    useKidsDailyGenerationStore.getState().clear()
+  },
+}
+
+export default kidsDailyGenerationManager

--- a/frontend/src/store/__tests__/useAgentChatStore.test.ts
+++ b/frontend/src/store/__tests__/useAgentChatStore.test.ts
@@ -198,6 +198,88 @@ describe("streaming pipeline", () => {
   });
 });
 
+// #727 — generation must survive navigation. The store owns the
+// AbortController + progress flags so an unmount of AgentChatPanel does
+// not cancel the buddy reply, while explicit Stop / session-switch still do.
+describe("streaming lifecycle (#727)", () => {
+  it("beginStream arms streaming state and returns a live signal", () => {
+    const store = useAgentChatStore.getState();
+    const signal = store.beginStream("s1");
+    const st = useAgentChatStore.getState();
+    expect(st.isStreaming).toBe(true);
+    expect(st.streamingSessionId).toBe("s1");
+    expect(signal.aborted).toBe(false);
+  });
+
+  it("beginStream supersedes (aborts) a prior in-flight stream", () => {
+    const store = useAgentChatStore.getState();
+    const first = store.beginStream("s1");
+    const second = store.beginStream("s1");
+    expect(first.aborted).toBe(true); // superseded
+    expect(second.aborted).toBe(false);
+  });
+
+  it("endStream clears progress for the owning signal", () => {
+    const store = useAgentChatStore.getState();
+    const signal = store.beginStream("s1");
+    store.setStreamStatus("thinking");
+    store.endStream(signal);
+    const st = useAgentChatStore.getState();
+    expect(st.isStreaming).toBe(false);
+    expect(st.streamStatus).toBeNull();
+    expect(st.streamingSessionId).toBeNull();
+  });
+
+  it("endStream is a no-op when a newer stream has taken over", () => {
+    const store = useAgentChatStore.getState();
+    const stale = store.beginStream("s1");
+    store.beginStream("s1"); // newer stream wins the controller
+    store.endStream(stale); // late finally from the stale turn
+    expect(useAgentChatStore.getState().isStreaming).toBe(true);
+  });
+
+  it("cancelStream aborts and leaves a stopped note", () => {
+    const store = useAgentChatStore.getState();
+    const signal = store.beginStream("s1");
+    store.cancelStream("Buddy stopped.");
+    const st = useAgentChatStore.getState();
+    expect(signal.aborted).toBe(true);
+    expect(st.isStreaming).toBe(false);
+    expect(st.streamStatus).toBe("Buddy stopped.");
+  });
+
+  it("abortIfSessionChanged aborts only when switching to a different session", () => {
+    const store = useAgentChatStore.getState();
+    const signal = store.beginStream("s1");
+    // Same session — must NOT abort.
+    store.abortIfSessionChanged("s1");
+    expect(signal.aborted).toBe(false);
+    expect(useAgentChatStore.getState().isStreaming).toBe(true);
+    // Different session — abort to stop cross-session bleed.
+    store.abortIfSessionChanged("s2");
+    expect(signal.aborted).toBe(true);
+    expect(useAgentChatStore.getState().isStreaming).toBe(false);
+  });
+
+  it("adoptStreamSession keeps the guard aligned with a server-issued id", () => {
+    const store = useAgentChatStore.getState();
+    const signal = store.beginStream(null);
+    store.adoptStreamSession("server_1");
+    // The selected session now equals the adopted one — no abort.
+    store.abortIfSessionChanged("server_1");
+    expect(signal.aborted).toBe(false);
+    expect(useAgentChatStore.getState().streamingSessionId).toBe("server_1");
+  });
+
+  it("reset aborts an active stream", () => {
+    const store = useAgentChatStore.getState();
+    const signal = store.beginStream("s1");
+    useAgentChatStore.getState().reset();
+    expect(signal.aborted).toBe(true);
+    expect(useAgentChatStore.getState().isStreaming).toBe(false);
+  });
+});
+
 describe("adoptServerSession", () => {
   it("sets currentSessionId only when none is selected", () => {
     useAgentChatStore.getState().adoptServerSession("server_1");

--- a/frontend/src/store/useAgentChatStore.ts
+++ b/frontend/src/store/useAgentChatStore.ts
@@ -28,6 +28,18 @@ interface AgentChatState {
   isLoadingMessages: boolean;
   error: string | null;
 
+  // --- Navigation-surviving streaming state (#727) ---------------------
+  // These live in the store (not AgentChatPanel local state) so an
+  // in-flight buddy reply keeps running and the progress/result reappear
+  // when the user navigates away and back. The AbortController is held at
+  // module scope below for the same reason.
+  isStreaming: boolean;
+  streamStatus: string | null;
+  streamTool: string | null;
+  streamError: string | null;
+  /** The session the active stream belongs to (cross-session bleed guard). */
+  streamingSessionId: string | null;
+
   loadSessions: (childId: string) => Promise<void>;
   selectSession: (sessionId: string) => Promise<void>;
   newSession: (childId: string) => Promise<AgentChatSessionSummary>;
@@ -44,8 +56,26 @@ interface AgentChatState {
   // Reconcile the server-issued session id from the first SSE `session`
   // event when the turn started without a selected session.
   adoptServerSession: (sessionId: string) => void;
+  // --- Streaming lifecycle (#727) -------------------------------------
+  /** Abort any prior stream, arm a fresh controller, return its signal. */
+  beginStream: (sessionId: string | null) => AbortSignal;
+  setStreamStatus: (text: string | null) => void;
+  setStreamTool: (text: string | null) => void;
+  setStreamError: (text: string | null) => void;
+  /** Keep the stream's owning session in sync when the server adopts one. */
+  adoptStreamSession: (sessionId: string) => void;
+  /** Clear progress flags; no-op if a newer stream has taken over. */
+  endStream: (signal?: AbortSignal) => void;
+  /** User pressed Stop — abort and leave a "stopped" note. */
+  cancelStream: (note?: string) => void;
+  /** Abort the active stream if the user switched to a different session. */
+  abortIfSessionChanged: (currentSessionId: string | null) => void;
   reset: () => void;
 }
+
+// Module-scoped so it outlives any single mount of AgentChatPanel — a
+// component unmount (navigation) must NOT abort the buddy reply (#727).
+let streamAbort: AbortController | null = null;
 
 let _counter = 0;
 function nextId(prefix: string): string {
@@ -69,6 +99,11 @@ const useAgentChatStore = create<AgentChatState>((set, get) => ({
   isLoadingSessions: false,
   isLoadingMessages: false,
   error: null,
+  isStreaming: false,
+  streamStatus: null,
+  streamTool: null,
+  streamError: null,
+  streamingSessionId: null,
 
   loadSessions: async (childId) => {
     set({ isLoadingSessions: true, error: null });
@@ -228,7 +263,73 @@ const useAgentChatStore = create<AgentChatState>((set, get) => ({
     }
   },
 
-  reset: () =>
+  beginStream: (sessionId) => {
+    // Supersede any prior in-flight stream so two replies never interleave.
+    streamAbort?.abort();
+    streamAbort = new AbortController();
+    set({
+      isStreaming: true,
+      streamStatus: null,
+      streamTool: null,
+      streamError: null,
+      streamingSessionId: sessionId,
+    });
+    return streamAbort.signal;
+  },
+
+  setStreamStatus: (text) => set({ streamStatus: text }),
+  setStreamTool: (text) => set({ streamTool: text }),
+  setStreamError: (text) => set({ streamError: text }),
+
+  adoptStreamSession: (sessionId) => set({ streamingSessionId: sessionId }),
+
+  endStream: (signal) => {
+    // A newer beginStream() may have replaced the controller while a stale
+    // turn was finishing; if so, leave the fresh stream's state intact.
+    if (signal && streamAbort && streamAbort.signal !== signal) return;
+    streamAbort = null;
+    set({
+      isStreaming: false,
+      streamStatus: null,
+      streamTool: null,
+      streamingSessionId: null,
+    });
+  },
+
+  cancelStream: (note) => {
+    streamAbort?.abort();
+    streamAbort = null;
+    set({
+      isStreaming: false,
+      streamStatus: note ?? null,
+      streamTool: null,
+      streamingSessionId: null,
+    });
+  },
+
+  abortIfSessionChanged: (currentSessionId) => {
+    const { isStreaming, streamingSessionId } = get();
+    if (
+      isStreaming &&
+      streamingSessionId !== null &&
+      currentSessionId !== streamingSessionId
+    ) {
+      streamAbort?.abort();
+      streamAbort = null;
+      set({
+        isStreaming: false,
+        streamStatus: null,
+        streamTool: null,
+        streamingSessionId: null,
+      });
+    }
+  },
+
+  reset: () => {
+    // Active stream belongs to the prior child/session — abort it so it
+    // can't write into the next child's freshly-loaded history.
+    streamAbort?.abort();
+    streamAbort = null;
     set({
       sessions: [],
       currentSessionId: null,
@@ -236,7 +337,13 @@ const useAgentChatStore = create<AgentChatState>((set, get) => ({
       isLoadingSessions: false,
       isLoadingMessages: false,
       error: null,
-    }),
+      isStreaming: false,
+      streamStatus: null,
+      streamTool: null,
+      streamError: null,
+      streamingSessionId: null,
+    });
+  },
 }));
 
 export default useAgentChatStore;

--- a/frontend/src/store/useKidsDailyGenerationStore.ts
+++ b/frontend/src/store/useKidsDailyGenerationStore.ts
@@ -1,0 +1,35 @@
+/**
+ * Kids Daily on-demand generation state (#727).
+ *
+ * Holds the "which topic is generating + status line" out of KidsDailyPage
+ * component state so a navigation away (and back) doesn't drop the
+ * in-flight episode. The fetch + completion navigation are driven by
+ * `kidsDailyGenerationManager`, which owns the AbortController at module
+ * scope. This mirrors the proven `useStoryStore` + `storyGenerationManager`
+ * split already used by Image-to-Story.
+ */
+import { create } from "zustand";
+import type { NewsCategory } from "@/types/api";
+
+interface KidsDailyGenerationState {
+  /** Topic whose episode is generating right now, or null when idle. */
+  generatingTopic: NewsCategory | null;
+  /** Kid-friendly progress line shown in the generation overlay. */
+  generationMessage: string | null;
+
+  begin: (topic: NewsCategory, message: string) => void;
+  setMessage: (message: string | null) => void;
+  clear: () => void;
+}
+
+const useKidsDailyGenerationStore = create<KidsDailyGenerationState>((set) => ({
+  generatingTopic: null,
+  generationMessage: null,
+
+  begin: (topic, message) =>
+    set({ generatingTopic: topic, generationMessage: message }),
+  setMessage: (message) => set({ generationMessage: message }),
+  clear: () => set({ generatingTopic: null, generationMessage: null }),
+}));
+
+export default useKidsDailyGenerationStore;


### PR DESCRIPTION
## What & why
Children tap around while they wait. Today that cancels their work: leaving a page during generation either **aborts the request** or **drops the result**. This makes generation survive navigation on the two broken surfaces.

Fixes #727

## Root cause
Generation state lived in the page component, so unmount = cancel/lose:
- **My Agent / Talk-to-Buddy chat** — `abort()` ran in a `useEffect` cleanup on unmount (`AgentChatPanel.tsx`).
- **Kids Daily** — progress + result were component `useState`; lost on unmount, episode never opened.

(Image-to-Story, Interactive Story, and Video already survive — they use module-level managers / background jobs. We reuse that exact pattern.)

## Changes
- **`useAgentChatStore`** now owns the streaming `AbortController` (module scope) + progress flags. New lifecycle actions: `beginStream`, `endStream(signal)`, `cancelStream`, `abortIfSessionChanged`, `adoptStreamSession`. `endStream` is signal-guarded so a stale turn's `finally` can't wipe a fresh stream.
- **`AgentChatPanel`** reads streaming state from the store and **no longer aborts on unmount** — only on explicit **Stop** or a real **session switch** (cross-session bleed guard preserved).
- **`useKidsDailyGenerationStore`** + **`kidsDailyGenerationManager`** (new) own Kids Daily progress, the `AbortController`, and **post-completion navigation** via `useGenerationNavigator`, so the episode opens even if the user left.

## Out of scope (follow-up)
Backend background-job queue so non-video streams continue after a **full** client disconnect / tab close (they currently stop on `request.is_disconnected()`). Tracked in #727's "Out of scope" note.

## Acceptance criteria
- [x] Buddy reply continues + is present after navigating away and back.
- [x] Kids Daily keeps generating; episode is reachable on completion.
- [x] Explicit Stop still cancels; session switch still aborts (no bleed).
- [x] Unit tests for store survival + manager supersede/cancel/queue-navigate.

## Testing
- `vitest run` — **459 passed** (incl. 28 in the two touched/new specs).
- `tsc --noEmit` clean; eslint clean on changed files (2 pre-existing `useStarter` warnings on main are untouched).

> Note: branched off `main` while a parallel session is editing other files; this PR touches only the 8 files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
