### PR TITLE
fix(kids-daily): stop speaking guest/host names aloud + let kids pick the Guest Anchor

### DIFF
--- a/backend/src/agents/kids_daily_agent.py
+++ b/backend/src/agents/kids_daily_agent.py
@@ -102,6 +102,23 @@ ROLE_DISPLAY_NAMES: Dict[str, Optional[str]] = {
     "guest": None,
 }
 
+def strip_self_name_prefix(text: str, speaker_name: Optional[str]) -> str:
+    """Remove a leading ``"Name:"`` / ``"Name says:"`` self-introduction.
+
+    Speaker attribution belongs in ``display_name`` / the role label, not in the
+    spoken sentence — otherwise TTS reads the name aloud and the UI shows it
+    twice. We only strip the line's *own* speaker name (case-insensitive), so
+    legitimate content like ``"Today: we learned..."`` is never touched.
+    """
+    if not text or not speaker_name:
+        return text
+    name = re.escape(speaker_name.strip())
+    if not name:
+        return text
+    pattern = rf"^\s*{name}\s*(?:says|said)?\s*[:\-—]\s*"
+    return re.sub(pattern, "", text, count=1, flags=re.IGNORECASE).lstrip()
+
+
 # Age rules for text conversion
 AGE_RULES: Dict[str, Dict[str, Any]] = {
     "3-5": {"max_sentences": 2, "max_words": 70, "tone": "warm and very simple"},
@@ -542,48 +559,51 @@ def _build_line_text(
 ) -> str:
     bucket = _age_bucket(age_group)
 
+    # NOTE: text is kept name-free. Speaker attribution comes from
+    # ``DialogueLine.display_name`` / role label, never from the spoken
+    # sentence — otherwise TTS reads the name aloud ("Duo, great question").
     if role == "curious_kid":
         if bucket == "3-5":
             prompts = [
-                f"Mimi: Why is the {topic} news so special?",
-                f"Mimi: What happened first in this {topic} story?",
-                f"Mimi: Can this help kids like me?",
+                f"Why is the {topic} news so special?",
+                f"What happened first in this {topic} story?",
+                "Can this help kids like me?",
             ]
         elif bucket in {"6-8"}:
             prompts = [
-                f"Mimi: How did this {topic} story begin?",
-                f"Mimi: What if we tried this idea at school?",
-                f"Mimi: Why does this matter in real life?",
+                f"How did this {topic} story begin?",
+                "What if we tried this idea at school?",
+                "Why does this matter in real life?",
             ]
         else:
             prompts = [
-                f"Mimi: But what about the hardest part of this {topic} challenge?",
-                "Mimi: How do experts know this will work long-term?",
-                "Mimi: What could go wrong, and how can people prepare?",
+                f"But what about the hardest part of this {topic} challenge?",
+                "How do experts know this will work long-term?",
+                "What could go wrong, and how can people prepare?",
             ]
         return prompts[idx % len(prompts)]
 
     if role == "guest":
-        return f"{guest_name} says: I can help explain this with a fun example from my own adventures!"
+        return "I can help explain this with a fun example from my own adventures!"
 
     # fun_expert
     if bucket == "3-5":
         answers = [
-            f"Duo: Great question! Think of {topic} like building a tiny helper for our world.",
-            "Duo: People worked together carefully, step by step, to keep everyone safe.",
-            "Duo: Yes. Small kind actions from kids can make a big difference.",
+            f"Great question! Think of {topic} like building a tiny helper for our world.",
+            "People worked together carefully, step by step, to keep everyone safe.",
+            "Yes. Small kind actions from kids can make a big difference.",
         ]
     elif bucket in {"6-8"}:
         answers = [
-            f"Duo: Imagine {topic} as a team puzzle where each piece solves part of the problem.",
-            "Duo: Scientists tested ideas, compared results, and improved the plan.",
-            "Duo: It matters because it can shape what we learn, build, and protect next.",
+            f"Imagine {topic} as a team puzzle where each piece solves part of the problem.",
+            "Scientists tested ideas, compared results, and improved the plan.",
+            "It matters because it can shape what we learn, build, and protect next.",
         ]
     else:
         answers = [
-            f"Duo: The big idea is that {topic} combines evidence, tradeoffs, and long-term planning.",
-            "Duo: Researchers validate with repeated observations and peer review.",
-            "Duo: Policy, engineering, and community behavior all affect final outcomes.",
+            f"The big idea is that {topic} combines evidence, tradeoffs, and long-term planning.",
+            "Researchers validate with repeated observations and peer review.",
+            "Policy, engineering, and community behavior all affect final outcomes.",
         ]
     return answers[idx % len(answers)]
 
@@ -606,13 +626,17 @@ def _build_mock_dialogue_script(
 
         text = _build_line_text(role, topic, age_group, idx, guest_name)
 
+        # Guest has no fixed persona name, so its display label is the chosen
+        # character. curious_kid/fun_expert use their fixed Mimi/Duo labels.
+        display_name = guest_name if role == "guest" else ROLE_DISPLAY_NAMES.get(role)
+
         start = round(current_time, 2)
         end = round(current_time + line_duration, 2)
         lines.append(
             DialogueLine(
                 role=role,
                 text=text,
-                display_name=ROLE_DISPLAY_NAMES.get(role),
+                display_name=display_name,
                 timestamp_start=start,
                 timestamp_end=end,
             )
@@ -786,8 +810,8 @@ async def _generate_dialogue_with_sdk(
         )
         normalized_lines[midpoint] = DialogueLine(
             role="guest",
-            text=f"{actual_guest} joins us with a fun tip: keep being curious and kind!",
-            display_name=None,
+            text="Here is a fun tip from me: keep being curious and kind!",
+            display_name=actual_guest,
             timestamp_start=guest_start,
             timestamp_end=guest_end,
         )
@@ -802,6 +826,13 @@ async def _generate_dialogue_with_sdk(
     actual_guest = (
         str(result_data.get("guest_character") or guest_name).strip() or guest_name
     )
+
+    # Label guest lines with the chosen character and defensively strip any
+    # self-name prefix the model may still have emitted (e.g. "Duo: ...").
+    for line in normalized_lines:
+        if line.role == "guest":
+            line.display_name = actual_guest
+        line.text = strip_self_name_prefix(line.text, line.display_name)
 
     script = DialogueScript(
         lines=normalized_lines,
@@ -822,6 +853,29 @@ async def _generate_dialogue_with_sdk(
 # ===========================================================================
 # Guest anchor resolution
 # ===========================================================================
+
+
+def _resolve_guest_choice(
+    requested: Optional[str],
+    characters: List[Dict[str, Any]],
+    fallback: str,
+) -> str:
+    """Honor the child's Guest Anchor pick if it's in their own roster.
+
+    Matching is case-insensitive and whitespace-tolerant. An unknown or empty
+    request falls back to the most-frequent character (``characters`` is sorted
+    by appearance count), then to ``fallback`` — so a spoofed or stale name can
+    never put an arbitrary character on the show.
+    """
+    most_frequent = characters[0].get("name", fallback) if characters else fallback
+    if not requested or not requested.strip():
+        return most_frequent
+    target = requested.strip().casefold()
+    for character in characters:
+        name = str(character.get("name", "")).strip()
+        if name and name.casefold() == target:
+            return name
+    return most_frequent
 
 
 def _default_guest(child_id: Optional[str]) -> str:
@@ -933,8 +987,16 @@ async def generate_kids_daily_dialogue(
     child_id: Optional[str] = None,
     news_url: Optional[str] = None,
     user_id: str = "",
+    guest_character: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Generate Kids Daily dialogue script with safety metadata."""
+    """Generate Kids Daily dialogue script with safety metadata.
+
+    ``guest_character`` is the child's explicit Guest Anchor pick. It is honored
+    only when it matches a character the child actually owns (validated against
+    ``character_repo``); otherwise we fall back to the most-frequent character,
+    then to a deterministic default. This keeps the guest tied to the child's
+    own art and prevents an arbitrary name being injected via the API.
+    """
 
     source_text = _clean_source_text(news_text, news_url)
     topic = _headline_from_text(source_text)
@@ -949,7 +1011,7 @@ async def generate_kids_daily_dialogue(
         try:
             characters = await character_repo.get_characters(user_id, child_id)
             if characters:
-                guest_name = characters[0].get("name", guest_name)
+                guest_name = _resolve_guest_choice(guest_character, characters, guest_name)
         except Exception:
             pass  # Fall back to default guest
 
@@ -1016,6 +1078,7 @@ async def generate_kids_daily_episode(
     category: str,
     news_url: Optional[str] = None,
     user_id: str = "",
+    guest_character: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Compose kid summary + dialogue script payload for Kids Daily."""
 
@@ -1036,6 +1099,7 @@ async def generate_kids_daily_episode(
         child_id=child_id,
         news_url=news_url,
         user_id=user_id,
+        guest_character=guest_character,
     )
 
     return {
@@ -1060,6 +1124,7 @@ async def stream_kids_daily_generation(
     category: str,
     news_url: Optional[str] = None,
     user_id: str = "",
+    guest_character: Optional[str] = None,
 ) -> AsyncGenerator[Dict[str, Any], None]:
     """Stream Kids Daily generation progress events."""
 
@@ -1083,6 +1148,7 @@ async def stream_kids_daily_generation(
         category=category,
         news_url=news_url,
         user_id=user_id,
+        guest_character=guest_character,
     )
 
     yield {

--- a/backend/src/api/models.py
+++ b/backend/src/api/models.py
@@ -539,6 +539,11 @@ class KidsDailyRequest(BaseModel):
     age_group: AgeGroup = Field(..., description="Age group")
     child_id: Optional[str] = Field(None, description="Child ID (optional)")
     category: NewsCategory = Field(default=NewsCategory.GENERAL, description="Topic category")
+    guest_character: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Chosen Guest Anchor name; honored only if the child owns it",
+    )
 
 
 class KidsDailyOnDemandRequest(BaseModel):
@@ -546,6 +551,11 @@ class KidsDailyOnDemandRequest(BaseModel):
     child_id: str = Field(..., min_length=1, max_length=100, description="Child ID")
     category: NewsCategory = Field(default=NewsCategory.GENERAL, description="Topic category")
     age_group: AgeGroup = Field(..., description="Age group")
+    guest_character: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Chosen Guest Anchor name; honored only if the child owns it",
+    )
 
 
 class KidsDailyRateLimitResponse(BaseModel):

--- a/backend/src/api/routes/kids_daily.py
+++ b/backend/src/api/routes/kids_daily.py
@@ -497,6 +497,7 @@ async def _build_episode(
             category=request.category.value,
             news_url=request.news_url,
             user_id=user.user_id,
+            guest_character=request.guest_character,
         )
     except Exception:
         # Graceful fallback to deterministic baseline conversion
@@ -510,14 +511,14 @@ async def _build_episode(
                 "lines": [
                     {
                         "role": "curious_kid",
-                        "text": "Mimi: What happened in this story?",
+                        "text": "What happened in this story?",
                         "display_name": "Mimi",
                         "timestamp_start": 0.0,
                         "timestamp_end": 4.0,
                     },
                     {
                         "role": "fun_expert",
-                        "text": "Duo: Here is a safe and simple explanation for kids.",
+                        "text": "Here is a safe and simple explanation for kids.",
                         "display_name": "Duo",
                         "timestamp_start": 4.0,
                         "timestamp_end": 8.0,
@@ -845,6 +846,7 @@ async def generate_kids_daily_on_demand(
         category=request.category,
         news_text=news_text,
         news_url=None,
+        guest_character=request.guest_character,
     )
     result = await _build_episode(build_request, user, source="on_demand")
     await usage_repo.increment(user.user_id, "kids_daily")
@@ -920,6 +922,7 @@ async def generate_kids_daily_on_demand_stream(
         category=request.category,
         news_text=news_text,
         news_url=None,
+        guest_character=request.guest_character,
     )
 
     async def event_generator() -> AsyncGenerator[str, None]:
@@ -938,6 +941,7 @@ async def generate_kids_daily_on_demand_stream(
             category=build_request.category.value,
             news_url=None,
             user_id=user.user_id,
+            guest_character=build_request.guest_character,
         ):
             if await http_request.is_disconnected():
                 logger.info("Client disconnected during on-demand script generation, aborting")
@@ -1012,6 +1016,7 @@ async def generate_kids_daily_stream(
             category=request.category.value,
             news_url=request.news_url,
             user_id=user.user_id,
+            guest_character=request.guest_character,
         ):
             if await http_request.is_disconnected():
                 logger.info("Client disconnected during kids daily generation, aborting")

--- a/backend/src/prompts/morning-show.md
+++ b/backend/src/prompts/morning-show.md
@@ -15,7 +15,7 @@ Return strict JSON with this shape:
   "lines": [
     {
       "role": "curious_kid | fun_expert | guest",
-      "text": "Mimi: Why is this so cool?",
+      "text": "Why is this so cool?",
       "display_name": "Mimi",
       "timestamp_start": 0.0,
       "timestamp_end": 4.2
@@ -28,7 +28,8 @@ Return strict JSON with this shape:
 ## Rules
 - Keep language age-appropriate for the requested age group.
 - Use a conversational rhythm between Mimi (Curious Kid) and Duo (Fun Expert).
-- Prefix dialogue text with the character name (e.g., "Mimi: ..." or "Duo: ...").
+- Do NOT put the speaker's name in `text` — the name lives only in `display_name`. The `text` is spoken aloud by TTS, so a name there would be read out loud (e.g. "Duo, great question"). Write only what the character actually says.
+- Set `display_name` to "Mimi" for `curious_kid`, "Duo" for `fun_expert`, and the guest_character's name for `guest`.
 - Include a guest anchor line if guest_character is provided.
 - Keep every line positive and child-safe.
 - Do not include markdown fences or extra keys.

--- a/backend/src/services/tts_service.py
+++ b/backend/src/services/tts_service.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 from datetime import datetime
 from pathlib import Path
@@ -520,6 +521,22 @@ def _voice_assignment_for_age(age_group: str) -> Dict[str, Dict[str, float | str
     return table.get(age_group, table["6-8"])
 
 
+def _strip_self_name_prefix(text: str, speaker_name: Optional[str]) -> str:
+    """Strip a leading ``"Name:"`` / ``"Name says:"`` self-introduction.
+
+    Only the line's *own* speaker name is removed (case-insensitive), so real
+    content like ``"Today: we learned..."`` is never touched. Mirrors the
+    agent-side guard in ``kids_daily_agent`` for defense-in-depth.
+    """
+    if not text or not speaker_name:
+        return text
+    name = re.escape(str(speaker_name).strip())
+    if not name:
+        return text
+    pattern = rf"^\s*{name}\s*(?:says|said)?\s*[:\-—]\s*"
+    return re.sub(pattern, "", text, count=1, flags=re.IGNORECASE).lstrip()
+
+
 def _extract_lines(dialogue_script: Any) -> List[Dict[str, Any]]:
     if isinstance(dialogue_script, dict):
         return dialogue_script.get("lines", []) or []
@@ -552,6 +569,16 @@ async def generate_multi_speaker_audio(dialogue_script: Any, age_group: str) -> 
     lines = _extract_lines(dialogue_script)
     if not lines:
         return {}
+
+    # Defense-in-depth: never let a speaker's own name leak into synthesized
+    # audio. Generators keep ``text`` name-free, but if a stale/cached script
+    # still carries a "Name: ..." prefix we strip it here using the line's own
+    # display_name so the child never hears "Duo, great question."
+    for line in lines:
+        if isinstance(line, dict):
+            line["text"] = _strip_self_name_prefix(
+                str(line.get("text", "")), line.get("display_name")
+            )
 
     voices = _voice_assignment_for_age(age_group)
     audio_urls: Dict[str, str] = {}

--- a/backend/tests/api/test_kids_daily_character_names.py
+++ b/backend/tests/api/test_kids_daily_character_names.py
@@ -22,7 +22,11 @@ class TestCharacterNamesInMockOutput:
     """Validate character names appear in mock-generated dialogue."""
 
     def test_mock_dialogue_lines_have_display_names(self):
-        """Mock output must include display_name on every line (#140)."""
+        """Mock output must include display_name on every line (#140).
+
+        The guest's label is the chosen Guest Anchor (not None), so the UI can
+        attribute the line without the name being spoken aloud.
+        """
         script = _build_mock_dialogue_script("space discovery", "6-8", "Professor Owl")
         for line in script.lines:
             if line.role == "curious_kid":
@@ -30,16 +34,20 @@ class TestCharacterNamesInMockOutput:
             elif line.role == "fun_expert":
                 assert line.display_name == "Duo"
             elif line.role == "guest":
-                assert line.display_name is None
+                assert line.display_name == "Professor Owl"
 
-    def test_mock_dialogue_text_uses_character_names(self):
-        """Mock builder should prefix text with character names where natural (#140)."""
+    def test_mock_dialogue_text_is_name_free(self):
+        """Spoken text must NOT contain the speaker's name — it is read by TTS.
+
+        Attribution lives in display_name / the role label; baking "Mimi:" /
+        "Duo:" into text made the narrator say the name aloud and doubled it on
+        screen. The name must never start the spoken sentence.
+        """
         script = _build_mock_dialogue_script("robots", "6-8", "Professor Owl")
         for line in script.lines:
-            if line.role == "curious_kid":
-                assert line.text.startswith("Mimi: "), f"curious_kid line should start with 'Mimi: ', got: {line.text!r}"
-            elif line.role == "fun_expert":
-                assert line.text.startswith("Duo: "), f"fun_expert line should start with 'Duo: ', got: {line.text!r}"
+            assert not line.text.startswith("Mimi:"), line.text
+            assert not line.text.startswith("Duo:"), line.text
+            assert not line.text.startswith("Professor Owl"), line.text
 
     def test_role_display_names_constant(self):
         """ROLE_DISPLAY_NAMES must map correctly (#140)."""
@@ -73,6 +81,7 @@ class TestCharacterNamesInAgentOutput:
             age_group="3-5",
         )
         lines = result["dialogue_script"]["lines"]
+        guest_name = result["dialogue_script"]["guest_character"]
         assert len(lines) > 0
         for line in lines:
             if line["role"] == "curious_kid":
@@ -80,7 +89,8 @@ class TestCharacterNamesInAgentOutput:
             elif line["role"] == "fun_expert":
                 assert line["display_name"] == "Duo"
             elif line["role"] == "guest":
-                assert line["display_name"] is None
+                # Guest is labeled with the chosen character, not None.
+                assert line["display_name"] == guest_name
 
 
 class TestTTSVoiceUnchanged:

--- a/backend/tests/contracts/test_kids_daily_guest_anchor.py
+++ b/backend/tests/contracts/test_kids_daily_guest_anchor.py
@@ -1,0 +1,133 @@
+"""
+Kids Daily — Guest Anchor selection + name-prefix bug fix.
+
+Covers two defects:
+1. Speaker names must NOT appear in spoken `text` (they belong in display_name /
+   role label) — otherwise TTS reads the name aloud and the UI shows it twice.
+2. When a child has 2+ characters, the user can choose which one is the Guest
+   Anchor; an unknown/spoofed pick falls back to the most-frequent character.
+"""
+
+import pytest
+
+from backend.src.agents import kids_daily_agent as agent
+from backend.src.agents.kids_daily_agent import (
+    ROLE_DISPLAY_NAMES,
+    _build_mock_dialogue_script,
+    _resolve_guest_choice,
+    generate_kids_daily_dialogue,
+    strip_self_name_prefix,
+)
+from backend.src.services.tts_service import _strip_self_name_prefix as tts_strip
+
+
+# ---------------------------------------------------------------------------
+# Issue 1: spoken text is name-free
+# ---------------------------------------------------------------------------
+class TestNameNotInSpokenText:
+    def test_mock_lines_do_not_prefix_speaker_name(self):
+        script = _build_mock_dialogue_script("space", "6-8", "Lightning Dog")
+        for line in script.lines:
+            assert not line.text.startswith("Mimi:"), line.text
+            assert not line.text.startswith("Duo:"), line.text
+            # Guest must not announce its own name either.
+            assert not line.text.startswith("Lightning Dog"), line.text
+
+    def test_curious_kid_and_expert_keep_fixed_display_names(self):
+        script = _build_mock_dialogue_script("animals", "3-5", "Rainbow Cat")
+        for line in script.lines:
+            if line.role == "curious_kid":
+                assert line.display_name == ROLE_DISPLAY_NAMES["curious_kid"] == "Mimi"
+            elif line.role == "fun_expert":
+                assert line.display_name == ROLE_DISPLAY_NAMES["fun_expert"] == "Duo"
+
+    def test_guest_line_labeled_with_chosen_character(self):
+        script = _build_mock_dialogue_script("science", "9-12", "Rainbow Cat")
+        guest_lines = [ln for ln in script.lines if ln.role == "guest"]
+        assert guest_lines, "mock script should contain a guest line"
+        for line in guest_lines:
+            assert line.display_name == "Rainbow Cat"
+
+    @pytest.mark.parametrize(
+        "text,name,expected",
+        [
+            ("Duo: Great question!", "Duo", "Great question!"),
+            ("Mimi: Why is this cool?", "Mimi", "Why is this cool?"),
+            ("Lightning Dog says: Hello!", "Lightning Dog", "Hello!"),
+            ("duo - hi there", "Duo", "hi there"),
+            # Must NOT strip legitimate content that merely contains a colon.
+            ("Today: we learned to share.", "Duo", "Today: we learned to share."),
+            ("No prefix here.", "Mimi", "No prefix here."),
+            ("Anything", None, "Anything"),
+        ],
+    )
+    def test_strip_self_name_prefix(self, text, name, expected):
+        assert strip_self_name_prefix(text, name) == expected
+        # The TTS-side guard mirrors the agent-side guard.
+        assert tts_strip(text, name) == expected
+
+
+# ---------------------------------------------------------------------------
+# Issue 2: user-chosen Guest Anchor
+# ---------------------------------------------------------------------------
+class TestResolveGuestChoice:
+    ROSTER = [
+        {"name": "Lightning Dog", "appearance_count": 9},
+        {"name": "Rainbow Cat", "appearance_count": 3},
+    ]
+
+    def test_honors_valid_pick(self):
+        assert _resolve_guest_choice("Rainbow Cat", self.ROSTER, "Owl") == "Rainbow Cat"
+
+    def test_pick_is_case_and_space_insensitive(self):
+        assert _resolve_guest_choice("  rainbow cat ", self.ROSTER, "Owl") == "Rainbow Cat"
+
+    def test_empty_pick_falls_back_to_most_frequent(self):
+        assert _resolve_guest_choice(None, self.ROSTER, "Owl") == "Lightning Dog"
+        assert _resolve_guest_choice("  ", self.ROSTER, "Owl") == "Lightning Dog"
+
+    def test_unknown_pick_falls_back_to_most_frequent(self):
+        # A name the child does not own must never reach the show.
+        assert _resolve_guest_choice("Spooky Ghost", self.ROSTER, "Owl") == "Lightning Dog"
+
+
+@pytest.mark.asyncio
+class TestGenerateDialogueHonorsGuest:
+    ROSTER = [
+        {"name": "Lightning Dog", "appearance_count": 9},
+        {"name": "Rainbow Cat", "appearance_count": 3},
+    ]
+
+    async def test_chosen_guest_is_used(self, monkeypatch):
+        async def fake_get_characters(user_id, child_id):
+            return self.ROSTER
+
+        monkeypatch.setattr(agent.character_repo, "get_characters", fake_get_characters)
+
+        result = await generate_kids_daily_dialogue(
+            news_text="A friendly news story about space rocks.",
+            age_group="6-8",
+            child_id="child-1",
+            user_id="user-1",
+            guest_character="Rainbow Cat",
+        )
+        assert result["guest_character"] == "Rainbow Cat"
+        guest_lines = [
+            ln for ln in result["dialogue_script"]["lines"] if ln["role"] == "guest"
+        ]
+        assert guest_lines and all(ln["display_name"] == "Rainbow Cat" for ln in guest_lines)
+
+    async def test_unknown_guest_falls_back_to_most_frequent(self, monkeypatch):
+        async def fake_get_characters(user_id, child_id):
+            return self.ROSTER
+
+        monkeypatch.setattr(agent.character_repo, "get_characters", fake_get_characters)
+
+        result = await generate_kids_daily_dialogue(
+            news_text="A friendly news story about animals.",
+            age_group="6-8",
+            child_id="child-1",
+            user_id="user-1",
+            guest_character="Not A Real Character",
+        )
+        assert result["guest_character"] == "Lightning Dog"

--- a/frontend/src/pages/KidsDailyPage/index.tsx
+++ b/frontend/src/pages/KidsDailyPage/index.tsx
@@ -12,16 +12,19 @@ import {
   PawPrint,
   Play,
   Rocket,
+  Sparkles,
   Trophy,
+  Users,
   type LucideIcon,
 } from "lucide-react";
 import Card from "@/components/common/Card";
 import { storyService } from "@/api/services/storyService";
+import { memoryService } from "@/api/services/memoryService";
 import useAuthStore from "@/store/useAuthStore";
 import useChildStore from "@/store/useChildStore";
 import useKidsDailyGenerationStore from "@/store/useKidsDailyGenerationStore";
 import { kidsDailyGenerationManager } from "@/services/kidsDailyGenerationManager";
-import type { NewsCategory } from "@/types/api";
+import type { MemoryCharacter, NewsCategory } from "@/types/api";
 import LoginPrompt from "@/components/common/LoginPrompt";
 import QuotaExceededOverlay, {
   isQuotaError,
@@ -273,6 +276,90 @@ function GeneratingOverlay({
   );
 }
 
+/** Per-card popover that lets a child pick the Guest Anchor before listening.
+ *  Shown only when the child has 2+ characters. "Surprise me!" (value `null`)
+ *  defers to the backend's most-frequent default. */
+function GuestPickerOverlay({
+  characters,
+  onStart,
+  onCancel,
+}: {
+  characters: MemoryCharacter[];
+  onStart: (guest: string | null) => void;
+  onCancel: () => void;
+}) {
+  // `undefined` = nothing picked yet; `null` = explicit "Surprise me!".
+  const [selected, setSelected] = useState<string | null | undefined>(
+    undefined,
+  );
+
+  const options: Array<{ key: string; label: string; value: string | null }> = [
+    ...characters.map((c) => ({ key: c.name, label: c.name, value: c.name })),
+    { key: "__surprise__", label: "Surprise me!", value: null },
+  ];
+
+  return (
+    <motion.div
+      className="absolute inset-0 z-10 flex flex-col rounded-3xl bg-white/95 backdrop-blur-sm p-4 text-left"
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+    >
+      <div className="flex items-center gap-2 mb-2 text-gray-800">
+        <Users className="h-5 w-5 text-primary" strokeWidth={2.25} />
+        <span className="font-bold text-sm">Who joins the show?</span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto space-y-1.5 pr-1">
+        {options.map((opt) => {
+          const isSelected =
+            selected === opt.value ||
+            (opt.value === null && selected === null);
+          return (
+            <button
+              key={opt.key}
+              type="button"
+              onClick={() => setSelected(opt.value)}
+              className={`w-full flex items-center gap-2 rounded-2xl border px-3 py-2 text-sm font-semibold transition-colors ${
+                isSelected
+                  ? "border-primary bg-primary/10 text-primary-dark"
+                  : "border-gray-200 bg-white text-gray-700 hover:bg-gray-50"
+              }`}
+            >
+              {opt.value === null && (
+                <Sparkles className="h-4 w-4 shrink-0" strokeWidth={2.25} />
+              )}
+              <span className="truncate">{opt.label}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-2 grid grid-cols-[1fr_auto] gap-2">
+        <button
+          type="button"
+          disabled={selected === undefined}
+          onClick={() => onStart(selected ?? null)}
+          className={`h-11 rounded-2xl text-sm font-bold border transition-colors ${
+            selected === undefined
+              ? "bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed"
+              : "bg-primary text-white border-transparent hover:bg-primary-dark"
+          }`}
+        >
+          Start episode
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="h-11 px-3 rounded-2xl text-sm font-semibold border border-gray-200 text-gray-600 bg-white hover:bg-gray-50 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </motion.div>
+  );
+}
+
 function KidsDailyPage() {
   const { isAuthenticated } = useAuthStore();
   const { currentChild, defaultChildId } = useChildStore();
@@ -299,6 +386,11 @@ function KidsDailyPage() {
     topic: NewsCategory;
     seconds: number;
   } | null>(null);
+  // Guest Anchor picker: roster of the child's characters and which card (if
+  // any) is currently showing the "Who joins the show?" popover.
+  const [characters, setCharacters] = useState<MemoryCharacter[]>([]);
+  const [guestPickerTopic, setGuestPickerTopic] =
+    useState<NewsCategory | null>(null);
   const retryTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const subscribedCount = subscribedTopics.size;
   const subscribedTopicList = useMemo(
@@ -323,6 +415,27 @@ function KidsDailyPage() {
     if (!isAuthenticated) return;
     void loadSubscriptions();
   }, [isAuthenticated, loadSubscriptions]);
+
+  // Load the child's character roster so we can offer a Guest Anchor pick.
+  // Failure is non-blocking — without a roster we just skip the picker.
+  useEffect(() => {
+    if (!isAuthenticated || !childId) {
+      setCharacters([]);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await memoryService.getCharacters(childId);
+        if (!cancelled) setCharacters(response.characters ?? []);
+      } catch {
+        if (!cancelled) setCharacters([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, childId]);
 
   const ensureSubscribed = useCallback(
     async (topic: NewsCategory) => {
@@ -372,8 +485,9 @@ function KidsDailyPage() {
   );
 
   const handleListenNow = useCallback(
-    async (topic: NewsCategory) => {
+    async (topic: NewsCategory, guestCharacter?: string) => {
       if (!childId || generatingTopic) return;
+      setGuestPickerTopic(null);
       setError(null);
       beginGenerationState(topic, "Joining the news club...");
 
@@ -386,7 +500,12 @@ function KidsDailyPage() {
 
         let episodeId: string | null = null;
         await storyService.generateMorningShowOnDemandStream(
-          { child_id: childId, category: topic, age_group: ageGroup },
+          {
+            child_id: childId,
+            category: topic,
+            age_group: ageGroup,
+            ...(guestCharacter ? { guest_character: guestCharacter } : {}),
+          },
           {
             onStatus: (data) => {
               setGenerationMessage(data.message || "Making your episode...");
@@ -631,7 +750,11 @@ function KidsDailyPage() {
                               : `${theme.listenBtn} ${theme.listenBtnHover} text-white border-transparent`
                         }`}
                         disabled={generatingTopic !== null || isRateLimited}
-                        onClick={() => handleListenNow(item.topic)}
+                        onClick={() =>
+                          characters.length >= 2
+                            ? setGuestPickerTopic(item.topic)
+                            : handleListenNow(item.topic)
+                        }
                         whileTap={
                           !isGenerating && !isRateLimited
                             ? { scale: 0.95 }
@@ -660,6 +783,19 @@ function KidsDailyPage() {
                       </motion.button>
                     </div>
                   </div>
+
+                  {/* Guest Anchor picker (only when 2+ characters) */}
+                  <AnimatePresence>
+                    {guestPickerTopic === item.topic && !isGenerating && (
+                      <GuestPickerOverlay
+                        characters={characters}
+                        onStart={(guest) =>
+                          handleListenNow(item.topic, guest ?? undefined)
+                        }
+                        onCancel={() => setGuestPickerTopic(null)}
+                      />
+                    )}
+                  </AnimatePresence>
 
                   {/* Generating overlay */}
                   <AnimatePresence>

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -370,6 +370,7 @@ export interface MorningShowOnDemandRequest {
   child_id: string;
   category: string; // NewsCategory value
   age_group: string; // AgeGroup value
+  guest_character?: string; // chosen Guest Anchor name; honored only if owned
 }
 
 export interface MorningShowRateLimitResponse {


### PR DESCRIPTION
## What & why

Two Kids Daily podcast defects reported together.

### 1. The host/guest spoke their own name aloud (bug)
`Mimi`/`Duo`/guest lines baked the speaker name into `DialogueLine.text` (`"Duo: ..."`). That text is fed straight to TTS, so the child heard *"Duo, great question"* and the name was also rendered twice on screen (role label + inline prefix).

**Fix:** keep `text` name-free everywhere it was generated — `morning-show.md` prompt + JSON example, the `_build_line_text` mock builder, the SDK guest fallback, and the route's degraded fallback. Attribution now lives only in `display_name` / the role label. A defensive `strip_self_name_prefix` guard runs on **both** the agent and TTS sides (using each line's *own* speaker name, so legitimate content like `"Today: ..."` is never touched) — defense-in-depth against a stale/cached script. Guest lines are now labeled with the chosen character via `display_name`.

### 2. Let the child choose the Guest Anchor (feature)
Previously the guest was always `characters[0]` (most-frequent), so every episode featured the same character. Now, when a child has **2+ characters**, they pick who guest-stars.

- Optional `guest_character` added to `KidsDailyRequest` / `KidsDailyOnDemandRequest`, threaded through `_build_episode` → `generate_kids_daily_episode` → `generate_kids_daily_dialogue` (incl. both SSE stream paths).
- `_resolve_guest_choice` honors the pick **only if it matches the child's own roster** (case/space-insensitive); an unknown or spoofed name falls back to the most-frequent character, then a deterministic default. A name the child doesn't own can never reach the show.
- Frontend: a per-card **"Who joins the show?"** popover on *Listen Now* (shown only with 2+ characters), with a **"Surprise me!"** auto option that defers to the backend default.

## Tests
- New `backend/tests/contracts/test_kids_daily_guest_anchor.py` (16 cases): name-free spoken text, guest labeling, prefix-strip table (incl. the "Today:" false-positive guard, mirrored on agent + TTS), `_resolve_guest_choice` honor/fallback, and end-to-end `generate_kids_daily_dialogue` honoring/rejecting a pick.
- Updated `test_kids_daily_character_names.py` (#140) which had **locked the old buggy behavior** (names in `text`, guest `display_name == None`) to the corrected contract.
- `100 passed` across the kids-daily contract + character-name suites. Pre-existing DB-backed API failures are an unrelated local Postgres pool/env issue (reproduces on untouched `test_image_to_story.py`).

## Safety
The mandatory post-generation safety gate still runs on the joined dialogue text; stripping name prefixes only removes the leading label, not content.

Related to #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)