### PR TITLE
fix(provenance): serialize run timestamps before binding to TEXT columns (#730)

### DIFF
--- a/backend/src/services/database/artifact_repository.py
+++ b/backend/src/services/database/artifact_repository.py
@@ -29,6 +29,18 @@ from ...services.models.artifact_models import (
 )
 
 
+def _iso_or_none(value: Any) -> Optional[str]:
+    """Normalize a timestamp to an ISO-8601 string for TEXT columns.
+
+    Models parse stored timestamps into ``datetime`` objects on read; binding
+    those straight back fails on strict drivers (asyncpg: "expected str, got
+    datetime"). Strings and ``None`` pass through unchanged (#730).
+    """
+    if isinstance(value, datetime):
+        return value.isoformat().replace("+00:00", "Z")
+    return value
+
+
 # ============================================================================
 # Artifact Repository
 # ============================================================================
@@ -1284,8 +1296,11 @@ class RunRepository:
             return False
 
         now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-        started_at = run.started_at
-        completed_at = run.completed_at
+        # The Run model coerces stored TEXT timestamps into datetime objects on
+        # read, so re-serialize before binding — asyncpg rejects datetimes for
+        # the TEXT columns with "expected str, got datetime" (#730).
+        started_at = _iso_or_none(run.started_at)
+        completed_at = _iso_or_none(run.completed_at)
 
         if status == "running" and not started_at:
             started_at = now

--- a/backend/tests/database/test_artifact_provenance_completion.py
+++ b/backend/tests/database/test_artifact_provenance_completion.py
@@ -179,6 +179,55 @@ async def test_story_text_artifact_links_to_character_record(db):
 
 
 @pytest.mark.asyncio
+async def test_update_status_binds_timestamps_as_strings_not_datetimes(db):
+    """Regression for #730.
+
+    The Run model coerces stored TEXT timestamps into ``datetime`` objects on
+    read. ``update_status`` re-reads the run and must re-serialize those values
+    to ISO strings before binding them, otherwise asyncpg rejects them with
+    ``DataError: expected str, got datetime`` against the TEXT columns on
+    Postgres. SQLite tolerates datetimes, so we assert on the *bound parameter
+    types* rather than on a raised error.
+    """
+    bound_timestamps: list[object] = []
+    original_execute = db.execute
+
+    async def spy_execute(sql, parameters=()):
+        if "UPDATE runs" in sql:
+            # started_at = $2, completed_at = $3 in the UPDATE statement
+            bound_timestamps.extend([parameters[1], parameters[2]])
+        return await original_execute(sql, parameters)
+
+    db.execute = spy_execute
+    try:
+        run_repo = RunRepository(db)
+        run_id = await run_repo.create(
+            RunCreate(story_id=None, workflow_type=WorkflowType.KIDS_DAILY)
+        )
+        # First transition stores started_at as a string.
+        await run_repo.update_status(run_id, "running")
+        # Second transition re-reads the run (started_at now a datetime) and
+        # must re-serialize before binding.
+        await run_repo.update_status(
+            run_id, "completed", result_summary={"episodes": 1}
+        )
+    finally:
+        db.execute = original_execute
+
+    assert bound_timestamps, "expected UPDATE runs statements to be captured"
+    for value in bound_timestamps:
+        assert value is None or isinstance(value, str), (
+            f"timestamp bound to TEXT column must be str/None, got "
+            f"{type(value).__name__}: {value!r}"
+        )
+
+    run = await RunRepository(db).get_by_id(run_id)
+    assert run.status.value == "completed"
+    assert run.started_at is not None
+    assert run.completed_at is not None
+
+
+@pytest.mark.asyncio
 async def test_kids_daily_script_image_and_audio_artifacts_publish_and_link(db):
     """Kids Daily visible outputs use published lifecycle with run/step lineage."""
     story_id = await create_test_story(db)


### PR DESCRIPTION
## Summary
Fixes a Postgres-only 500 that crashed provenance tracking when completing a Kids Daily episode (and any run that transitions through more than one `update_status` call).

`RunRepository.update_status` re-read the `Run`, whose `started_at`/`completed_at` had been coerced from stored `TEXT` into `datetime` objects by the `Run.parse_datetime` validator, then bound that `datetime` straight back into the `TEXT` column. asyncpg's TEXT codec strictly requires `str`:

```
asyncpg.exceptions.DataError: invalid input for query argument $2:
datetime.datetime(2026, 6, 20, 3, 2, 31, ...) (expected str, got datetime)
```

SQLite masked the bug by stringifying datetimes through its (now-deprecated) adapter — classic SQLite→Postgres dialect drift.

## Changes
- `backend/src/services/database/artifact_repository.py` — add `_iso_or_none()` helper that normalizes `datetime → ISO-8601 string` at the write boundary; apply it to `started_at`/`completed_at` in `RunRepository.update_status`.
- `backend/tests/database/test_artifact_provenance_completion.py` — regression test asserting the values bound to the `runs` TEXT columns are `str`/`None` across a `running → completed` transition (backend-agnostic, so it fails on SQLite too without the fix).

## Testing
- `pytest tests/database/test_artifact_provenance_completion.py` — 4 passed (RED before fix, GREEN after)
- Related suite (artifact repo + provenance chain/news/interactive + provenance contract) — 47 passed

## Context
**Parent Epic**: #43 (Artifact Lifecycle)

Fixes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)