### PR TITLE
fix(frontend): harmonize profile overview stat-card icon colors

### DIFF
--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -353,8 +353,8 @@ function ProfilePage() {
           className="cursor-pointer"
           onClick={() => navigate("/library?tab=interactive")}
         >
-          <div className="bg-gradient-to-br from-accent/20 to-accent/10 rounded-card p-5 text-center">
-            <Theater className="mx-auto mb-2 h-9 w-9 text-emerald-600" aria-hidden="true" />
+          <div className="bg-gradient-to-br from-secondary/20 to-secondary/10 rounded-card p-5 text-center">
+            <Theater className="mx-auto mb-2 h-9 w-9 text-teal-700" aria-hidden="true" />
             <div className="text-3xl font-bold text-gray-800">
               {statsLoading ? "..." : (stats?.interactive_count ?? 0)}
             </div>
@@ -367,8 +367,8 @@ function ProfilePage() {
           className="cursor-pointer"
           onClick={() => navigate("/library?tab=kids-news")}
         >
-          <div className="bg-gradient-to-br from-secondary/20 to-secondary/10 rounded-card p-5 text-center">
-            <Newspaper className="mx-auto mb-2 h-9 w-9 text-amber-600" aria-hidden="true" />
+          <div className="bg-gradient-to-br from-accent/20 to-accent/10 rounded-card p-5 text-center">
+            <Newspaper className="mx-auto mb-2 h-9 w-9 text-yellow-700" aria-hidden="true" />
             <div className="text-3xl font-bold text-gray-800">
               {statsLoading ? "..." : (stats?.news_count ?? 0)}
             </div>


### PR DESCRIPTION
## Summary
The **My Profile → Overview** stat cards paired clashing icon and background colors. This aligns each icon color with its card background tint, following the homepage `FEATURE_SHOWCASE` palette so flat-icon styling is consistent across surfaces.

| Card | Before | After |
|------|--------|-------|
| Art Stories | primary tile + `text-primary` | unchanged (already matched) |
| Interactive Tales | yellow (`accent`) tile + green `text-emerald-600` | teal (`secondary`) tile + `text-teal-700` |
| Kids News | teal (`secondary`) tile + amber `text-amber-600` | yellow (`accent`) tile + `text-yellow-700` |

Matches homepage convention: Interactive Tales → secondary/teal, Kids Daily/News → accent/yellow.

## Testing
- `tsc -b` clean (className-only change; no behavior or type impact).

Fixes #732
Related to #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)