### PR TITLE
chore(frontend): replace heavy 3D tilt with subtle CSS micro-interactions

### DIFF
--- a/frontend/src/components/common/Card/index.tsx
+++ b/frontend/src/components/common/Card/index.tsx
@@ -50,18 +50,17 @@ const Card = forwardRef<HTMLDivElement, CardProps>(
       lg: 'p-8',
     }
 
-    // Depth-specific styling
+    // Depth-specific styling — soft shadows convey elevation without 3D
+    // translateZ layers (#735).
     const depthStyles = useMemo(() => {
       switch (depth) {
         case 'raised':
           return {
             boxShadow: '0 8px 30px rgba(0, 0, 0, 0.08)',
-            transform: 'translateZ(10px)',
           }
         case 'floating':
           return {
             boxShadow: '0 15px 40px rgba(0, 0, 0, 0.1)',
-            transform: 'translateZ(20px)',
           }
         default:
           return {}

--- a/frontend/src/components/depth/TiltCard.tsx
+++ b/frontend/src/components/depth/TiltCard.tsx
@@ -1,35 +1,41 @@
 /**
  * TiltCard Component
- * Interactive 3D card with tilt effects based on mouse position
- * Creates an immersive 2.5D experience
+ *
+ * Previously a mouse-tracking 3D tilt card. As of #735 it is a calm, CSS-driven
+ * micro-interaction: the card lifts and scales slightly on hover with a soft
+ * shadow — no perspective, no per-frame rotation following the cursor.
+ *
+ * The original prop surface is kept so existing call sites compile unchanged;
+ * the 3D-specific props (maxTilt, perspective, glare, glow, dynamicShadow,
+ * spring*) are accepted but intentionally inert.
  */
 
-import { motion, useMotionValue, useSpring, useTransform } from 'framer-motion'
-import { useRef, type ReactNode, type CSSProperties, type MouseEvent } from 'react'
+import { motion } from 'framer-motion'
+import type { ReactNode, CSSProperties } from 'react'
 
 interface TiltCardProps {
   children: ReactNode
   className?: string
   style?: CSSProperties
-  /** Maximum rotation angle in degrees */
+  /** @deprecated 3D tilt removed in #735 — kept for API compatibility */
   maxTilt?: number
-  /** Perspective distance in pixels */
+  /** @deprecated 3D perspective removed in #735 — kept for API compatibility */
   perspective?: number
   /** Scale on hover */
   hoverScale?: number
-  /** Enable glare effect */
+  /** @deprecated glare overlay removed in #735 — kept for API compatibility */
   glare?: boolean
-  /** Enable glow effect on edges */
+  /** @deprecated glow overlay removed in #735 — kept for API compatibility */
   glow?: boolean
-  /** Glow color */
+  /** @deprecated glow color removed in #735 — kept for API compatibility */
   glowColor?: string
-  /** Enable shadow that responds to tilt */
+  /** @deprecated dynamic shadow removed in #735 — kept for API compatibility */
   dynamicShadow?: boolean
-  /** Spring stiffness for smooth animation */
+  /** @deprecated spring stiffness removed in #735 — kept for API compatibility */
   springStiffness?: number
-  /** Spring damping */
+  /** @deprecated spring damping removed in #735 — kept for API compatibility */
   springDamping?: number
-  /** Disable all effects */
+  /** Disable the hover lift */
   disabled?: boolean
   /** Click handler */
   onClick?: () => void
@@ -39,138 +45,19 @@ export function TiltCard({
   children,
   className = '',
   style,
-  maxTilt = 15,
-  perspective = 1000,
   hoverScale = 1.02,
-  glare = true,
-  glow = false,
-  glowColor = 'rgba(255, 107, 107, 0.4)',
-  dynamicShadow = true,
-  springStiffness = 300,
-  springDamping = 30,
   disabled = false,
   onClick,
 }: TiltCardProps) {
-  const cardRef = useRef<HTMLDivElement>(null)
-
-  // Motion values for tilt
-  const rotateX = useMotionValue(0)
-  const rotateY = useMotionValue(0)
-  const glareX = useMotionValue(50)
-  const glareY = useMotionValue(50)
-  const glareOpacity = useMotionValue(0)
-
-  // Smooth spring animations
-  const springConfig = { stiffness: springStiffness, damping: springDamping }
-  const rotateXSpring = useSpring(rotateX, springConfig)
-  const rotateYSpring = useSpring(rotateY, springConfig)
-  const glareXSpring = useSpring(glareX, springConfig)
-  const glareYSpring = useSpring(glareY, springConfig)
-  const glareOpacitySpring = useSpring(glareOpacity, springConfig)
-  const glareBackground = useTransform(
-    [glareXSpring, glareYSpring],
-    ([x, y]) => `radial-gradient(circle at ${x}% ${y}%, rgba(255,255,255,0.3) 0%, transparent 50%)`
-  )
-
-  // Dynamic shadow based on tilt
-  const shadowX = useTransform(rotateYSpring, [-maxTilt, maxTilt], [20, -20])
-  const shadowY = useTransform(rotateXSpring, [-maxTilt, maxTilt], [-20, 20])
-
-  const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
-    if (disabled || !cardRef.current) return
-
-    const rect = cardRef.current.getBoundingClientRect()
-    const centerX = rect.left + rect.width / 2
-    const centerY = rect.top + rect.height / 2
-
-    // Calculate rotation based on mouse position relative to center
-    const mouseX = e.clientX - centerX
-    const mouseY = e.clientY - centerY
-
-    // Normalize to -1 to 1 range
-    const normalizedX = mouseX / (rect.width / 2)
-    const normalizedY = mouseY / (rect.height / 2)
-
-    // Set rotation (inverted for natural feel)
-    rotateY.set(normalizedX * maxTilt)
-    rotateX.set(-normalizedY * maxTilt)
-
-    // Glare position (percentage)
-    const glareXPos = ((e.clientX - rect.left) / rect.width) * 100
-    const glareYPos = ((e.clientY - rect.top) / rect.height) * 100
-    glareX.set(glareXPos)
-    glareY.set(glareYPos)
-    glareOpacity.set(0.15)
-  }
-
-  const handleMouseLeave = () => {
-    rotateX.set(0)
-    rotateY.set(0)
-    glareOpacity.set(0)
-  }
-
   return (
     <motion.div
-      ref={cardRef}
       className={`tilt-card-container ${className}`}
-      style={{
-        perspective: `${perspective}px`,
-        ...style,
-      }}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
+      style={style}
       onClick={onClick}
+      whileHover={disabled ? undefined : { y: -4, scale: hoverScale }}
+      transition={{ type: 'spring', stiffness: 400, damping: 30 }}
     >
-      <motion.div
-        className="tilt-card-inner preserve-3d"
-        style={{
-          rotateX: rotateXSpring,
-          rotateY: rotateYSpring,
-          transformStyle: 'preserve-3d',
-        }}
-        whileHover={disabled ? {} : { scale: hoverScale }}
-        transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-      >
-        {/* Main content */}
-        <div className="tilt-card-content relative">
-          {children}
-
-          {/* Glare overlay */}
-          {glare && !disabled && (
-            <motion.div
-              className="tilt-card-glare absolute inset-0 pointer-events-none rounded-inherit overflow-hidden"
-              style={{
-                background: glareBackground,
-                opacity: glareOpacitySpring,
-              }}
-            />
-          )}
-
-          {/* Glow effect */}
-          {glow && !disabled && (
-            <motion.div
-              className="tilt-card-glow absolute -inset-1 rounded-inherit pointer-events-none -z-10"
-              style={{
-                boxShadow: `0 0 30px 10px ${glowColor}`,
-                opacity: glareOpacitySpring,
-              }}
-            />
-          )}
-        </div>
-
-        {/* Dynamic shadow */}
-        {dynamicShadow && !disabled && (
-          <motion.div
-            className="tilt-card-shadow absolute inset-0 -z-20 rounded-inherit"
-            style={{
-              x: shadowX,
-              y: shadowY,
-              boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.25)',
-              opacity: 0.3,
-            }}
-          />
-        )}
-      </motion.div>
+      {children}
     </motion.div>
   )
 }

--- a/frontend/src/components/interactive/ChoiceButtons/index.tsx
+++ b/frontend/src/components/interactive/ChoiceButtons/index.tsx
@@ -1,4 +1,4 @@
-import { motion, useSpring } from 'framer-motion'
+import { motion } from 'framer-motion'
 import { useState } from 'react'
 import type { StoryChoice } from '@/types/api'
 
@@ -19,7 +19,7 @@ function ChoiceButtons({
 }: ChoiceButtonsProps) {
   return (
     <div
-      className={`flex flex-col md:flex-row gap-3 perspective-1000 ${className}`}
+      className={`flex flex-col md:flex-row gap-3 ${className}`}
     >
       {choices.map((choice, index) => (
         <ChoiceButton
@@ -46,37 +46,16 @@ interface ChoiceButtonProps {
 function ChoiceButton({ choice, index, onChoose, isLoading, disabled }: ChoiceButtonProps) {
   const [isHovered, setIsHovered] = useState(false)
 
-  // 3D tilt effect
-  const rotateX = useSpring(0, { stiffness: 300, damping: 30 })
-  const rotateY = useSpring(0, { stiffness: 300, damping: 30 })
-  const scale = useSpring(1, { stiffness: 300, damping: 30 })
-
-  const handleMouseMove = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (disabled || isLoading) return
-
-    const rect = e.currentTarget.getBoundingClientRect()
-    const centerX = rect.left + rect.width / 2
-    const centerY = rect.top + rect.height / 2
-
-    const x = (e.clientX - centerX) / (rect.width / 2)
-    const y = (e.clientY - centerY) / (rect.height / 2)
-
-    rotateX.set(-y * 8)
-    rotateY.set(x * 8)
-  }
-
   const handleMouseEnter = () => {
     if (disabled || isLoading) return
     setIsHovered(true)
-    scale.set(1.02)
   }
 
   const handleMouseLeave = () => {
     setIsHovered(false)
-    rotateX.set(0)
-    rotateY.set(0)
-    scale.set(1)
   }
+
+  const interactive = !disabled && !isLoading
 
   return (
     <motion.button
@@ -87,32 +66,24 @@ function ChoiceButton({ choice, index, onChoose, isLoading, disabled }: ChoiceBu
         border-2 border-gray-200
         text-left font-medium text-gray-700
         transition-colors duration-200
-        preserve-3d gpu-accelerated
         ${
           disabled || isLoading
             ? 'opacity-50 cursor-not-allowed'
-            : 'hover:border-primary hover:shadow-lg cursor-pointer'
+            : 'hover:border-primary cursor-pointer'
         }
       `}
-      onClick={() => !disabled && !isLoading && onChoose(choice.choice_id)}
+      onClick={() => interactive && onChoose(choice.choice_id)}
       disabled={disabled || isLoading}
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.1 }}
       style={{
-        rotateX,
-        rotateY,
-        scale,
-        boxShadow: isHovered ? '0 15px 30px rgba(0,0,0,0.12)' : '0 4px 12px rgba(0,0,0,0.05)',
+        boxShadow: isHovered ? '0 10px 22px rgba(0,0,0,0.10)' : '0 4px 12px rgba(0,0,0,0.05)',
       }}
-      onMouseMove={handleMouseMove}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
-      whileTap={
-        !disabled && !isLoading
-          ? { scale: 0.98 }
-          : {}
-      }
+      whileHover={interactive ? { y: -3, scale: 1.02 } : undefined}
+      whileTap={interactive ? { scale: 0.98 } : undefined}
     >
           {/* Emoji */}
           <motion.span

--- a/frontend/src/components/story/BookContainer/index.tsx
+++ b/frontend/src/components/story/BookContainer/index.tsx
@@ -78,9 +78,9 @@ function BookContainer({
     const normalizedX = mouseX / (rect.width / 2)
     const normalizedY = mouseY / (rect.height / 2)
 
-    // Subtle tilt (max 8 degrees)
-    rotateY.set(normalizedX * 8)
-    rotateX.set(-normalizedY * 4)
+    // Very gentle tilt (#735) — a hint of life, not a full 3D swing
+    rotateY.set(normalizedX * 3)
+    rotateX.set(-normalizedY * 1.5)
   }
 
   const handleMouseLeave = () => {

--- a/frontend/src/config/animationPresets.test.ts
+++ b/frontend/src/config/animationPresets.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { defaultParallaxConfig, defaultTiltConfig } from './animationPresets'
+
+/**
+ * Issue #735 — replace heavy mouse-tracking 3D with subtle CSS micro-interactions.
+ *
+ * These defaults are the global lever consumed by useParallax / useTilt /
+ * PerspectiveContainer / Card. Keeping them disabled (and the residual angles
+ * small) guarantees we don't reintroduce full-3D tilt on every card and button.
+ */
+describe('animation defaults — subtle by default (#735)', () => {
+  it('disables mouse-tracking card tilt by default', () => {
+    expect(defaultTiltConfig.enabled).toBe(false)
+  })
+
+  it('disables mouse-tracking parallax rotation by default', () => {
+    expect(defaultParallaxConfig.enabled).toBe(false)
+  })
+
+  it('keeps any residual tilt gentle (<= 4 degrees)', () => {
+    expect(defaultTiltConfig.maxTilt).toBeLessThanOrEqual(4)
+    expect(defaultParallaxConfig.maxRotation).toBeLessThanOrEqual(4)
+  })
+})

--- a/frontend/src/config/animationPresets.ts
+++ b/frontend/src/config/animationPresets.ts
@@ -12,20 +12,25 @@ import type {
   TiltConfig,
 } from '@/types/streaming'
 
-// Default parallax configuration
+// Default parallax configuration.
+// Mouse-tracking 3D rotation is off by default (#735) — we favour calm, cheap
+// CSS micro-interactions over full-3D tilt on every surface. Residual angles are
+// kept gentle so re-enabling parallax can never feel heavy.
 export const defaultParallaxConfig: ParallaxConfig = {
-  enabled: true,
+  enabled: false,
   intensity: 0.5,
   smoothing: 0.1,
-  maxRotation: 8,
+  maxRotation: 4,
   maxTranslation: 20,
   perspective: 1000,
 }
 
-// Default tilt configuration for cards
+// Default tilt configuration for cards.
+// Disabled by default (#735): cards lift gently on hover via CSS instead of
+// rotating with the cursor. Kept available behind an explicit opt-in.
 export const defaultTiltConfig: TiltConfig = {
-  enabled: true,
-  maxTilt: 8,
+  enabled: false,
+  maxTilt: 4,
   scale: 1.02,
   speed: 300,
   glare: true,

--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -458,7 +458,7 @@ function HomePage() {
   }
 
   return (
-    <div className="space-y-8 perspective-1500">
+    <div className="space-y-8">
       <StarFlyAnimation
         active={starFlying}
         fromRef={newspaperRef}
@@ -467,9 +467,9 @@ function HomePage() {
       />
 
       <motion.section
-        className="hero-banner relative min-h-[540px] overflow-hidden rounded-card preserve-3d sm:min-h-[520px]"
-        initial={{ opacity: 0, y: 30, rotateX: 10 }}
-        animate={{ opacity: 1, y: 0, rotateX: 0 }}
+        className="hero-banner relative min-h-[540px] overflow-hidden rounded-card sm:min-h-[520px]"
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6, type: 'spring', stiffness: 100 }}
       >
         <DepthLayer config={{ layer: 'background', parallaxFactor: 0.3 }}>

--- a/frontend/src/pages/UploadPage/index.tsx
+++ b/frontend/src/pages/UploadPage/index.tsx
@@ -151,7 +151,7 @@ function UploadPage() {
   // Show loading state with enhanced streaming visualization
   if (currentUploadStatus === 'uploading' || currentUploadStatus === 'processing' || isLoading || isGenerating) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] perspective-1000">
+      <div className="flex flex-col items-center justify-center min-h-[60vh]">
         <PerspectiveContainer enableTilt={false} className="w-full max-w-md">
           <StreamingVisualizer
             phase={animationPhase}
@@ -191,12 +191,12 @@ function UploadPage() {
   }
 
   return (
-    <div className="space-y-6 perspective-1500">
+    <div className="space-y-6">
       {/* Page title with floating decoration */}
       <motion.div
         className="text-center relative"
-        initial={{ opacity: 0, y: -20, rotateX: 15 }}
-        animate={{ opacity: 1, y: 0, rotateX: 0 }}
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
         transition={{ type: 'spring', stiffness: 100 }}
       >
         <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 text-primary">
@@ -219,9 +219,9 @@ function UploadPage() {
               {imagePreviewUrl ? (
                 <motion.div
                   key="preview"
-                  initial={{ opacity: 0, scale: 0.9, rotateY: -10 }}
-                  animate={{ opacity: 1, scale: 1, rotateY: 0 }}
-                  exit={{ opacity: 0, scale: 0.9, rotateY: 10 }}
+                  initial={{ opacity: 0, scale: 0.9 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.9 }}
                   transition={{ type: 'spring', stiffness: 200 }}
                 >
                   <ImagePreview
@@ -264,7 +264,7 @@ function UploadPage() {
                 return (
                   <motion.button
                     key={group.value}
-                    className={`age-select-card p-4 rounded-card border-2 transition-all preserve-3d ${
+                    className={`age-select-card p-4 rounded-card border-2 transition-all ${
                       selectedAgeGroup === group.value
                         ? 'border-primary bg-primary/10 shadow-lg'
                         : 'border-gray-200 hover:border-gray-300 hover:shadow-md'
@@ -275,13 +275,12 @@ function UploadPage() {
                         ? {}
                         : {
                             scale: 1.05,
-                            rotateY: 5,
-                            z: 20,
+                            y: -4,
                           }
                     }
                     whileTap={{ scale: 0.95 }}
-                    initial={{ opacity: 0, y: 20, rotateX: 15 }}
-                    animate={{ opacity: 1, y: 0, rotateX: 0 }}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
                     transition={{ delay: 0.2 + index * 0.1 }}
                   >
                     <div className="text-center">

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -485,19 +485,13 @@
   animation: card-flip-in 0.5s cubic-bezier(0.16, 1, 0.3, 1);
 }
 
-/* Float with depth */
+/* Gentle vertical float — no 3D rotation (#735) */
 @keyframes float-3d {
   0%, 100% {
-    transform: translateY(0) rotateX(0deg) rotateY(0deg);
-  }
-  25% {
-    transform: translateY(-8px) rotateX(2deg) rotateY(2deg);
+    transform: translateY(0);
   }
   50% {
-    transform: translateY(-12px) rotateX(0deg) rotateY(-1deg);
-  }
-  75% {
-    transform: translateY(-6px) rotateX(-1deg) rotateY(1deg);
+    transform: translateY(-8px);
   }
 }
 


### PR DESCRIPTION
## Summary
Nearly every card and button used mouse-tracking **full-3D tilt/parallax** (perspective + per-mousemove `rotateX/rotateY` springs). It felt heavy for a kids' app and added runtime cost. This swaps it for **calm CSS micro-interactions** — a small hover lift + scale + soft shadow — while keeping all component APIs intact so call sites compile unchanged.

Fixes #735

## Changes
- **`config/animationPresets.ts`** — `defaultTiltConfig`/`defaultParallaxConfig` now disabled by default; residual angles capped at 4°. This is the global lever consumed by `useTilt` / `useParallax` / `PerspectiveContainer` / `Card`.
- **`TiltCard.tsx`** — now a hover lift+scale (`y:-4`, `scale:1.02`). 3D props (`maxTilt`, `perspective`, `glare`, `dynamicShadow`, …) kept as inert no-ops for API compatibility.
- **`ChoiceButtons`** — dropped `perspective-1000` + cursor-tracking tilt + `preserve-3d`; keeps a gentle hover lift and tap feedback.
- **`Card`** — elevation now via `box-shadow` instead of `translateZ` depth layers.
- **`BookContainer`** — gentle 3°/1.5° tilt instead of 8°/4°.
- **`HomePage` / `UploadPage`** — entry animations softened to fade/slide (removed `rotateX/rotateY` swings and `perspective-*` wrappers).
- **`globals.css`** — `float-3d` keyframe simplified to a vertical float.

## Testing
- Added `animationPresets.test.ts` locking "no heavy 3D by default" (TDD: red → green).
- `npx tsc -b` ✅ · `npx eslint` ✅ (1 pre-existing unrelated warning) · `npx vitest run` ✅ **53 files / 449 tests**.
- `prefers-reduced-motion` guards left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)