### PR TITLE
fix(auth): skip non-JWT legacy tokens before Supabase decode (#740)

### DIFF
--- a/backend/src/services/supabase_auth.py
+++ b/backend/src/services/supabase_auth.py
@@ -45,6 +45,16 @@ def get_jwt_secret() -> Optional[str]:
     return os.getenv("SUPABASE_JWT_SECRET")
 
 
+def _looks_like_jwt(token: str) -> bool:
+    """Return True if the token is structurally a JWT (three segments).
+
+    A JWS compact-serialized JWT is `header.payload.signature` — exactly two
+    dots. Opaque legacy tokens have none, so this cheaply filters them out
+    before any decode attempt.
+    """
+    return bool(token) and token.count(".") == 2
+
+
 def _fetch_jwks_keys() -> Optional[list[dict[str, Any]]]:
     """Fetch and cache JWKS keys from the Supabase project."""
     global _jwks_keys
@@ -74,6 +84,14 @@ def decode_supabase_token(token: str) -> Optional[SupabaseClaims]:
     Returns SupabaseClaims on success, None if the token is invalid or
     no Supabase auth is configured.
     """
+    # Structural guard: a JWT has exactly three dot-separated segments.
+    # Legacy custom tokens are opaque `secrets.token_urlsafe` strings with no
+    # dots, so skip them here silently — they are validated downstream by the
+    # legacy fallback. This avoids a wasted jwt.decode and a misleading
+    # "Not enough segments" WARNING on every legacy-authed request (#740).
+    if not _looks_like_jwt(token):
+        return None
+
     claims = _decode_with_jwks(token)
     if claims:
         return claims

--- a/backend/tests/unit/test_supabase_auth_token_guard.py
+++ b/backend/tests/unit/test_supabase_auth_token_guard.py
@@ -1,0 +1,70 @@
+"""Regression tests for the Supabase token structural guard (#740).
+
+Legacy accounts authenticate with opaque `secrets.token_urlsafe(32)` tokens
+that are NOT JWTs. `decode_supabase_token` must skip these cheaply and
+silently — no `jwt.decode`, no WARNING log spam — while still validating and
+warning on genuine (3-segment) JWTs.
+"""
+
+import logging
+import secrets
+
+import jwt
+import pytest
+
+from backend.src.services import supabase_auth
+from backend.src.services.supabase_auth import decode_supabase_token
+
+
+@pytest.fixture
+def hs256_secret(monkeypatch):
+    secret = "test-supabase-jwt-secret"
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", secret)
+    # Ensure the JWKS path is a no-op so we exercise the HS256 branch.
+    monkeypatch.setattr(supabase_auth, "_jwks_keys", [])
+    monkeypatch.delenv("SUPABASE_URL", raising=False)
+    return secret
+
+
+def test_legacy_opaque_token_is_skipped_without_warning(hs256_secret, caplog):
+    """A non-JWT legacy token returns None and emits no warning."""
+    legacy_token = secrets.token_urlsafe(32)  # no dots -> not a JWT
+    assert "." not in legacy_token or legacy_token.count(".") != 2
+
+    with caplog.at_level(logging.WARNING, logger="backend.src.services.supabase_auth"):
+        result = decode_supabase_token(legacy_token)
+
+    assert result is None
+    assert "Not enough segments" not in caplog.text
+    assert "Invalid Supabase token" not in caplog.text
+
+
+def test_malformed_jwt_still_warns(hs256_secret, caplog):
+    """A structurally-valid (3-segment) but bogus JWT still logs a warning."""
+    bogus_jwt = "aaaa.bbbb.cccc"  # 3 segments, undecodable signature
+
+    with caplog.at_level(logging.WARNING, logger="backend.src.services.supabase_auth"):
+        result = decode_supabase_token(bogus_jwt)
+
+    assert result is None
+    assert "Invalid Supabase token" in caplog.text
+
+
+def test_valid_hs256_jwt_decodes(hs256_secret):
+    """A correctly signed Supabase HS256 JWT still decodes to claims."""
+    token = jwt.encode(
+        {
+            "sub": "user-uuid-123",
+            "email": "kid@example.com",
+            "aud": "authenticated",
+            "email_confirmed_at": "2026-01-01T00:00:00Z",
+        },
+        hs256_secret,
+        algorithm="HS256",
+    )
+
+    claims = decode_supabase_token(token)
+
+    assert claims is not None
+    assert claims.sub == "user-uuid-123"
+    assert claims.email == "kid@example.com"


### PR DESCRIPTION
## Summary

Silences the `Invalid Supabase token (HS256): Not enough segments` WARNING spam seen in local-dev (and any pre-Supabase account) backend logs.

**Root cause:** legacy tokens are opaque `secrets.token_urlsafe(32)` strings (no dots). `get_current_user` (`backend/src/api/deps.py:158`) always tries `decode_supabase_token()` first; with `SUPABASE_JWT_SECRET` set, the HS256 branch ran `jwt.decode()` on the non-JWT token → `DecodeError("Not enough segments")` → logged at WARNING. Auth still succeeded via the legacy fallback, so it was **benign but noisy** and wasted a decode + secret lookup on every request. Pages that fan out parallel calls (Inspiration Daily, Library) produced bursts of 9+.

## Fix

Add a structural guard `_looks_like_jwt()` in `backend/src/services/supabase_auth.py`: a JWS compact JWT has exactly two dots, so non-JWT tokens return `None` immediately and defer to legacy validation — no decode attempt, no warning. Genuinely malformed/expired 3-segment JWTs still warn as before.

## Tests

New `backend/tests/unit/test_supabase_auth_token_guard.py`:
- legacy `token_urlsafe` token → returns `None`, **zero** warnings ✅
- bogus 3-segment JWT → still warns ✅
- valid HS256 JWT → decodes to claims ✅

Auth regression suites (`test_supabase_referrals.py`, `test_user_service_security.py`) pass.

Fixes #740 · Related to epic #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)
