### PR TITLE
fix(memory): keep story settings/props out of the character roster (#742)

### DIFF
--- a/backend/src/agents/image_to_story_agent.py
+++ b/backend/src/agents/image_to_story_agent.py
@@ -771,7 +771,9 @@ Return your response as JSON:
   "concepts": ["concept1", "concept2"],
   "moral": "the moral lesson",
   "characters": [{{"name": "...", "description": "...", "appearances": 1}}]
-}}"""
+}}
+
+For "characters", list ONLY living characters (people, animals, or creatures with a name and personality). Do NOT include settings, places, or objects (e.g. "The Forest", "The Castle", "The Mirror")."""
 
     client = AsyncAnthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
     try:

--- a/backend/src/services/database/character_repository.py
+++ b/backend/src/services/database/character_repository.py
@@ -30,6 +30,48 @@ class CharacterRepository:
         cleaned = " ".join(cleaned.split())
         return cleaned.strip()
 
+    # Head nouns that mark a story *setting* (place) or *prop* (object) rather
+    # than a character. Used to keep non-characters out of the roster (#742).
+    _SETTING_OBJECT_NOUNS = frozenset({
+        # places / settings
+        "forest", "ocean", "sea", "castle", "kingdom", "realm", "world", "land",
+        "village", "town", "city", "mountain", "mountains", "river", "lake",
+        "sky", "garden", "meadow", "valley", "cave", "cavern", "island",
+        "palace", "tower", "temple", "dungeon", "desert", "jungle", "swamp",
+        "field", "beach", "harbor", "harbour", "bridge", "road", "path", "maze",
+        "labyrinth", "wonderland",
+        # objects / props
+        "mirror", "sword", "shield", "key", "book", "lamp", "lantern", "crown",
+        "ring", "map", "door", "gate", "box", "chest", "wand", "staff",
+        "potion", "gem", "jewel", "stone", "crystal", "orb", "amulet",
+        "necklace", "scroll", "bell", "clock", "candle", "torch", "flute",
+        "drum", "compass", "telescope", "portal", "throne",
+    })
+
+    _LEADING_ARTICLES = ("the ", "a ", "an ")
+
+    @classmethod
+    def _is_non_character_name(cls, name: str) -> bool:
+        """True if `name` denotes a story setting or prop, not a character.
+
+        Heuristic: the name opens with an article ("The/A/An") AND ends in a
+        known place/object noun — e.g. "The Enchanted Forest", "The Mirror".
+        Both signals are required because real character names rarely start
+        with an article, and an article alone is not enough ("The Wizard" is a
+        character). Requiring both keeps false positives near zero, because we
+        would rather keep an odd character than silently drop a real one.
+        """
+        cleaned = cls._sanitize_name(name)
+        if not cleaned:
+            return False
+        lowered = cleaned.casefold()
+        if not lowered.startswith(cls._LEADING_ARTICLES):
+            return False
+        tokens = [t for t in re.split(r"[^\w]+", lowered) if t]
+        if not tokens:
+            return False
+        return tokens[-1] in cls._SETTING_OBJECT_NOUNS
+
     @classmethod
     def _normalized_name_key(cls, name: str) -> str:
         """Build key used for dedupe and matching.
@@ -110,7 +152,7 @@ class CharacterRepository:
         description: Optional[str] = None,
         visual_features: Optional[Dict[str, Any]] = None,
         traits: Optional[List[str]] = None,
-    ) -> Dict[str, Any]:
+    ) -> Optional[Dict[str, Any]]:
         """Insert a new character or update an existing one.
 
         On conflict (same user_id + child_id + name): increments appearance_count,
@@ -126,6 +168,12 @@ class CharacterRepository:
         cleaned_name = self._sanitize_name(name)
         if not cleaned_name:
             raise ValueError("Character name cannot be empty")
+
+        # Settings ("The Enchanted Forest") and props ("The Mirror") are mined
+        # from story text but are not characters — never persist them, so they
+        # cannot pollute the gallery or Morning Show guest picker (#742).
+        if self._is_non_character_name(cleaned_name):
+            return None
 
         canonical = await self._find_by_normalized_name(user_id, child_id, cleaned_name)
         target_name = canonical["name"] if canonical else cleaned_name
@@ -175,6 +223,11 @@ class CharacterRepository:
         for item in deserialized:
             key = self._normalized_name_key(item.get("name", ""))
             if not key:
+                continue
+
+            # Exclude settings/props persisted before the write-side guard
+            # existed (#742), so legacy junk disappears without a migration.
+            if self._is_non_character_name(item.get("name", "")):
                 continue
 
             if key not in merged:

--- a/backend/tests/contracts/test_character_entity_filter.py
+++ b/backend/tests/contracts/test_character_entity_filter.py
@@ -1,0 +1,148 @@
+"""Contract tests: non-character entities (settings/props) are filtered (#742).
+
+Story extraction mines a `characters` list from generated story JSON with no
+guard, so settings ("The Enchanted Forest") and props ("The Mirror") were
+stored as characters and surfaced in the Morning Show guest picker. The
+repository must:
+  1. classify such names as non-characters,
+  2. skip persisting them on write (upsert returns None), and
+  3. exclude any already-stored ones on read.
+
+Parent Epic: #42 (Memory System) | Issue: #742
+"""
+
+import pytest
+
+from backend.src.services.database.character_repository import CharacterRepository
+from backend.src.services.database.connection import DatabaseManager
+
+
+@pytest.fixture
+async def db():
+    manager = DatabaseManager(":memory:")
+    await manager.connect()
+    await manager.execute(
+        """
+        CREATE TABLE IF NOT EXISTS characters (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL DEFAULT '',
+            child_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            visual_features TEXT,
+            traits TEXT,
+            appearance_count INTEGER DEFAULT 1,
+            first_seen_at TEXT NOT NULL,
+            last_seen_at TEXT NOT NULL,
+            UNIQUE(user_id, child_id, name)
+        )
+        """
+    )
+    # Minimal stories table so get_characters_grouped's main-count query runs.
+    await manager.execute(
+        """
+        CREATE TABLE IF NOT EXISTS stories (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT,
+            child_id TEXT,
+            characters TEXT,
+            created_at TEXT
+        )
+        """
+    )
+    await manager.commit()
+    yield manager
+    await manager.disconnect()
+
+
+@pytest.fixture
+def repo(db):
+    r = CharacterRepository()
+    r._db = db
+    return r
+
+
+# Names that should be rejected as settings/props.
+NON_CHARACTER_NAMES = [
+    "The Mirror",
+    "The Enchanted Forest",
+    "The Sparkling Ocean",
+    "A Magical Castle",
+    "The Kingdom",
+]
+
+# Real characters that must always pass.
+CHARACTER_NAMES = [
+    "Ember",
+    "Luna",
+    "Squirrel",
+    "Fox Kit",
+    "Rabbit",
+    "Stella",
+    "Hero",
+    "Dog",
+    "The Wizard",  # an article alone is not enough — wizard is animate
+]
+
+
+@pytest.mark.parametrize("name", NON_CHARACTER_NAMES)
+def test_classifier_flags_settings_and_props(name):
+    assert CharacterRepository._is_non_character_name(name) is True
+
+
+@pytest.mark.parametrize("name", CHARACTER_NAMES)
+def test_classifier_keeps_real_characters(name):
+    assert CharacterRepository._is_non_character_name(name) is False
+
+
+class TestWriteSkip:
+    @pytest.mark.asyncio
+    async def test_upsert_skips_non_character(self, repo):
+        result = await repo.upsert_character(
+            user_id="u1", child_id="c1", name="The Mirror",
+            description="A magical mirror that forgot its own beauty",
+        )
+        assert result is None
+        rows = await repo.get_characters("u1", "c1")
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_upsert_keeps_real_character(self, repo):
+        result = await repo.upsert_character(
+            user_id="u1", child_id="c1", name="Ember",
+            description="A wise young deer",
+        )
+        assert result is not None
+        assert result["name"] == "Ember"
+
+
+class TestReadExclusion:
+    @pytest.mark.asyncio
+    async def test_existing_junk_excluded_on_read(self, repo, db):
+        # Simulate already-polluted data inserted before the fix existed.
+        now = "2026-01-01T00:00:00"
+        for name in ["Stella", "The Mirror", "The Enchanted Forest"]:
+            await db.execute(
+                "INSERT INTO characters (user_id, child_id, name, appearance_count, first_seen_at, last_seen_at) "
+                "VALUES (?, ?, ?, 1, ?, ?)",
+                ("u1", "c1", name, now, now),
+            )
+        await db.commit()
+
+        names = {c["name"] for c in await repo.get_characters("u1", "c1")}
+        assert names == {"Stella"}
+
+    @pytest.mark.asyncio
+    async def test_grouped_view_excludes_junk(self, repo, db):
+        now = "2026-01-01T00:00:00"
+        for name in ["Luna", "The Sparkling Ocean"]:
+            await db.execute(
+                "INSERT INTO characters (user_id, child_id, name, appearance_count, first_seen_at, last_seen_at) "
+                "VALUES (?, ?, ?, 1, ?, ?)",
+                ("u1", "c1", name, now, now),
+            )
+        await db.commit()
+
+        grouped = await repo.get_characters_grouped("u1", "c1")
+        all_names = {c["name"] for c in grouped["characters"]}
+        assert all_names == {"Luna"}


### PR DESCRIPTION
## Summary

The Morning Show **"Who joins the show?"** guest picker listed story *settings* and *props* instead of the child's characters — e.g. a child whose roster is Ember / Squirrel / Luna / Rabbit / Fox Kit saw **"The Mirror"**, **"The Enchanted Forest"**, **"The Sparkling Ocean"**.

**Root cause:** characters are auto-mined from generated story JSON and saved via `character_repo.upsert_character()` with no filtering, and the extraction prompt never told the model to exclude non-characters. Confirmed in local Postgres for `child_613ecb75bb86`:

| name | appearance_count | kind |
|---|---|---|
| Stella, Marcus, Clara | 1–2 | character ✓ |
| The Enchanted Forest, The Sparkling Ocean | 1 | setting ✗ |
| The Mirror | 1 | prop ✗ |

## Fix

`backend/src/services/database/character_repository.py`:
- New deterministic `_is_non_character_name(name)` — flags a name that opens with an article (*The/A/An*) **and** ends in a known place/object noun. Both signals required, so "The Wizard", "Ember", "Luna" are never dropped.
- **Write:** `upsert_character` skips non-characters (returns `None`; all three production call sites already tolerate a falsy return).
- **Read:** `get_characters` excludes them, so already-stored junk disappears from the gallery + guest picker **without a data migration**.

`backend/src/agents/image_to_story_agent.py`: one-line guardrail telling the extractor to return only living characters.

## Tests

New `backend/tests/contracts/test_character_entity_filter.py` (18 cases): classifier accept/reject table, write-skip, and read-exclusion of legacy rows. Full `test_character_repository_contract.py` + `test_kids_daily_guest_anchor.py` pass.

> Note: 10 failures in `tests/api/test_memory.py` are pre-existing and environmental (they connect to live Postgres :54322 and hit an event-loop issue) — identical with and without this change.

## Out of scope

There is no explicit user-managed "my characters" roster — all characters are auto-mined. A roster-management feature is a separate enhancement.

Fixes #742 · Related to epic #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
