### PR TITLE
fix(profiles): promote a remaining child when archiving the default (#744)

### DIFF
--- a/backend/src/services/database/child_profile_repository.py
+++ b/backend/src/services/database/child_profile_repository.py
@@ -273,9 +273,33 @@ class ChildProfileRepository:
             (now, now, user_id, child_id),
         )
         if existing.is_default:
-            await self._sync_user_default(user_id, None)
+            # Promote the oldest remaining active profile so the account is
+            # never left without a default child (#744). Only fall back to
+            # None when no active profile remains.
+            await self._promote_new_default(user_id)
         await self._db.commit()
         return await self.get_for_user(user_id, child_id, include_archived=True)
+
+    async def _promote_new_default(self, user_id: str) -> None:
+        """Make the oldest remaining active profile the default, if any."""
+        row = await self._db.fetchone(
+            """
+            SELECT child_id FROM child_profiles
+            WHERE user_id = ? AND archived_at IS NULL
+            ORDER BY created_at ASC
+            LIMIT 1
+            """,
+            (user_id,),
+        )
+        new_default = row.get("child_id") if row else None
+        if new_default:
+            now = datetime.now().isoformat()
+            await self._db.execute(
+                "UPDATE child_profiles SET is_default = 1, updated_at = ? "
+                "WHERE user_id = ? AND child_id = ?",
+                (now, user_id, new_default),
+            )
+        await self._sync_user_default(user_id, new_default)
 
     async def _clear_default(self, user_id: str) -> None:
         await self._db.execute(

--- a/backend/tests/contracts/test_child_profile_archive_promotion.py
+++ b/backend/tests/contracts/test_child_profile_archive_promotion.py
@@ -1,0 +1,77 @@
+"""Archiving the default child must promote a remaining profile (#744).
+
+Before this fix, archiving the default child cleared `users.default_child_id`
+to NULL and left no `is_default` profile, stranding the account with no active
+child even when other profiles existed.
+
+Parent Epic: #436 | Issue: #744
+"""
+
+import pytest
+import pytest_asyncio
+
+from backend.src.services.database.child_profile_repository import (
+    ChildProfileRepository,
+)
+from backend.src.services.database.connection import DatabaseManager
+from backend.src.services.database.schema import init_schema
+
+USER = "user-1"
+
+
+@pytest_asyncio.fixture
+async def repo():
+    db = DatabaseManager(":memory:")
+    await db.connect()
+    await init_schema(db)
+    # A user row so we can assert users.default_child_id sync.
+    await db.execute(
+        "INSERT INTO users (user_id, username, email, password_hash, created_at, updated_at) "
+        "VALUES (?, 'u1', 'u1@example.com', 'x', '2026-01-01', '2026-01-01')",
+        (USER,),
+    )
+    await db.commit()
+    r = ChildProfileRepository(db)
+    yield r
+    await db.disconnect()
+
+
+async def _default_child_id(repo):
+    row = await repo._db.fetchone(
+        "SELECT default_child_id FROM users WHERE user_id = ?", (USER,)
+    )
+    return row.get("default_child_id") if row else None
+
+
+@pytest.mark.asyncio
+async def test_archiving_default_promotes_oldest_remaining(repo):
+    # child_old created first, then child_new which becomes default.
+    await repo.create(user_id=USER, child_id="child_old", name="Old", age_group="9-12", is_default=False)
+    await repo.create(user_id=USER, child_id="child_new", name="New", age_group="9-12", is_default=True)
+
+    await repo.archive(user_id=USER, child_id="child_new")
+
+    remaining = await repo.get_for_user(USER, "child_old")
+    assert remaining.is_default is True
+    assert await _default_child_id(repo) == "child_old"
+
+
+@pytest.mark.asyncio
+async def test_archiving_last_active_clears_default(repo):
+    await repo.create(user_id=USER, child_id="only_child", name="Solo", age_group="9-12", is_default=True)
+
+    await repo.archive(user_id=USER, child_id="only_child")
+
+    assert await _default_child_id(repo) is None
+
+
+@pytest.mark.asyncio
+async def test_archiving_non_default_leaves_default_untouched(repo):
+    await repo.create(user_id=USER, child_id="keep", name="Keep", age_group="9-12", is_default=True)
+    await repo.create(user_id=USER, child_id="extra", name="Extra", age_group="9-12", is_default=False)
+
+    await repo.archive(user_id=USER, child_id="extra")
+
+    keep = await repo.get_for_user(USER, "keep")
+    assert keep.is_default is True
+    assert await _default_child_id(repo) == "keep"


### PR DESCRIPTION
## Summary

Fixes a profile-management bug uncovered while debugging why a user's Morning Show guest picker showed unfamiliar characters.

**Root cause:** `archive()` (`backend/src/services/database/child_profile_repository.py`) cleared `users.default_child_id` to `NULL` when archiving the **default** child and never promoted a replacement, so the account was left with no active child even when other profiles remained. Kid-facing surfaces then fell back to the wrong/empty roster.

**Real-world trace:** a user archived their character-rich "Demi" profile; with no default promoted, the account later defaulted to a sparse "Diana" profile, so the picker listed Diana's characters (Clara/Stella/Marcus) and none of the user's roster (Ember/Luna/…).

## Fix

`archive()` now calls `_promote_new_default()`: when the archived profile was the default, promote the **oldest remaining active profile** (set `is_default = 1` + sync `users.default_child_id`). Only fall back to `None` when no active profile remains. Non-default archives are untouched.

## Tests

New `backend/tests/contracts/test_child_profile_archive_promotion.py`:
- archive default with another active profile → oldest remaining promoted ✅
- archive the last active profile → default becomes `None` ✅
- archive a non-default profile → existing default untouched ✅

Existing `test_child_profiles_contract.py` passes (9 total).

Fixes #744 · Related to epic #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)
