### PR TITLE
fix(memory): show the selected child's own characters, not a sibling's (#747)

### DIFF
--- a/frontend/src/hooks/__tests__/useMemoryApi.fallback.test.ts
+++ b/frontend/src/hooks/__tests__/useMemoryApi.fallback.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldUseFallbackMemory } from "@/hooks/useMemoryApi";
+
+/**
+ * The memory fallback must never override an explicitly-selected child that
+ * has its own data. It may only borrow the resolved primary child's memory
+ * when the selected child has none. (#747)
+ */
+describe("shouldUseFallbackMemory", () => {
+  it("does NOT override a selected child that has its own data", () => {
+    // Diana selected (score 15) vs higher-activity Demi (score 25).
+    expect(shouldUseFallbackMemory(true, 15, 25)).toBe(false);
+  });
+
+  it("falls back when the selected child has no memory but the primary does", () => {
+    expect(shouldUseFallbackMemory(true, 0, 25)).toBe(true);
+  });
+
+  it("does not fall back when there is no fallback child", () => {
+    expect(shouldUseFallbackMemory(false, 0, 25)).toBe(false);
+  });
+
+  it("does not fall back when both children are empty", () => {
+    expect(shouldUseFallbackMemory(true, 0, 0)).toBe(false);
+  });
+
+  it("does not fall back when the selected child has data even if primary is empty", () => {
+    expect(shouldUseFallbackMemory(true, 10, 0)).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useMemoryApi.ts
+++ b/frontend/src/hooks/useMemoryApi.ts
@@ -156,6 +156,20 @@ function memoryDataScore(
   return characters.length * 5 + profileScore(preferences);
 }
 
+/**
+ * Decide whether to show the resolved primary child's memory instead of the
+ * explicitly-selected child's. We only borrow another child's data when the
+ * selected child has NONE of its own — an explicit, non-empty selection is
+ * never overridden, even by a higher-activity sibling (#747).
+ */
+export function shouldUseFallbackMemory(
+  hasFallbackChild: boolean,
+  preferredScore: number,
+  fallbackScore: number,
+): boolean {
+  return hasFallbackChild && preferredScore === 0 && fallbackScore > 0;
+}
+
 export function useMemoryApi(childId: string | null) {
   const queryClient = useQueryClient();
   const { user } = useAuthStore();
@@ -249,7 +263,11 @@ export function useMemoryApi(childId: string | null) {
     fallbackCharacters,
     fallbackPreferences,
   );
-  const useFallbackData = !!fallbackChildId && fallbackScore > preferredScore;
+  const useFallbackData = shouldUseFallbackMemory(
+    !!fallbackChildId,
+    preferredScore,
+    fallbackScore,
+  );
   const activeChildId = useFallbackData ? fallbackChildId : preferredChildId;
 
   const activeCharacters = useFallbackData


### PR DESCRIPTION
## Summary

On the Profile **Memory** section, the selected child's characters didn't show — a higher-activity sibling's roster appeared instead. With "Diana" active (Stella, Clara, Marcus), the gallery showed the user's "Demi" roster, not Diana's.

**Root cause:** `frontend/src/hooks/useMemoryApi.ts` resolves the user's "primary" child via `GET /memory/child-id` (most stories) and, when it differs from the explicitly-selected child, shows whichever has the higher `memoryDataScore` (`characters*5 + prefs`):

```js
const useFallbackData = !!fallbackChildId && fallbackScore > preferredScore;
```

So Diana (3 chars → 15) was silently overridden by Demi (5 chars → 25). The fallback was meant only for the case where the selected child has *no* memory yet.

## Fix

Extract the decision into a pure, exported `shouldUseFallbackMemory(hasFallbackChild, preferredScore, fallbackScore)` that borrows the primary child's data **only when the selected child has none of its own** (`preferredScore === 0 && fallbackScore > 0`). An explicit, non-empty selection is never overridden.

## Tests

New `frontend/src/hooks/__tests__/useMemoryApi.fallback.test.ts` (5 cases): no-override-when-selected-has-data (the bug), fall-back-when-empty, no-fallback-child, both-empty, selected-has-data-primary-empty. `tsc --noEmit` clean.

Fixes #747 · Related to epic #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
