### PR TITLE
fix(memory): rank "Main characters" by appearance frequency, not story-lead

### DIFF
--- a/backend/src/services/database/character_repository.py
+++ b/backend/src/services/database/character_repository.py
@@ -15,6 +15,10 @@ from typing import Any, Dict, List, Optional
 
 from .connection import db_manager
 
+# Number of most-frequently-appearing characters shown as "Main characters"
+# in the Profile → Memory gallery. The rest are grouped as "Other characters".
+MAIN_CHARACTER_LIMIT = 5
+
 
 class CharacterRepository:
     def __init__(self):
@@ -339,40 +343,40 @@ class CharacterRepository:
     async def get_characters_grouped(
         self, user_id: str, child_id: str
     ) -> Dict[str, List[Dict[str, Any]]]:
-        """Return character gallery split into main/supporting groups."""
+        """Return character gallery split into main/supporting groups.
+
+        "Main characters" are the most frequently appearing characters — the
+        top ``MAIN_CHARACTER_LIMIT`` by ``appearance_count`` — because the
+        gallery should surface a child's recurring stars, not whoever happened
+        to lead a single story. Everyone else is grouped as "other". Ties are
+        broken by recency (``last_seen_at``) then name for a stable ordering.
+
+        ``main_story_count`` is still attached to each entry for reference, but
+        it no longer gates the grouping.
+        """
         characters = await self.get_characters(user_id, child_id)
         main_story_counts = await self._get_main_story_counts(user_id, child_id)
 
+        ranked = sorted(
+            (dict(item) for item in characters),
+            key=lambda c: (
+                int(c.get("appearance_count", 0)),
+                c.get("last_seen_at", "") or "",
+                c.get("name", "") or "",
+            ),
+            reverse=True,
+        )
+
         main_characters: List[Dict[str, Any]] = []
         other_characters: List[Dict[str, Any]] = []
-
-        for item in characters:
-            entry = dict(item)
+        for index, entry in enumerate(ranked):
             key = self._normalized_name_key(entry.get("name", ""))
-            main_count = int(main_story_counts.get(key, 0)) if key else 0
-            entry["main_story_count"] = main_count
-            entry["character_role"] = "main" if main_count > 0 else "other"
-
-            if main_count > 0:
-                main_characters.append(entry)
-            else:
-                other_characters.append(entry)
-
-        main_characters.sort(
-            key=lambda c: (
-                int(c.get("main_story_count", 0)),
-                int(c.get("appearance_count", 0)),
-                c.get("last_seen_at", ""),
-            ),
-            reverse=True,
-        )
-        other_characters.sort(
-            key=lambda c: (
-                int(c.get("appearance_count", 0)),
-                c.get("last_seen_at", ""),
-            ),
-            reverse=True,
-        )
+            entry["main_story_count"] = (
+                int(main_story_counts.get(key, 0)) if key else 0
+            )
+            is_main = index < MAIN_CHARACTER_LIMIT
+            entry["character_role"] = "main" if is_main else "other"
+            (main_characters if is_main else other_characters).append(entry)
 
         # Keep backward compatibility for existing consumers.
         all_characters = main_characters + other_characters

--- a/backend/tests/api/test_memory.py
+++ b/backend/tests/api/test_memory.py
@@ -130,52 +130,47 @@ class TestMemoryCharactersEndpoints:
             assert "main_characters" in resp.json()
             assert "other_characters" in resp.json()
 
-    async def test_get_characters_grouped_main_and_other(self, test_client):
+    async def test_get_characters_grouped_by_appearance_frequency(self, test_client):
+        """Main characters are the top 5 by appearance frequency, not story-lead.
+
+        A frequently-appearing supporting character must rank as "main", and a
+        one-off lead must drop to "other" once 5 more-frequent characters exist.
+        """
         child_id = f"child-chr-group-{uuid.uuid4().hex[:8]}"
-        story_id_1 = f"story-chr-group-1-{uuid.uuid4().hex[:8]}"
-        story_id_2 = f"story-chr-group-2-{uuid.uuid4().hex[:8]}"
         async with test_client as client:
             from backend.src.services.database import character_repo, story_repo
 
-            await character_repo.upsert_character(
-                user_id="test_user",
-                child_id=child_id,
-                name="Hero Fox",
-                description="The protagonist",
-            )
-            await character_repo.upsert_character(
-                user_id="test_user",
-                child_id=child_id,
-                name="Helper Bunny",
-                description="The helper",
-            )
+            # Seed 6 characters with descending appearance frequency.
+            # frequency: Star=6, Comet=5, Nova=4, Luna=3, Sol=2, Pip=1
+            seeds = [
+                ("Star", 6),
+                ("Comet", 5),
+                ("Nova", 4),
+                ("Luna", 3),
+                ("Sol", 2),
+                ("Pip", 1),
+            ]
+            for name, freq in seeds:
+                for _ in range(freq):
+                    await character_repo.upsert_character(
+                        user_id="test_user",
+                        child_id=child_id,
+                        name=name,
+                        description=f"{name} character",
+                    )
 
+            # Make the *least* frequent character (Pip) the lead of a story.
+            # Under the old rule this forced Pip into "main"; it must NOT now.
+            story_id = f"story-chr-group-{uuid.uuid4().hex[:8]}"
             await story_repo.create(
                 {
-                    "story_id": story_id_1,
+                    "story_id": story_id,
                     "user_id": "test_user",
                     "child_id": child_id,
                     "age_group": "6-8",
-                    "story": {"text": "Story one", "word_count": 2},
+                    "story": {"text": "Pip's tale", "word_count": 2},
                     "educational_value": {"themes": [], "concepts": [], "moral": None},
-                    "characters": [
-                        {"character_name": "Hero Fox"},
-                        {"character_name": "Helper Bunny"},
-                    ],
-                    "analysis": {},
-                    "safety_score": 0.9,
-                    "story_type": "image_to_story",
-                }
-            )
-            await story_repo.create(
-                {
-                    "story_id": story_id_2,
-                    "user_id": "test_user",
-                    "child_id": child_id,
-                    "age_group": "6-8",
-                    "story": {"text": "Story two", "word_count": 2},
-                    "educational_value": {"themes": [], "concepts": [], "moral": None},
-                    "characters": [{"name": "Hero Fox"}],
+                    "characters": [{"character_name": "Pip"}],
                     "analysis": {},
                     "safety_score": 0.9,
                     "story_type": "image_to_story",
@@ -188,12 +183,19 @@ class TestMemoryCharactersEndpoints:
 
             main_names = [c["name"] for c in body["main_characters"]]
             other_names = [c["name"] for c in body["other_characters"]]
-            assert "Hero Fox" in main_names
-            assert "Helper Bunny" in other_names
 
-            hero = next(c for c in body["main_characters"] if c["name"] == "Hero Fox")
-            assert hero["main_story_count"] == 2
-            assert hero["character_role"] == "main"
+            # Top 5 by frequency are "main"; the 6th drops to "other".
+            assert main_names == ["Star", "Comet", "Nova", "Luna", "Sol"]
+            assert other_names == ["Pip"]
+
+            # A one-off story lead with the lowest frequency is NOT main.
+            assert "Pip" not in main_names
+            pip = next(c for c in body["other_characters"] if c["name"] == "Pip")
+            assert pip["character_role"] == "other"
+
+            star = next(c for c in body["main_characters"] if c["name"] == "Star")
+            assert star["character_role"] == "main"
+            assert star["appearance_count"] == 6
 
     async def test_delete_single_character_item(self, test_client):
         child_id = f"child-chr-item-{uuid.uuid4().hex[:8]}"

--- a/backend/tests/contracts/test_character_repository_contract.py
+++ b/backend/tests/contracts/test_character_repository_contract.py
@@ -515,3 +515,77 @@ class TestJsonFields:
         assert char["appearance_count"] == 2
         assert char["visual_features"] == {"features": ["star forehead", "sparkly fur"]}
         assert char["traits"] == ["curious", "gentle"]
+
+
+# ============================================================================
+# get_characters_grouped — main/other by appearance frequency (Issue #746)
+# ============================================================================
+
+
+class TestGroupedByFrequency:
+    """Contract: 'Main characters' are the top-N most frequently appearing.
+
+    Regression for #746 — grouping used to be gated by main_story_count
+    (was this character a story's lead), which mis-sorted frequent supporting
+    characters into 'other' and one-off leads into 'main'.
+    """
+
+    @pytest.fixture
+    async def db_with_stories(self, db):
+        """Augment the in-memory db with a minimal stories table."""
+        await db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS stories (
+                story_id TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL DEFAULT '',
+                child_id TEXT NOT NULL,
+                characters TEXT,
+                created_at TEXT NOT NULL DEFAULT ''
+            )
+            """
+        )
+        await db.commit()
+        return db
+
+    @pytest.mark.asyncio
+    async def test_top5_by_appearance_are_main(self, db_with_stories):
+        repo = CharacterRepository()
+        repo._db = db_with_stories
+
+        # frequency: Star=6, Comet=5, Nova=4, Luna=3, Sol=2, Pip=1
+        seeds = [("Star", 6), ("Comet", 5), ("Nova", 4), ("Luna", 3), ("Sol", 2), ("Pip", 1)]
+        for name, freq in seeds:
+            for _ in range(freq):
+                await repo.upsert_character(
+                    user_id="u1", child_id="c1", name=name, description=f"{name}"
+                )
+
+        # Make the least-frequent character (Pip) the lead of a story.
+        await db_with_stories.execute(
+            "INSERT INTO stories (story_id, user_id, child_id, characters, created_at) VALUES (?, ?, ?, ?, ?)",
+            ("s1", "u1", "c1", json.dumps([{"character_name": "Pip"}]), "2026-01-01"),
+        )
+        await db_with_stories.commit()
+
+        grouped = await repo.get_characters_grouped("u1", "c1")
+        main_names = [c["name"] for c in grouped["main_characters"]]
+        other_names = [c["name"] for c in grouped["other_characters"]]
+
+        assert main_names == ["Star", "Comet", "Nova", "Luna", "Sol"]
+        assert other_names == ["Pip"]
+        # A one-off story lead with the lowest frequency must NOT be main.
+        assert all(c["character_role"] == "main" for c in grouped["main_characters"])
+        pip = grouped["other_characters"][0]
+        assert pip["character_role"] == "other"
+        assert pip["main_story_count"] == 1  # still reported, just not gating
+
+    @pytest.mark.asyncio
+    async def test_fewer_than_limit_all_main(self, db_with_stories):
+        repo = CharacterRepository()
+        repo._db = db_with_stories
+        for name in ["A", "B", "C"]:
+            await repo.upsert_character(user_id="u2", child_id="c2", name=name)
+
+        grouped = await repo.get_characters_grouped("u2", "c2")
+        assert len(grouped["main_characters"]) == 3
+        assert grouped["other_characters"] == []

--- a/frontend/src/hooks/useMemoryApi.ts
+++ b/frontend/src/hooks/useMemoryApi.ts
@@ -14,6 +14,11 @@ import type {
 } from "@/types/api";
 import useAuthStore from "@/store/useAuthStore";
 
+// "Main characters" = the most frequently appearing characters (top N by
+// appearance_count). Keep in sync with MAIN_CHARACTER_LIMIT in
+// backend/src/services/database/character_repository.py.
+const MAIN_CHARACTER_LIMIT = 5;
+
 function normalizeCharacterName(name: string): string {
   if (!name) return "";
   return name
@@ -84,12 +89,10 @@ function mergeCharacters(items: MemoryCharacter[]): MemoryCharacter[] {
       main_story_count:
         Number(existing.main_story_count || 0) +
         Number(item.main_story_count || 0),
-      character_role:
-        Number(existing.main_story_count || 0) +
-          Number(item.main_story_count || 0) >
-        0
-          ? "main"
-          : "other",
+      // Grouping is decided by appearance frequency (see splitCharacterGroups);
+      // preserve whichever role the backend assigned rather than re-deriving it
+      // from main_story_count, which no longer gates main/other.
+      character_role: existing.character_role ?? item.character_role,
       description:
         (item.description?.length || 0) > (existing.description?.length || 0)
           ? item.description
@@ -104,19 +107,10 @@ function mergeCharacters(items: MemoryCharacter[]): MemoryCharacter[] {
     });
   }
 
-  return Array.from(merged.values())
-    .map((c) => {
-      const role: MemoryCharacter["character_role"] =
-        Number(c.main_story_count || 0) > 0 ? "main" : "other";
-      return {
-        ...c,
-        character_role: role,
-      };
-    })
-    .sort(
-      (a, b) =>
-        Number(b.appearance_count || 0) - Number(a.appearance_count || 0),
-    );
+  return Array.from(merged.values()).sort(
+    (a, b) =>
+      Number(b.appearance_count || 0) - Number(a.appearance_count || 0),
+  );
 }
 
 function splitCharacterGroups(
@@ -128,14 +122,16 @@ function splitCharacterGroups(
     return { main: hintedMain, other: hintedOther };
   }
 
-  const main = allCharacters.filter(
-    (c) => Number(c.main_story_count || 0) > 0 || c.character_role === "main",
+  // Fallback when the backend sent no grouped hints: rank by appearance
+  // frequency and treat the top N as main characters, the rest as other.
+  const ranked = [...allCharacters].sort(
+    (a, b) =>
+      Number(b.appearance_count || 0) - Number(a.appearance_count || 0),
   );
-  const other = allCharacters.filter(
-    (c) =>
-      !(Number(c.main_story_count || 0) > 0 || c.character_role === "main"),
-  );
-  return { main, other };
+  return {
+    main: ranked.slice(0, MAIN_CHARACTER_LIMIT),
+    other: ranked.slice(MAIN_CHARACTER_LIMIT),
+  };
 }
 
 function profileScore(profile: PreferenceProfile | null): number {

--- a/frontend/src/pages/ProfilePage/CharacterGallery.tsx
+++ b/frontend/src/pages/ProfilePage/CharacterGallery.tsx
@@ -14,6 +14,10 @@ interface CharacterGalleryProps {
   deletingCharacterName?: string | null;
 }
 
+// "Main characters" = the most frequently appearing characters (top N by
+// appearance_count). Keep in sync with the backend grouping and useMemoryApi.
+const MAIN_CHARACTER_LIMIT = 5;
+
 const CARD_COLORS = [
   "from-purple-100 to-purple-50 border-purple-200",
   "from-blue-100 to-blue-50 border-blue-200",
@@ -36,18 +40,18 @@ function CharacterGallery({
 }: CharacterGalleryProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const hasGrouped = mainCharacters.length > 0 || otherCharacters.length > 0;
+  // Fallback when the backend sent no grouped arrays: rank by appearance
+  // frequency and treat the top N as main characters, the rest as other.
+  const rankedByFrequency = [...characters].sort(
+    (a, b) =>
+      Number(b.appearance_count || 0) - Number(a.appearance_count || 0),
+  );
   const resolvedMainCharacters = hasGrouped
     ? mainCharacters
-    : characters.filter(
-        (c) =>
-          Number(c.main_story_count || 0) > 0 || c.character_role === "main",
-      );
+    : rankedByFrequency.slice(0, MAIN_CHARACTER_LIMIT);
   const resolvedOtherCharacters = hasGrouped
     ? otherCharacters
-    : characters.filter(
-        (c) =>
-          !(Number(c.main_story_count || 0) > 0 || c.character_role === "main"),
-      );
+    : rankedByFrequency.slice(MAIN_CHARACTER_LIMIT);
 
   const renderCharacterCards = (items: MemoryCharacter[], offset = 0) =>
     items.map((character, index) => (


### PR DESCRIPTION
## Summary
Profile → Memory → **My Characters** split the roster into **Main** and **Other** based on `main_story_count` (whether a character was ever a story's *lead*). A frequently-appearing supporting character showed under **Other**, while a one-off protagonist (appearance_count = 1) showed under **Main** — the opposite of what users expect.

Now **Main characters = the top 5 by `appearance_count` (frequency)**, descending, ties broken by `last_seen_at` then name; everyone else is **Other**. `main_story_count` is still attached for reference but no longer gates grouping.

## Changes
- `backend/.../character_repository.py` — `get_characters_grouped()` ranks by `appearance_count`, top `MAIN_CHARACTER_LIMIT` (5) = main.
- `frontend/.../useMemoryApi.ts` — fallback split ranks by frequency; `mergeCharacters` preserves the backend role instead of re-deriving from `main_story_count`.
- `frontend/.../CharacterGallery.tsx` — no-hint fallback ranks by frequency.

## Tests
- `tests/contracts/test_character_repository_contract.py::TestGroupedByFrequency` — new, runs on SQLite locally. ✅ passing
- `tests/api/test_memory.py` — grouped test rewritten for frequency semantics (CI).

Note: the API suite can't run in this local env due to a pre-existing pytest-asyncio 0.23 session-pool event-loop mismatch (unrelated); the SQLite contract test is the local regression guard.

Fixes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)