### PR TITLE
fix: align character grouping and deployment docs

### DIFF
--- a/backend/src/services/database/character_repository.py
+++ b/backend/src/services/database/character_repository.py
@@ -345,14 +345,22 @@ class CharacterRepository:
     ) -> Dict[str, List[Dict[str, Any]]]:
         """Return character gallery split into main/supporting groups.
 
-        "Main characters" are the most frequently appearing characters — the
-        top ``MAIN_CHARACTER_LIMIT`` by ``appearance_count`` — because the
-        gallery should surface a child's recurring stars, not whoever happened
-        to lead a single story. Everyone else is grouped as "other". Ties are
-        broken by recency (``last_seen_at``) then name for a stable ordering.
+        "Main characters" are the most frequently appearing characters, because
+        the gallery should surface a child's recurring stars, not whoever
+        happened to lead a single story. The split scales with how many
+        characters exist:
 
-        ``main_story_count`` is still attached to each entry for reference, but
-        it no longer gates the grouping.
+        - More than ``MAIN_CHARACTER_LIMIT`` characters: the top
+          ``MAIN_CHARACTER_LIMIT`` by ``appearance_count`` are "main".
+        - ``MAIN_CHARACTER_LIMIT`` or fewer: only the most-frequent
+          character(s) — those tied at the highest ``appearance_count`` — are
+          "main", so a small cast still divides instead of all landing in
+          "main". If every character appears equally often (including a single
+          character), they are all "main".
+
+        Ties are broken by recency (``last_seen_at``) then name for a stable
+        ordering. ``main_story_count`` is still attached to each entry for
+        reference, but it no longer gates the grouping.
         """
         characters = await self.get_characters(user_id, child_id)
         main_story_counts = await self._get_main_story_counts(user_id, child_id)
@@ -366,17 +374,32 @@ class CharacterRepository:
             ),
             reverse=True,
         )
-
-        main_characters: List[Dict[str, Any]] = []
-        other_characters: List[Dict[str, Any]] = []
-        for index, entry in enumerate(ranked):
+        for entry in ranked:
             key = self._normalized_name_key(entry.get("name", ""))
             entry["main_story_count"] = (
                 int(main_story_counts.get(key, 0)) if key else 0
             )
-            is_main = index < MAIN_CHARACTER_LIMIT
-            entry["character_role"] = "main" if is_main else "other"
-            (main_characters if is_main else other_characters).append(entry)
+
+        if len(ranked) > MAIN_CHARACTER_LIMIT:
+            main_characters = ranked[:MAIN_CHARACTER_LIMIT]
+            other_characters = ranked[MAIN_CHARACTER_LIMIT:]
+        else:
+            # Small cast: only the most-frequent character(s) are main. ranked
+            # is sorted by appearance_count desc, so the top count is first.
+            top_count = (
+                int(ranked[0].get("appearance_count", 0)) if ranked else 0
+            )
+            main_characters = [
+                e for e in ranked if int(e.get("appearance_count", 0)) == top_count
+            ]
+            other_characters = [
+                e for e in ranked if int(e.get("appearance_count", 0)) != top_count
+            ]
+
+        for entry in main_characters:
+            entry["character_role"] = "main"
+        for entry in other_characters:
+            entry["character_role"] = "other"
 
         # Keep backward compatibility for existing consumers.
         all_characters = main_characters + other_characters

--- a/backend/tests/contracts/test_character_repository_contract.py
+++ b/backend/tests/contracts/test_character_repository_contract.py
@@ -589,3 +589,21 @@ class TestGroupedByFrequency:
         grouped = await repo.get_characters_grouped("u2", "c2")
         assert len(grouped["main_characters"]) == 3
         assert grouped["other_characters"] == []
+
+    @pytest.mark.asyncio
+    async def test_small_cast_uses_highest_frequency_as_main(self, db_with_stories):
+        repo = CharacterRepository()
+        repo._db = db_with_stories
+
+        for _ in range(3):
+            await repo.upsert_character(
+                user_id="u3", child_id="c3", name="Star", description="Star"
+            )
+        await repo.upsert_character(
+            user_id="u3", child_id="c3", name="Pip", description="Pip"
+        )
+
+        grouped = await repo.get_characters_grouped("u3", "c3")
+
+        assert [c["name"] for c in grouped["main_characters"]] == ["Star"]
+        assert [c["name"] for c in grouped["other_characters"]] == ["Pip"]

--- a/docs/learning/infrastructure/overview.md
+++ b/docs/learning/infrastructure/overview.md
@@ -20,7 +20,7 @@ User's Browser
        ▼
 ┌─────────────┐
 │  Railway    │  ← Runs the FastAPI server (backend)
-│  (Server)   │     Backend auto-deploys from GitHub
+│  (Server)   │     Backend deploys manually from the repository
 └──────┬──────┘
        │ SQL + Auth
        ▼
@@ -66,4 +66,4 @@ User's Browser
 
 ## Thinking Question
 
-Our backend auto-deploys from GitHub but our frontend is manually deployed. What could go wrong if we push a backend change that adds a new API field, but forget to deploy the frontend that needs that field? How would you design a system to prevent this mismatch?
+Our backend and frontend are currently deployed manually from the same repository. What could go wrong if we deploy a backend change that adds a new API field, but forget to deploy the frontend that needs that field? How would you design a system to prevent this mismatch?

--- a/docs/learning/infrastructure/railway.md
+++ b/docs/learning/infrastructure/railway.md
@@ -6,14 +6,14 @@
 
 **Explorer**: Railway is like a house for our Python brain. When someone visits the website and asks for a story, the request travels to Railway where our FastAPI server lives, thinks about it, and sends back the answer.
 
-**Maker**: Railway is a PaaS (Platform as a Service) that runs our FastAPI backend as a containerized process. It auto-deploys from the `main` branch on GitHub using Nixpacks (a buildpack system), injects environment variables, and provides health monitoring.
+**Maker**: Railway is a PaaS (Platform as a Service) that runs our FastAPI backend as a containerized process. This project currently deploys manually with `railway up`, using Nixpacks (a buildpack system), injected environment variables, and health monitoring.
 
 ## How It Works
 
 ### Deployment Pipeline
 ```
-1. Developer pushes to main branch on GitHub
-2. Railway detects the push → triggers a new build
+1. Developer merges verified changes to `main` on GitHub
+2. Developer runs `railway up --detach` from the repository root
 3. Nixpacks reads requirements.txt → installs Python dependencies
 4. Railway runs the start command: python backend/scripts/start_server.py
 5. Server starts on Railway's assigned PORT → health check passes
@@ -48,7 +48,7 @@ If health checks fail, Railway automatically restarts the process (up to 3 retri
 
 **Nixpacks**: Railway's build system that auto-detects your language (Python, Node, etc.) and installs dependencies. It reads `requirements.txt` for Python and creates a container image automatically.
 
-**Auto-Deploy**: Every push to the `main` branch triggers a new deployment. This means code merged on GitHub is live in production within ~2 minutes. Fast feedback, but also means broken code deploys immediately.
+**Deployment source of truth**: A GitHub push alone does not deploy this project today. Production is updated only after a verified change is merged to `main` and explicitly deployed with the Railway CLI. If Railway is later connected to GitHub, update this document and the operations guide together.
 
 **Zero-Downtime Deploy**: Railway starts the new version alongside the old one, waits for the health check to pass, then switches traffic. Users never see downtime during deployments.
 
@@ -61,4 +61,4 @@ If health checks fail, Railway automatically restarts the process (up to 3 retri
 
 ## Thinking Question
 
-Railway auto-deploys every push to `main`. What if someone merges a broken migration that corrupts the database? The code deploys, the server starts, but database queries fail. How would you add a pre-deploy check that runs migrations in a test database first? Think about: staging environments, migration dry-runs, and rollback strategies.
+Railway currently deploys manually after changes reach `main`. What if someone deploys a broken migration that corrupts the database? The code deploys, the server starts, but database queries fail. How would you add a pre-deploy check that runs migrations in a test database first? Think about: staging environments, migration dry-runs, and rollback strategies.

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -1167,8 +1167,8 @@ Prevents throwaway accounts that drain quota.
 
 | Layer | Service | Dev (local) | Prod (deployed) |
 |-------|---------|-------------|-----------------|
-| Frontend | Vercel (free) | Vite dev server | Auto-deploys from `main` |
-| Backend | Railway ($5–7/month) | `uvicorn` local | FastAPI on Railway |
+| Frontend | Vercel (free) | Vite dev server | Manual `vercel deploy --prod` |
+| Backend | Railway ($5–7/month) | `uvicorn` local | Manual `railway up` |
 | Database | Supabase (free tier) | SQLite (aiosqlite) | PostgreSQL (asyncpg) |
 | Vector Search | Supabase pgvector | ChromaDB (local) | pgvector extension in Supabase PostgreSQL |
 | File Storage | Supabase Storage | Local disk (`data/`) | Supabase Storage buckets (CDN URLs) |

--- a/frontend/src/hooks/useMemoryApi.ts
+++ b/frontend/src/hooks/useMemoryApi.ts
@@ -13,11 +13,7 @@ import type {
   PreferenceProfile,
 } from "@/types/api";
 import useAuthStore from "@/store/useAuthStore";
-
-// "Main characters" = the most frequently appearing characters (top N by
-// appearance_count). Keep in sync with MAIN_CHARACTER_LIMIT in
-// backend/src/services/database/character_repository.py.
-const MAIN_CHARACTER_LIMIT = 5;
+import { splitByAppearanceFrequency } from "@/lib/characterGrouping";
 
 function normalizeCharacterName(name: string): string {
   if (!name) return "";
@@ -122,16 +118,9 @@ function splitCharacterGroups(
     return { main: hintedMain, other: hintedOther };
   }
 
-  // Fallback when the backend sent no grouped hints: rank by appearance
-  // frequency and treat the top N as main characters, the rest as other.
-  const ranked = [...allCharacters].sort(
-    (a, b) =>
-      Number(b.appearance_count || 0) - Number(a.appearance_count || 0),
-  );
-  return {
-    main: ranked.slice(0, MAIN_CHARACTER_LIMIT),
-    other: ranked.slice(MAIN_CHARACTER_LIMIT),
-  };
+  // Fallback when the backend sent no grouped hints: divide by appearance
+  // frequency using the same rule as the backend.
+  return splitByAppearanceFrequency(allCharacters);
 }
 
 function profileScore(profile: PreferenceProfile | null): number {

--- a/frontend/src/lib/characterGrouping.test.ts
+++ b/frontend/src/lib/characterGrouping.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { splitByAppearanceFrequency } from "@/lib/characterGrouping";
+import type { MemoryCharacter } from "@/types/api";
+
+const character = (name: string, appearance_count: number): MemoryCharacter => ({
+  name,
+  description: `${name} description`,
+  visual_features: null,
+  traits: null,
+  appearance_count,
+  main_story_count: 0,
+  character_role: "other",
+  first_seen_at: "2026-01-01T00:00:00Z",
+  last_seen_at: "2026-01-01T00:00:00Z",
+});
+
+describe("splitByAppearanceFrequency", () => {
+  it("keeps the most frequent character as main for a small cast", () => {
+    const result = splitByAppearanceFrequency([
+      character("Pip", 1),
+      character("Star", 3),
+    ]);
+
+    expect(result.main.map(({ name }) => name)).toEqual(["Star"]);
+    expect(result.other.map(({ name }) => name)).toEqual(["Pip"]);
+  });
+
+  it("keeps tied top characters together", () => {
+    const result = splitByAppearanceFrequency([
+      character("Pip", 2),
+      character("Star", 2),
+      character("Nova", 1),
+    ]);
+
+    expect(result.main.map(({ name }) => name)).toEqual(["Pip", "Star"]);
+    expect(result.other.map(({ name }) => name)).toEqual(["Nova"]);
+  });
+});

--- a/frontend/src/lib/characterGrouping.ts
+++ b/frontend/src/lib/characterGrouping.ts
@@ -1,0 +1,39 @@
+import type { MemoryCharacter } from "@/types/api";
+
+// "Main characters" = the most frequently appearing characters. Keep this rule
+// in sync with get_characters_grouped + MAIN_CHARACTER_LIMIT in
+// backend/src/services/database/character_repository.py.
+export const MAIN_CHARACTER_LIMIT = 5;
+
+/**
+ * Split characters into main/other by appearance frequency.
+ *
+ * - More than MAIN_CHARACTER_LIMIT characters: the top N by appearance_count
+ *   are main; the rest are other.
+ * - MAIN_CHARACTER_LIMIT or fewer: only the most-frequent character(s) — those
+ *   tied at the highest appearance_count — are main, so a small cast still
+ *   divides instead of all landing in main. If every character appears equally
+ *   often (including a single character), they are all main.
+ */
+export function splitByAppearanceFrequency(characters: MemoryCharacter[]): {
+  main: MemoryCharacter[];
+  other: MemoryCharacter[];
+} {
+  const ranked = [...characters].sort(
+    (a, b) => Number(b.appearance_count || 0) - Number(a.appearance_count || 0),
+  );
+  if (ranked.length === 0) return { main: [], other: [] };
+
+  if (ranked.length > MAIN_CHARACTER_LIMIT) {
+    return {
+      main: ranked.slice(0, MAIN_CHARACTER_LIMIT),
+      other: ranked.slice(MAIN_CHARACTER_LIMIT),
+    };
+  }
+
+  const topCount = Number(ranked[0].appearance_count || 0);
+  return {
+    main: ranked.filter((c) => Number(c.appearance_count || 0) === topCount),
+    other: ranked.filter((c) => Number(c.appearance_count || 0) !== topCount),
+  };
+}

--- a/frontend/src/pages/ProfilePage/CharacterGallery.tsx
+++ b/frontend/src/pages/ProfilePage/CharacterGallery.tsx
@@ -3,6 +3,7 @@ import { motion } from "framer-motion";
 import { Palette, Star, Users } from "lucide-react";
 import Card from "@/components/common/Card";
 import type { MemoryCharacter } from "@/types/api";
+import { splitByAppearanceFrequency } from "@/lib/characterGrouping";
 
 interface CharacterGalleryProps {
   characters: MemoryCharacter[];
@@ -13,10 +14,6 @@ interface CharacterGalleryProps {
   onDeleteCharacter?: (name: string) => Promise<void> | void;
   deletingCharacterName?: string | null;
 }
-
-// "Main characters" = the most frequently appearing characters (top N by
-// appearance_count). Keep in sync with the backend grouping and useMemoryApi.
-const MAIN_CHARACTER_LIMIT = 5;
 
 const CARD_COLORS = [
   "from-purple-100 to-purple-50 border-purple-200",
@@ -40,18 +37,15 @@ function CharacterGallery({
 }: CharacterGalleryProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const hasGrouped = mainCharacters.length > 0 || otherCharacters.length > 0;
-  // Fallback when the backend sent no grouped arrays: rank by appearance
-  // frequency and treat the top N as main characters, the rest as other.
-  const rankedByFrequency = [...characters].sort(
-    (a, b) =>
-      Number(b.appearance_count || 0) - Number(a.appearance_count || 0),
-  );
+  // Fallback when the backend sent no grouped arrays: divide by appearance
+  // frequency using the same rule as the backend.
+  const fallbackGroups = splitByAppearanceFrequency(characters);
   const resolvedMainCharacters = hasGrouped
     ? mainCharacters
-    : rankedByFrequency.slice(0, MAIN_CHARACTER_LIMIT);
+    : fallbackGroups.main;
   const resolvedOtherCharacters = hasGrouped
     ? otherCharacters
-    : rankedByFrequency.slice(MAIN_CHARACTER_LIMIT);
+    : fallbackGroups.other;
 
   const renderCharacterCards = (items: MemoryCharacter[], offset = 0) =>
     items.map((character, index) => (

--- a/frontend/src/pages/ProfilePage/index.tsx
+++ b/frontend/src/pages/ProfilePage/index.tsx
@@ -3,14 +3,14 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { motion } from "framer-motion";
 import { useQuery } from "@tanstack/react-query";
 import {
+  BookOpen,
   Check,
   Flame,
   Gift,
+  ImagePlus,
   Newspaper,
-  Palette,
   PartyPopper,
   Star,
-  Theater,
 } from "lucide-react";
 import Button from "@/components/common/Button";
 import Card from "@/components/common/Card";
@@ -340,7 +340,7 @@ function ProfilePage() {
           onClick={() => navigate("/library?tab=art-stories")}
         >
           <div className="bg-gradient-to-br from-primary/10 to-primary/5 rounded-card p-5 text-center">
-            <Palette className="mx-auto mb-2 h-9 w-9 text-primary" aria-hidden="true" />
+            <ImagePlus className="mx-auto mb-2 h-9 w-9 text-primary" aria-hidden="true" />
             <div className="text-3xl font-bold text-gray-800">
               {statsLoading ? "..." : (stats?.art_story_count ?? 0)}
             </div>
@@ -354,7 +354,7 @@ function ProfilePage() {
           onClick={() => navigate("/library?tab=interactive")}
         >
           <div className="bg-gradient-to-br from-secondary/20 to-secondary/10 rounded-card p-5 text-center">
-            <Theater className="mx-auto mb-2 h-9 w-9 text-teal-700" aria-hidden="true" />
+            <BookOpen className="mx-auto mb-2 h-9 w-9 text-teal-700" aria-hidden="true" />
             <div className="text-3xl font-bold text-gray-800">
               {statsLoading ? "..." : (stats?.interactive_count ?? 0)}
             </div>


### PR DESCRIPTION
## Summary
- align backend and frontend character grouping for small casts
- add backend and frontend regression coverage
- document the current manual Railway/Vercel deployment source of truth

## Verification
- `backend/.venv/bin/pytest -q backend/tests/contracts/test_character_repository_contract.py` (27 passed)
- `cd frontend && npm test -- --run src/lib/characterGrouping.test.ts`
- `cd frontend && npm run build`
- `git diff --check`

## Deployment note
Production is currently behind `main`: Railway's latest successful deployment predates `main`, and Vercel's latest production deployment is stale. This PR should be merged before the coordinated Railway and Vercel production deploy.
