### PR TITLE
fix(safety): revalidate agent-direct styled images

### DIFF
--- a/backend/src/agents/image_to_story_agent.py
+++ b/backend/src/agents/image_to_story_agent.py
@@ -233,6 +233,90 @@ async def _call_mcp_tool(tool_ref: Any, args: Dict[str, Any]) -> Dict[str, Any]:
     return result
 
 
+async def _validate_styled_image_for_delivery(
+    styled_image_path: str,
+    original_image_path: str,
+    child_age: int,
+    theme: str,
+    session_id: str,
+) -> tuple[Optional[str], Dict[str, Any]]:
+    """Return a styled image only after a successful vision safety check.
+
+    The direct agent path feeds its result to My Agent without passing through
+    the API-route safety gate. Keep this boundary fail-closed: a missing file,
+    validator exception, unsafe verdict, or unexpected validator path all
+    discard the generated image. The original drawing remains the caller's
+    fallback, so the unsafe candidate is never exposed.
+    """
+    fallback = {
+        "used_image_path": original_image_path,
+        "safety_passed": False,
+        "fell_back": True,
+    }
+
+    if not Path(styled_image_path).is_file():
+        logger.warning(
+            "Styled image safety validation skipped for missing file; discarding "
+            "candidate | original=%s styled=%s theme=%s session=%s",
+            original_image_path,
+            styled_image_path,
+            theme,
+            session_id,
+        )
+        return None, {**fallback, "reason": "Styled image file is missing"}
+
+    try:
+        from ..mcp_servers.image_style_server import validate_and_fallback
+
+        safety_result = await validate_and_fallback(
+            styled_image_path=styled_image_path,
+            original_image_path=original_image_path,
+            child_age=child_age,
+            theme=theme,
+            session_id=session_id,
+        )
+    except Exception as exc:  # noqa: BLE001 — safety boundary fails closed
+        logger.warning(
+            "Styled image safety validation failed; discarding candidate | "
+            "original=%s styled=%s theme=%s session=%s error=%s",
+            original_image_path,
+            styled_image_path,
+            theme,
+            session_id,
+            exc,
+            exc_info=True,
+        )
+        return None, {**fallback, "reason": f"Safety validation exception: {exc}"}
+
+    if not isinstance(safety_result, dict):
+        logger.warning(
+            "Styled image safety validator returned malformed result; discarding "
+            "candidate | original=%s styled=%s theme=%s session=%s",
+            original_image_path,
+            styled_image_path,
+            theme,
+            session_id,
+        )
+        return None, {**fallback, "reason": "Malformed safety validation result"}
+
+    if (
+        safety_result.get("safety_passed") is True
+        and safety_result.get("used_image_path") == styled_image_path
+    ):
+        return styled_image_path, safety_result
+
+    logger.warning(
+        "Styled image failed safety validation; discarding candidate | "
+        "original=%s styled=%s theme=%s session=%s reason=%s",
+        original_image_path,
+        styled_image_path,
+        theme,
+        session_id,
+        safety_result.get("reason"),
+    )
+    return None, safety_result
+
+
 def _should_use_mock() -> bool:
     """Return True in pytest, or when force-mock is enabled in test env only."""
     if os.getenv("PYTEST_CURRENT_TEST") is not None:
@@ -864,29 +948,17 @@ For "characters", list ONLY living characters (people, animals, or creatures wit
             pass
         # Step 5b: Re-validate the styled image for child safety (#710).
         # The API routes already gate stylized images via validate_and_fallback;
-        # the agent-direct path (used by My Agent) bypassed that check, so the
-        # styled image could be returned without a vision safety pass. We
-        # fail closed here — discard the styled image and fall back to the
-        # original drawing if validation fails or errors.
-        if styled_image_path and Path(styled_image_path).exists():
-            try:
-                from ..mcp_servers.image_style_server import validate_and_fallback
-
-                styled_image_safety = await validate_and_fallback(
+        # keep the direct agent path under the same fail-closed boundary.
+        if styled_image_path:
+            styled_image_path, _styled_image_safety = (
+                await _validate_styled_image_for_delivery(
                     styled_image_path=styled_image_path,
                     original_image_path=str(image_path),
                     child_age=child_age,
                     theme=art_theme,
                     session_id=child_id,
                 )
-                if not styled_image_safety.get("safety_passed"):
-                    styled_image_path = None
-            except Exception:
-                logger.warning(
-                    "Styled image safety validation failed (agent path), using original",
-                    exc_info=True,
-                )
-                styled_image_path = None
+            )
         yield {"type": "tool_result", "data": {"status": "completed"}}
 
     # Step 6: Audio generation (if enabled)

--- a/backend/tests/contracts/test_post_gen_safety.py
+++ b/backend/tests/contracts/test_post_gen_safety.py
@@ -425,3 +425,120 @@ async def test_image_to_story_direct_stream_invokes_post_gen_safety(
         "safety_check content_type=image_story" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_agent_direct_styled_image_safety_keeps_only_validated_image(
+    monkeypatch, tmp_path
+):
+    """The agent-direct path must pass a generated image through vision safety."""
+
+    from backend.src.agents import image_to_story_agent
+    import importlib
+    image_style_module = importlib.import_module(
+        "backend.src.mcp_servers.image_style_server"
+    )
+
+    styled_image = tmp_path / "styled.png"
+    styled_image.write_bytes(b"styled")
+    validate_mock = AsyncMock(return_value={
+        "used_image_path": str(styled_image),
+        "safety_passed": True,
+        "fell_back": False,
+    })
+    monkeypatch.setattr(image_style_module, "validate_and_fallback", validate_mock)
+
+    selected_path, safety = await image_to_story_agent._validate_styled_image_for_delivery(
+        str(styled_image), "/uploads/original.png", 7, "cartoon", "child-710"
+    )
+
+    assert selected_path == str(styled_image)
+    assert safety["safety_passed"] is True
+    validate_mock.assert_awaited_once_with(
+        styled_image_path=str(styled_image),
+        original_image_path="/uploads/original.png",
+        child_age=7,
+        theme="cartoon",
+        session_id="child-710",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "validation_result, expected_safety_passed",
+    [
+        ({"used_image_path": "/uploads/original.png", "safety_passed": False}, False),
+        ({"used_image_path": "/uploads/original.png", "safety_passed": True}, True),
+    ],
+)
+async def test_agent_direct_styled_image_safety_discards_failed_validation(
+    monkeypatch, tmp_path, validation_result, expected_safety_passed
+):
+    """Unsafe or failed validation must never return the styled image."""
+
+    from backend.src.agents import image_to_story_agent
+    import importlib
+    image_style_module = importlib.import_module(
+        "backend.src.mcp_servers.image_style_server"
+    )
+
+    styled_image = tmp_path / "styled.png"
+    styled_image.write_bytes(b"styled")
+    validate_mock = AsyncMock(return_value=validation_result)
+    monkeypatch.setattr(image_style_module, "validate_and_fallback", validate_mock)
+
+    selected_path, safety = await image_to_story_agent._validate_styled_image_for_delivery(
+        str(styled_image), "/uploads/original.png", 7, "cartoon", "child-710"
+    )
+
+    assert selected_path is None
+    assert safety["safety_passed"] is expected_safety_passed
+
+
+@pytest.mark.asyncio
+async def test_agent_direct_styled_image_safety_fails_closed_on_missing_file(
+    monkeypatch,
+):
+    """A missing generated file is discarded instead of being returned unchecked."""
+
+    from backend.src.agents import image_to_story_agent
+    import importlib
+    image_style_module = importlib.import_module(
+        "backend.src.mcp_servers.image_style_server"
+    )
+
+    validate_mock = AsyncMock()
+    monkeypatch.setattr(image_style_module, "validate_and_fallback", validate_mock)
+
+    selected_path, safety = await image_to_story_agent._validate_styled_image_for_delivery(
+        "/missing/styled.png", "/uploads/original.png", 7, "cartoon", "child-710"
+    )
+
+    assert selected_path is None
+    assert safety["safety_passed"] is False
+    validate_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_direct_styled_image_safety_fails_closed_on_validator_error(
+    monkeypatch, tmp_path
+):
+    """Validator failures and malformed envelopes must discard the candidate."""
+
+    from backend.src.agents import image_to_story_agent
+    import importlib
+    image_style_module = importlib.import_module(
+        "backend.src.mcp_servers.image_style_server"
+    )
+
+    styled_image = tmp_path / "styled.png"
+    styled_image.write_bytes(b"styled")
+    validate_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(image_style_module, "validate_and_fallback", validate_mock)
+
+    selected_path, safety = await image_to_story_agent._validate_styled_image_for_delivery(
+        str(styled_image), "/uploads/original.png", 7, "cartoon", "child-710"
+    )
+
+    assert selected_path is None
+    assert safety["safety_passed"] is False


### PR DESCRIPTION
## Summary

- route agent-direct stylized images through the shared Vision safety validator
- fail closed for missing files, unsafe results, malformed validator responses, and validator exceptions
- add regression coverage for safe, unsafe, mismatched, missing, and malformed outcomes

## Tests

- backend/.venv/bin/pytest -q backend/tests/contracts/test_post_gen_safety.py backend/tests/contracts/test_styled_image_safety_contract.py backend/tests/contracts/test_my_agent_proxy.py backend/tests/api/test_image_to_story_mcp_tools.py
- 67 passed

Fixes #710