### PR TITLE
fix(content-hub): hydrate reaction state in post feed

### DIFF
--- a/backend/tests/contracts/test_hub_posts_endpoint_contract.py
+++ b/backend/tests/contracts/test_hub_posts_endpoint_contract.py
@@ -543,6 +543,42 @@ class TestHappyPath:
         assert "kept" in ids
         assert "soon-gone" not in ids
 
+    @pytest.mark.asyncio
+    async def test_feed_includes_reaction_counts_and_viewer_reactions(self, client):
+        """The feed carries the reaction state needed for an initial ReactionBar."""
+        await _seed_buddy(_OWNER)
+        gid = await _create_public_group(client)
+        created = await client.post(
+            f"/api/v1/hub/groups/{gid}/posts",
+            json={"source_artifact_type": "art_story", "source_id": "story-717"},
+        )
+        assert created.status_code == 201, created.text
+        post_id = created.json()["post_id"]
+
+        # The peer has one active reaction, while the owner has another. The
+        # feed must expose aggregate counts and only the requesting user's
+        # active reactions.
+        _switch_user(_PEER)
+        peer_reaction = await client.post(
+            f"/api/v1/hub/posts/{post_id}/reactions",
+            json={"reaction_type": "heart"},
+        )
+        assert peer_reaction.status_code == 200, peer_reaction.text
+        _switch_user(_OWNER)
+        owner_reaction = await client.post(
+            f"/api/v1/hub/posts/{post_id}/reactions",
+            json={"reaction_type": "star"},
+        )
+        assert owner_reaction.status_code == 200, owner_reaction.text
+
+        _switch_user(_PEER)
+        feed = await client.get(f"/api/v1/hub/groups/{gid}/posts")
+
+        assert feed.status_code == 200, feed.text
+        item = feed.json()["items"][0]
+        assert item["reaction_counts"] == {"heart": 1, "star": 1, "wow": 0}
+        assert item["viewer_reactions"] == ["heart"]
+
 
 # ---------------------------------------------------------------------------
 # Private group read access

--- a/frontend/src/api/services/hubService.test.ts
+++ b/frontend/src/api/services/hubService.test.ts
@@ -110,11 +110,31 @@ describe("joinGroup", () => {
 
 describe("listGroupPosts", () => {
   it("threads cursor params into the GET", async () => {
-    mockedGet.mockResolvedValueOnce({ data: { items: [], next_cursor: null } });
-    await listGroupPosts("g5", {
+    const feed = {
+      items: [
+        {
+          post_id: "p1",
+          group_id: "g5",
+          agent_name: "Sparkle",
+          agent_avatar_id: "emoji:🦁",
+          agent_title: "Brave Lion",
+          source_artifact_type: "art_story" as const,
+          source_id: "story-1",
+          caption: null,
+          created_at: "x",
+          reaction_counts: { heart: 3, star: 1, wow: 0 },
+          viewer_reactions: ["heart" as const],
+        },
+      ],
+      next_cursor: null,
+    };
+    mockedGet.mockResolvedValueOnce({ data: feed });
+    const result = await listGroupPosts("g5", {
       limit: 5,
       cursor: { cursor_created_at: "2026-01-01", cursor_post_id: "p1" },
     });
+    expect(result.items[0].reaction_counts).toEqual({ heart: 3, star: 1, wow: 0 });
+    expect(result.items[0].viewer_reactions).toEqual(["heart"]);
     expect(mockedGet).toHaveBeenCalledWith(
       "/hub/groups/g5/posts",
       {
@@ -141,6 +161,8 @@ describe("createHubPost", () => {
         source_id: "s",
         caption: null,
         created_at: "x",
+        reaction_counts: { heart: 2, star: 1, wow: 0 },
+        viewer_reactions: ["heart"],
       },
     });
     await createHubPost("g6", {

--- a/frontend/src/pages/GroupPage/PostCard.tsx
+++ b/frontend/src/pages/GroupPage/PostCard.tsx
@@ -113,7 +113,11 @@ export default function PostCard({ post }: Props) {
         )}
 
         <div className="mt-auto flex items-center justify-between gap-3 pt-2">
-          <ReactionBar postId={post.post_id} />
+          <ReactionBar
+            postId={post.post_id}
+            initialCounts={post.reaction_counts}
+            initialViewerReactions={post.viewer_reactions}
+          />
           <button
             type="button"
             onClick={() => navigate(destination)}

--- a/frontend/src/pages/GroupPage/destinationFor.test.ts
+++ b/frontend/src/pages/GroupPage/destinationFor.test.ts
@@ -24,6 +24,8 @@ const base: Omit<HubPost, "source_artifact_type" | "source_id"> = {
   agent_title: "Brave Lion",
   caption: null,
   created_at: "2026-01-01T00:00:00",
+  reaction_counts: { heart: 0, star: 0, wow: 0 },
+  viewer_reactions: [],
 };
 
 describe("destinationFor", () => {

--- a/frontend/src/types/hub.ts
+++ b/frontend/src/types/hub.ts
@@ -5,6 +5,11 @@
  * Issue: #451 / #452 / #453 / #454 | Parent epic: #437
  */
 
+import type {
+  ReactionCounts,
+  ReactionType,
+} from "@/api/services/reactionsService";
+
 export type GroupVisibility = "public" | "private";
 
 export interface Group {
@@ -53,6 +58,10 @@ export interface HubPost {
   source_id: string;
   caption: string | null;
   created_at: string;
+  /** Aggregate reaction totals returned by the post feed. */
+  reaction_counts: ReactionCounts;
+  /** Reaction types active for the authenticated viewer. */
+  viewer_reactions: ReactionType[];
 }
 
 export interface HubPostCursor {


### PR DESCRIPTION
## Summary
Fixes the Content Hub post-feed reaction contract so reaction totals and the authenticated viewer active reactions are available and rendered on each post card.

## Changes
- Lock the GET post-feed API contract with aggregate and viewer-scoped reaction assertions.
- Add reaction fields to the typed frontend HubPost model.
- Seed ReactionBar from feed data instead of issuing a redundant reaction read.
- Update affected TypeScript fixtures.

## Testing
- backend: 44 related Content Hub contract tests passed.
- frontend: 13 focused logic tests passed with Vitest Node environment.
- frontend: npm run build passed.
- frontend lint has pre-existing errors outside this change.

## Agent / MCP Impact
None.

## Related Issues
Fixes #717
**Parent Epic**: #437