### PR TITLE
fix(voice): disable unsafe direct WebRTC delivery

### DIFF
--- a/backend/src/api/routes/voice_realtime.py
+++ b/backend/src/api/routes/voice_realtime.py
@@ -357,11 +357,8 @@ async def start_voice_session(
     prefer_webrtc: bool = Query(
         default=False,
         description=(
-            "E4 (#647) WebRTC opt-in. When ``true`` AND the active provider "
-            "supports browser-direct realtime (OpenAI), the response sets "
-            "``transport=\"webrtc\"`` and surfaces an ephemeral OpenAI "
-            "client secret. Non-OpenAI providers silently fall back to "
-            "``ws`` — the WS broker is the universal path."
+            "Deprecated WebRTC preference. All sessions use the server-relay "
+            "transport so assistant output passes the server-side safety gate."
         ),
     ),
 ) -> VoiceSessionStartResponse:
@@ -424,14 +421,11 @@ async def start_voice_session(
 
     provider = _provider_for_session()
 
-    # #647: WebRTC is opt-in AND only meaningful when the provider can
-    # serve a browser-direct realtime handshake. Today that's only
-    # ``openai_realtime``. Anything else silently degrades to WS — the
-    # client never sees a 4xx for asking, because the WS broker is the
-    # universal fallback and refusing would break the panel UX.
+    # Direct browser → OpenAI delivery cannot enforce the broker's
+    # pre-delivery assistant safety gate. Keep every session on the WS
+    # broker until a server-mediated WebRTC path exists. ``prefer_webrtc``
+    # remains accepted for backwards compatibility with older clients.
     selected_transport: str = "ws"
-    if prefer_webrtc and provider.name == "openai_realtime":
-        selected_transport = "webrtc"
 
     persisted = await voice_session_repo.create_session(
         user_id=user.user_id,
@@ -446,39 +440,10 @@ async def start_voice_session(
         child_id=request.child_id,
     )
 
-    # For the OpenAI Realtime provider we bundle the ephemeral client
-    # secret so the frontend can hold it for E4's WebRTC transport.
-    # Pre-#647 the secret was minted for both paths (so a client could
-    # try WebRTC after the fact); we keep that behavior unchanged.
+    # Never expose a direct-mode credential while the server-relay path is
+    # the only safety-preserving transport. This also prevents clients from
+    # bypassing the broker by attempting the old WebRTC handshake manually.
     openai_secret: Optional[str] = None
-    if provider.name == "openai_realtime":
-        try:
-            target_age = _target_age_for(profile.age_group)
-            preview_handle = await provider.start_session(
-                user_id=user.user_id,
-                child_id=request.child_id,
-                target_age=target_age,
-                persona=profile.voice_persona or "buddy_default",
-                voice_premium_voice=bool(
-                    getattr(profile, "voice_premium_voice", False)
-                ),
-                voice_premium_voice_consent=bool(
-                    getattr(profile, "voice_premium_voice_consent", False)
-                ),
-            )
-            openai_secret = (
-                preview_handle.provider_state.get("openai_client_secret") or None
-            )
-            # Release the preview handle's upstream WS (if any) — the WS
-            # broker will mint its own when the client connects.
-            try:
-                await provider.close(preview_handle)
-            except Exception:  # pragma: no cover
-                pass
-        except Exception as exc:
-            logger.warning(
-                "Failed to pre-mint OpenAI client secret for /session: %s", exc,
-            )
 
     return VoiceSessionStartResponse(
         session_id=persisted.session_id,

--- a/backend/tests/contracts/test_voice_session_webrtc_contract.py
+++ b/backend/tests/contracts/test_voice_session_webrtc_contract.py
@@ -1,12 +1,12 @@
 """
 WebRTC direct-mode transport contract tests (#647).
 
-Locks the REST `/voice/session` surface for the opt-in WebRTC path:
+Locks the REST `/voice/session` surface and its safety-preserving transport
+policy:
 
-  - ``prefer_webrtc=true`` on the OpenAI Realtime provider yields
-    ``transport: "webrtc"`` + a populated
-    ``openai_realtime_client_secret`` so the browser can complete the
-    SDP handshake directly against OpenAI.
+  - ``prefer_webrtc=true`` on the OpenAI Realtime provider still yields
+    ``transport: "ws"``. Direct browser → OpenAI delivery is disabled until
+    assistant output can pass through the server-side pre-delivery safety gate.
   - ``prefer_webrtc=true`` on a non-OpenAI provider (mock / hybrid)
     gracefully degrades to ``transport: "ws"`` (no 4xx — the WS broker
     is the universal fallback, never a refusal).
@@ -223,10 +223,10 @@ class TestSchemaContract:
 # ===========================================================================
 
 class TestPreferWebRTCWithOpenAIProvider:
-    """``prefer_webrtc=true`` on the OpenAI path returns the WebRTC contract."""
+    """The OpenAI path stays on the server-relay transport for safety."""
 
     @pytest.mark.asyncio
-    async def test_prefer_webrtc_true_yields_transport_webrtc(
+    async def test_prefer_webrtc_true_stays_on_server_relay(
         self, openai_client, consented_child,
     ):
         response = await openai_client.post(
@@ -235,15 +235,13 @@ class TestPreferWebRTCWithOpenAIProvider:
         )
         assert response.status_code == 200, response.text
         body = response.json()
-        assert body["transport"] == "webrtc"
-        # The browser uses this secret to POST the SDP offer directly to
-        # OpenAI — without it the WebRTC handshake is dead on arrival.
-        assert body["openai_realtime_client_secret"], (
-            "openai_realtime_client_secret must be populated for WebRTC"
+        assert body["transport"] == "ws"
+        assert body["openai_realtime_client_secret"] is None, (
+            "direct-mode credentials must not be exposed while WebRTC is disabled"
         )
 
     @pytest.mark.asyncio
-    async def test_prefer_webrtc_true_records_transport_in_voice_sessions_row(
+    async def test_prefer_webrtc_true_records_server_relay_transport(
         self, openai_client, consented_child,
     ):
         response = await openai_client.post(
@@ -254,7 +252,7 @@ class TestPreferWebRTCWithOpenAIProvider:
         session_id = response.json()["session_id"]
         persisted = await voice_session_repo.get_by_id(session_id)
         assert persisted is not None
-        assert persisted.transport == "webrtc"
+        assert persisted.transport == "ws"
 
 
 class TestPreferWebRTCWithMockProvider:


### PR DESCRIPTION
## Summary\n\n- Keep all voice sessions on the server-relay WebSocket path.\n- Stop exposing direct-mode OpenAI credentials while WebRTC output bypasses the broker safety gate.\n- Preserve the prefer_webrtc query parameter for backwards compatibility, but make it safely degrade to ws.\n\n## Verification\n\n- Focused transport and pre-delivery safety suites: 22 passed.\n- All voice contract suites: 199 passed, 1 skipped.\n\nFixes #753