### PR TITLE
Enforce OpenAI Realtime monthly cost ceiling

### DIFF
--- a/backend/src/api/routes/voice_realtime.py
+++ b/backend/src/api/routes/voice_realtime.py
@@ -37,6 +37,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import time
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -63,6 +64,7 @@ from ...services.realtime_voice_service import (
     _select_provider,
     estimate_session_cost_usd,
     log_voice_session_end,
+    OPENAI_REALTIME_MONTHLY_CAP_USD_ENV,
     safety_threshold_for_age,
 )
 from ...services.realtime_voice_tools import (
@@ -104,6 +106,12 @@ WS_CLOSE_INTERNAL = 1011  # unexpected error
 # bypassed and this object is used directly. Reset to None after tests.
 _TEST_PROVIDER_OVERRIDE: Optional[RealtimeVoiceProvider] = None
 
+# OpenAI Realtime monthly cost ceiling (#720). The cap is deliberately read
+# at request time so operators can adjust it without a code change/redeploy.
+OPENAI_REALTIME_COST_WARN_RATIO: float = 0.80
+OPENAI_REALTIME_COST_PROVIDER: str = "openai_realtime"
+OPENAI_REALTIME_COST_LIMIT_CODE: str = "VOICE_COST_LIMIT_EXCEEDED"
+
 
 def _set_test_provider_override(provider: Optional[RealtimeVoiceProvider]) -> None:
     """Test-only seam — install a stub provider for the broker."""
@@ -115,6 +123,75 @@ def _provider_for_session() -> RealtimeVoiceProvider:
     if _TEST_PROVIDER_OVERRIDE is not None:
         return _TEST_PROVIDER_OVERRIDE
     return _select_provider()
+
+
+def _openai_realtime_month_start() -> str:
+    """Return the local-naive ISO timestamp used by voice session rows."""
+    now = datetime.now()
+    return now.replace(
+        day=1, hour=0, minute=0, second=0, microsecond=0,
+    ).isoformat()
+
+
+def _openai_realtime_monthly_cap_usd() -> Optional[float]:
+    """Parse the optional operator-set monthly OpenAI Realtime cap."""
+    raw = os.getenv(OPENAI_REALTIME_MONTHLY_CAP_USD_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        cap = float(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid %s=%r", OPENAI_REALTIME_MONTHLY_CAP_USD_ENV, raw,
+        )
+        return None
+    if cap <= 0:
+        logger.warning(
+            "Ignoring non-positive %s=%r",
+            OPENAI_REALTIME_MONTHLY_CAP_USD_ENV,
+            raw,
+        )
+        return None
+    return cap
+
+
+async def _enforce_openai_realtime_cost_ceiling(
+    provider: RealtimeVoiceProvider,
+) -> None:
+    """Warn at 80% and refuse new OpenAI sessions at 100% of the cap."""
+    if provider.name != OPENAI_REALTIME_COST_PROVIDER:
+        return
+
+    cap_usd = _openai_realtime_monthly_cap_usd()
+    if cap_usd is None:
+        return
+
+    month_to_date_usd = await voice_session_repo.sum_cost_in_window(
+        provider=OPENAI_REALTIME_COST_PROVIDER,
+        since_iso=_openai_realtime_month_start(),
+    )
+    if month_to_date_usd >= cap_usd:
+        logger.warning(
+            "OpenAI Realtime monthly cost reached 100%%: spent=$%.4f cap=$%.4f; "
+            "refusing new session",
+            month_to_date_usd,
+            cap_usd,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={
+                "code": OPENAI_REALTIME_COST_LIMIT_CODE,
+                "month_to_date_usd": month_to_date_usd,
+                "monthly_cap_usd": cap_usd,
+            },
+        )
+    if month_to_date_usd >= cap_usd * OPENAI_REALTIME_COST_WARN_RATIO:
+        logger.warning(
+            "OpenAI Realtime monthly cost is at or above 80%%: "
+            "spent=$%.4f cap=$%.4f",
+            month_to_date_usd,
+            cap_usd,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -421,6 +498,10 @@ async def start_voice_session(
         )
 
     provider = _provider_for_session()
+
+    # #720: enforce the application-side monthly ceiling before creating a
+    # persisted session or minting any OpenAI credentials.
+    await _enforce_openai_realtime_cost_ceiling(provider)
 
     # Direct browser → OpenAI delivery cannot enforce the broker's
     # pre-delivery assistant safety gate. Keep every session on the WS

--- a/backend/src/services/database/voice_session_repository.py
+++ b/backend/src/services/database/voice_session_repository.py
@@ -235,6 +235,33 @@ class VoiceSessionRepository:
         total = row.get("total_seconds", 0) or 0
         return int(total)
 
+    async def sum_cost_in_window(
+        self,
+        *,
+        provider: str,
+        since_iso: str,
+    ) -> float:
+        """Return finalized session cost for a provider since ``since_iso``.
+
+        Only ended sessions with a recorded cost contribute. The OpenAI
+        Realtime monthly ceiling uses this as its month-to-date source of
+        truth; other providers are excluded by the explicit provider filter.
+        """
+        row = await self._db.fetchone(
+            """
+            SELECT COALESCE(SUM(cost_estimate_usd), 0) AS total_cost
+            FROM voice_sessions
+            WHERE provider = ?
+              AND ended_at >= ?
+              AND ended_at IS NOT NULL
+              AND cost_estimate_usd IS NOT NULL
+            """,
+            (provider, since_iso),
+        )
+        if not row:
+            return 0.0
+        return float(row.get("total_cost", 0) or 0.0)
+
     @classmethod
     def _row_to_data(cls, row: dict) -> VoiceSessionData:
         cache_raw = row.get("prompt_cache_hit")

--- a/backend/tests/contracts/test_voice_broker_contract.py
+++ b/backend/tests/contracts/test_voice_broker_contract.py
@@ -239,6 +239,72 @@ class TestSessionEndpoint:
         assert response.status_code == 429
         assert response.json()["detail"]["code"] == "VOICE_QUOTA_EXHAUSTED"
 
+    @pytest.mark.asyncio
+    async def test_openai_cost_cap_warns_at_80_percent(
+        self, client, consented_child, monkeypatch, caplog,
+    ):
+        provider = MockRealtimeVoiceProvider()
+        provider.name = "openai_realtime"
+        voice_realtime._set_test_provider_override(provider)
+        monkeypatch.setenv("OPENAI_REALTIME_MONTHLY_CAP_USD", "10")
+
+        spent = await voice_session_repo.create_session(
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+            provider="openai_realtime",
+        )
+        await voice_session_repo.end_session(
+            session_id=spent.session_id,
+            reason="user_ended",
+            duration_seconds=60,
+            cost_estimate_usd=8.0,
+        )
+
+        with caplog.at_level("WARNING"):
+            response = await client.post(
+                "/api/v1/me/agent/voice/session",
+                json={"child_id": consented_child.child_id},
+            )
+
+        assert response.status_code == 200, response.text
+        assert any(
+            "OpenAI Realtime monthly cost is at or above 80%" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_openai_cost_cap_hard_stops_at_100_percent(
+        self, client, consented_child, monkeypatch,
+    ):
+        provider = MockRealtimeVoiceProvider()
+        provider.name = "openai_realtime"
+        voice_realtime._set_test_provider_override(provider)
+        monkeypatch.setenv("OPENAI_REALTIME_MONTHLY_CAP_USD", "10")
+
+        spent = await voice_session_repo.create_session(
+            user_id=PARENT_USER.user_id,
+            child_id=consented_child.child_id,
+            provider="openai_realtime",
+        )
+        await voice_session_repo.end_session(
+            session_id=spent.session_id,
+            reason="user_ended",
+            duration_seconds=60,
+            cost_estimate_usd=10.0,
+        )
+
+        response = await client.post(
+            "/api/v1/me/agent/voice/session",
+            json={"child_id": consented_child.child_id},
+        )
+
+        assert response.status_code == 429
+        assert response.json()["detail"]["code"] == "VOICE_COST_LIMIT_EXCEEDED"
+        assert await voice_session_repo.sum_cost_in_window(
+            provider="openai_realtime",
+            since_iso="0001-01-01T00:00:00",
+        ) == pytest.approx(10.0)
+
 
 # ============================================================================
 # WS broker contract (sync TestClient — WS support)

--- a/backend/tests/contracts/test_voice_session_repository_contract.py
+++ b/backend/tests/contracts/test_voice_session_repository_contract.py
@@ -235,6 +235,42 @@ class TestQuotaQueries:
             user_id="voice_parent", child_id="child_beta", since_iso=an_hour_ago,
         ) == 0
 
+    @pytest.mark.asyncio
+    async def test_sum_cost_in_window_scopes_provider_and_ended_rows(
+        self, test_db, repo,
+    ):
+        openai_session = await repo.create_session(
+            user_id="voice_parent", child_id="child_alpha",
+            provider="openai_realtime",
+        )
+        await repo.end_session(
+            session_id=openai_session.session_id,
+            reason="user_ended",
+            duration_seconds=60,
+            cost_estimate_usd=8.25,
+        )
+
+        hybrid_session = await repo.create_session(
+            user_id="voice_parent", child_id="child_alpha", provider="hybrid",
+        )
+        await repo.end_session(
+            session_id=hybrid_session.session_id,
+            reason="user_ended",
+            duration_seconds=60,
+            cost_estimate_usd=99.0,
+        )
+
+        # In-flight sessions have no finalized cost and must not count.
+        await repo.create_session(
+            user_id="voice_parent", child_id="child_alpha",
+            provider="openai_realtime",
+        )
+
+        an_hour_ago = (datetime.now() - timedelta(hours=1)).isoformat()
+        assert await repo.sum_cost_in_window(
+            provider="openai_realtime", since_iso=an_hour_ago,
+        ) == pytest.approx(8.25)
+
 
 # ---------------------- get_by_id -------------------------------------------
 


### PR DESCRIPTION
## Summary
- aggregate finalized OpenAI Realtime session cost month-to-date
- warn at 80% of OPENAI_REALTIME_MONTHLY_CAP_USD
- reject new sessions with VOICE_COST_LIMIT_EXCEEDED at 100%

## Tests
- focused cost ceiling and repository tests: 3 passed
- related voice/realtime contracts: 72 passed
- full backend suite attempted; unrelated PostgreSQL setup is blocked in the sandbox (127.0.0.1:54322), while the isolated voice suite is green

Fixes #720
Parent Epic: #605