### PR TITLE
fix(frontend): recover from transient production bootstrap errors

### DIFF
--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -13,6 +13,40 @@ interface ErrorBoundaryState {
   error: Error | null
 }
 
+const BOOTSTRAP_RECOVERY_KEY = 'creative-workshop:bootstrap-recovery'
+const BOOTSTRAP_RECOVERY_WINDOW_MS = 30_000
+
+/**
+ * This error was observed during a transient production bundle/bootstrap
+ * mismatch. A single automatic retry lets the browser recover from a stale
+ * document without creating an infinite reload loop.
+ */
+function isTransientBootstrapError(error: Error): boolean {
+  return error.message.includes(
+    'useStreamVisualizationContext must be used within a StreamVisualizationProvider',
+  )
+}
+
+function attemptBootstrapRecovery(): boolean {
+  if (typeof window === 'undefined' || typeof window.sessionStorage === 'undefined') {
+    return false
+  }
+
+  try {
+    const previousAttempt = Number(window.sessionStorage.getItem(BOOTSTRAP_RECOVERY_KEY))
+    if (Number.isFinite(previousAttempt) && Date.now() - previousAttempt < BOOTSTRAP_RECOVERY_WINDOW_MS) {
+      return false
+    }
+
+    window.sessionStorage.setItem(BOOTSTRAP_RECOVERY_KEY, String(Date.now()))
+    window.location.reload()
+    return true
+  } catch {
+    // Storage and reload can be unavailable in privacy-restricted contexts.
+    return false
+  }
+}
+
 /**
  * Global ErrorBoundary.
  *
@@ -33,9 +67,20 @@ interface ErrorBoundaryState {
  *  - Recovering from async errors thrown outside React render
  */
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  static isTransientBootstrapError = isTransientBootstrapError
+
   state: ErrorBoundaryState = {
     hasError: false,
     error: null,
+  }
+
+  componentDidMount(): void {
+    // A successful mount proves that any prior bootstrap retry recovered.
+    try {
+      window.sessionStorage.removeItem(BOOTSTRAP_RECOVERY_KEY)
+    } catch {
+      // Ignore storage failures; the boundary still provides its fallback.
+    }
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
@@ -45,8 +90,11 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     // Log so developers can debug. No remote reporting (out of scope).
-    // eslint-disable-next-line no-console
     console.error('ErrorBoundary caught an error:', error, errorInfo)
+
+    if (isTransientBootstrapError(error)) {
+      attemptBootstrapRecovery()
+    }
   }
 
   handleReload = (): void => {

--- a/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/__tests__/ErrorBoundary.test.tsx
@@ -35,6 +35,15 @@ describe('ErrorBoundary', () => {
     expect(next).toEqual({ hasError: true, error: boom })
   })
 
+  it('recognizes the transient stream-provider bootstrap error', () => {
+    expect(
+      ErrorBoundary.isTransientBootstrapError(
+        new Error('useStreamVisualizationContext must be used within a StreamVisualizationProvider'),
+      ),
+    ).toBe(true)
+    expect(ErrorBoundary.isTransientBootstrapError(new Error('unrelated render failure'))).toBe(false)
+  })
+
   it('componentDidCatch logs the error and errorInfo to console.error', () => {
     const instance = new ErrorBoundary({ children: null })
     const err = new Error('render exploded')
@@ -48,6 +57,31 @@ describe('ErrorBoundary', () => {
       err,
       info,
     )
+  })
+
+  it('retries a transient bootstrap failure only once within the recovery window', () => {
+    const values = new Map<string, string>()
+    const reload = vi.fn()
+    vi.stubGlobal('window', {
+      sessionStorage: {
+        getItem: (key: string) => values.get(key) ?? null,
+        setItem: (key: string, value: string) => values.set(key, value),
+        removeItem: (key: string) => values.delete(key),
+      },
+      location: { reload },
+    })
+
+    const instance = new ErrorBoundary({ children: null })
+    const error = new Error(
+      'useStreamVisualizationContext must be used within a StreamVisualizationProvider',
+    )
+    const info: ErrorInfo = { componentStack: '' }
+
+    instance.componentDidCatch(error, info)
+    instance.componentDidCatch(error, info)
+
+    expect(reload).toHaveBeenCalledTimes(1)
+    vi.unstubAllGlobals()
   })
 
   it('handleReload invokes the onReload override when provided', () => {


### PR DESCRIPTION
## Summary

Prevent the production app from remaining blank when a transient deployment/cache mismatch causes the stream-visualization provider bootstrap error observed in issue #763.

## Changes

- Detect the specific provider-context bootstrap failure.
- Automatically retry once using a session-scoped recovery marker.
- Prevent infinite reload loops and retain the existing friendly ErrorBoundary fallback.
- Add regression tests for error detection and one-retry behavior.

## Testing

- npx vitest run src/components/common/__tests__/ErrorBoundary.test.tsx --environment node — 6 passed
- npx eslint src/components/common/ErrorBoundary.tsx src/components/common/__tests__/ErrorBoundary.test.tsx — passed
- npm run build — passed
- Default Vitest/jsdom mode remains blocked by the existing html-encoding-sniffer / @exodus/bytes ERR_REQUIRE_ESM dependency incompatibility.

## Agent / MCP Impact

None.

## Related Issues

Fixes #763
**Parent Epic**: #313