### PR TITLE
fix(frontend): prevent My Agent bootstrap race

### DIFF
--- a/frontend/src/pages/HomePage/index.tsx
+++ b/frontend/src/pages/HomePage/index.tsx
@@ -124,20 +124,26 @@ function getItemTypeLabel(item: LibraryItem): string {
 
 function RecentCreationCard({ item, onClick }: { item: LibraryItem; onClick: () => void }) {
   const imageUrl = item.thumbnail_url || item.image_url
+  const [imageFailed, setImageFailed] = useState(false)
   const FallbackIcon =
     item.type === 'interactive' ? BookOpen : item.type === 'art-story' ? ImagePlus : Newspaper
 
   return (
     <motion.div
-      className="card-kid cursor-pointer"
+      className="card-kid w-full min-w-0 cursor-pointer"
       onClick={onClick}
       whileHover={{ scale: 1.02 }}
       whileTap={{ scale: 0.98 }}
     >
       <div className="flex gap-4">
         <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center overflow-hidden rounded-lg bg-gradient-to-br from-primary/20 to-secondary/20">
-          {imageUrl ? (
-            <img src={resolveMediaUrl(imageUrl) || ''} alt="" className="h-full w-full object-cover" />
+          {imageUrl && !imageFailed ? (
+            <img
+              src={resolveMediaUrl(imageUrl) || ''}
+              alt=""
+              className="h-full w-full object-cover"
+              onError={() => setImageFailed(true)}
+            />
           ) : (
             <FallbackIcon className="text-primary" size={28} />
           )}

--- a/frontend/src/pages/MyAgentPage/index.tsx
+++ b/frontend/src/pages/MyAgentPage/index.tsx
@@ -33,16 +33,24 @@ import SignInPrompt from "@/components/common/SignInPrompt";
 import { AnimalAvatarIcon } from "@/lib/avatarIcons";
 
 export default function MyAgentPage() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+  const user = useAuthStore((s) => s.user);
   const currentChild = useChildStore((s) => s.currentChild);
   const childProfiles = useChildStore((s) => s.childProfiles);
   const childProfilesLoading = useChildStore((s) => s.isLoading);
   const loadChildProfiles = useChildStore((s) => s.loadChildProfiles);
   const defaultChildId = useChildStore((s) => s.defaultChildId);
-  const childId = currentChild?.child_id ?? defaultChildId;
+  // Parent accounts must wait for the server-backed child profiles before
+  // using an ID. The child store starts with a locally generated fallback
+  // ID, which is not owned by the account and causes transient 404s during
+  // the first My Agent mount (#763 follow-up).
+  const childProfilesResolved =
+    user?.role !== "parent" || currentChild != null || childProfiles.length > 0;
+  const childId = childProfilesResolved
+    ? (currentChild?.child_id ?? defaultChildId)
+    : undefined;
   const ageGroup = currentChild?.age_group;
 
-  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
-  const user = useAuthStore((s) => s.user);
   const onboardedAt = user?.onboarded_at;
   const isPendingChildApproval =
     user?.role === "child" && user?.consent_status === "pending_parent_consent";
@@ -240,7 +248,7 @@ export default function MyAgentPage() {
         </div>
         <OnboardingModal
           open={onboardingOpen}
-          childId={childId}
+          childId={childId ?? defaultChildId}
           ageGroup={ageGroup}
           onClose={() => setOnboardingOpen(false)}
         />

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "framework": "vite",
+  "buildCommand": "cd frontend && npm run build",
+  "installCommand": "cd frontend && npm install",
+  "outputDirectory": "frontend/dist",
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
Prevent the My Agent page from issuing requests with a locally generated child ID before a parent account's server-backed child profiles have loaded. This removes the first-navigation 404 race that could leave the production page blank until refresh.

## Changes
- Wait for parent child-profile resolution before loading the agent persona or chat sessions.
- Show fallback icons for missing Recent Creations media instead of broken images.
- Keep recent creation cards within the viewport on narrow screens.

## Testing
- `npx eslint src/pages/MyAgentPage/index.tsx`
- `npx eslint src/pages/HomePage/index.tsx`
- `npm run build`
- `git diff --check`
- Production smoke checks: Railway `/health` returned healthy; My Agent sessions route returned `401` unauthenticated instead of `404`; Vercel deployment reached `READY`.

## Agent / MCP Impact
No backend agent or MCP behavior changed. This is a frontend bootstrap and rendering fix.

## Related Issues
Related to #763
**Parent Epic**: #313